### PR TITLE
CEDS-949 Add multiplicity to 2/2 AdditionalInformation

### DIFF
--- a/app/controllers/supplementary/AdditionalInformationController.scala
+++ b/app/controllers/supplementary/AdditionalInformationController.scala
@@ -18,13 +18,19 @@ package controllers.supplementary
 import config.AppConfig
 import controllers.actions.AuthAction
 import controllers.util.CacheIdGenerator.supplementaryCacheId
+import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
 import forms.supplementary.AdditionalInformation
-import forms.supplementary.AdditionalInformation._
+import forms.supplementary.AdditionalInformation.form
+import handlers.ErrorHandler
 import javax.inject.Inject
-import play.api.data.Form
+import models.declaration.supplementary.AdditionalInformationData
+import models.declaration.supplementary.AdditionalInformationData.{formId, maxNumberOfItems}
+import models.requests.AuthenticatedRequest
+import play.api.data.{Form, FormError}
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, AnyContent}
+import play.api.mvc.{Action, AnyContent, Request, Result}
 import services.CustomsCacheService
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.supplementary.additional_information
 
@@ -34,27 +40,155 @@ class AdditionalInformationController @Inject()(
   appConfig: AppConfig,
   override val messagesApi: MessagesApi,
   authenticate: AuthAction,
+  errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService
 )(implicit ec: ExecutionContext)
     extends FrontendController with I18nSupport {
 
   def displayForm(): Action[AnyContent] = authenticate.async { implicit request =>
-    customsCacheService.fetchAndGetEntry[AdditionalInformation](supplementaryCacheId, formId).map {
-      case Some(data) => Ok(additional_information(appConfig, form.fill(data)))
-      case _          => Ok(additional_information(appConfig, form))
+    customsCacheService.fetchAndGetEntry[AdditionalInformationData](supplementaryCacheId, formId).map {
+      case Some(data) => Ok(additional_information(appConfig, form, data.items))
+      case _          => Ok(additional_information(appConfig, form, Seq()))
     }
   }
 
   def saveAdditionalInfo(): Action[AnyContent] = authenticate.async { implicit request =>
-    form
-      .bindFromRequest()
-      .fold(
-        (formWithErrors: Form[AdditionalInformation]) =>
-          Future.successful(Ok(additional_information(appConfig, formWithErrors))),
-        validForm =>
-          customsCacheService.cache[AdditionalInformation](supplementaryCacheId, formId, validForm).map { _ =>
-            Redirect(controllers.supplementary.routes.DocumentsProducedController.displayForm())
-        }
-      )
+    val boundForm = form.bindFromRequest()
+
+    val actionTypeOpt = request.body.asFormUrlEncoded.flatMap(FormAction.fromUrlEncoded(_))
+
+    val cachedData = customsCacheService
+      .fetchAndGetEntry[AdditionalInformationData](supplementaryCacheId, formId)
+      .map(_.getOrElse(AdditionalInformationData(Seq())))
+
+    cachedData.flatMap { cache =>
+      boundForm
+        .fold(
+          (formWithErrors: Form[AdditionalInformation]) =>
+            Future.successful(BadRequest(additional_information(appConfig, formWithErrors, cache.items))),
+          validForm =>
+            actionTypeOpt match {
+              case Some(Add)             => addItem(validForm, cache)
+              case Some(SaveAndContinue) => saveAndContinue(validForm, cache)
+              case Some(Remove(values))  => removeItem(retrieveItem(values), cache)
+              case _                     => errorHandler.displayErrorPage()
+          }
+        )
+    }
   }
+
+  private def saveAndContinue(
+    userInput: AdditionalInformation,
+    cachedData: AdditionalInformationData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    (userInput, cachedData.items) match {
+      case (item, Seq()) => handleSaveAndContinueEmptyCache(item)
+      case (item, items) => handleSaveAndContinueCache(item, items)
+    }
+
+  private def handleSaveAndContinueCache(item: AdditionalInformation, items: Seq[AdditionalInformation])(
+    implicit request: AuthenticatedRequest[_]
+  ) =
+    item match {
+      case _ if items.length >= maxNumberOfItems =>
+        handleErrorPage(Seq(("", "supplementary.additionalInformation.maximumAmount.error")), item, items)
+
+      case _ if items.contains(item) =>
+        handleErrorPage(Seq(("", "supplementary.additionalInformation.duplicated")), item, items)
+
+      case _ if item.code.isDefined == item.description.isDefined =>
+        val updatedItems = if (item.code.isDefined) items :+ item else items
+        val updatedCache = AdditionalInformationData(updatedItems)
+
+        customsCacheService.cache[AdditionalInformationData](supplementaryCacheId, formId, updatedCache).map { _ =>
+          Redirect(controllers.supplementary.routes.DocumentsProducedController.displayForm())
+        }
+
+      case AdditionalInformation(maybeCode, maybeDescription) =>
+        val codeError =
+          maybeCode.fold(Seq(("code", "supplementary.additionalInformation.code.empty")))(_ => Seq[(String, String)]())
+        val descriptionError = maybeDescription.fold(
+          Seq(("description", "supplementary.additionalInformation.description.empty"))
+        )(_ => Seq[(String, String)]())
+
+        handleErrorPage(codeError ++ descriptionError, item, items)
+    }
+
+  private def handleSaveAndContinueEmptyCache(item: AdditionalInformation)(implicit request: AuthenticatedRequest[_]) =
+    item match {
+      case AdditionalInformation(Some(code), Some(description)) =>
+        val updateCache = AdditionalInformationData(Seq(AdditionalInformation(Some(code), Some(description))))
+
+        customsCacheService.cache[AdditionalInformationData](supplementaryCacheId(), formId, updateCache).map { _ =>
+          Redirect(controllers.supplementary.routes.DocumentsProducedController.displayForm())
+        }
+
+      case AdditionalInformation(maybeCode, maybeDescription) =>
+        val codeError =
+          maybeCode.fold(Seq(("code", "supplementary.additionalInformation.code.empty")))(_ => Seq[(String, String)]())
+
+        val descriptionError = maybeDescription.fold(
+          Seq(("description", "supplementary.additionalInformation.description.empty"))
+        )(_ => Seq[(String, String)]())
+
+        handleErrorPage(codeError ++ descriptionError, item, Seq())
+    }
+  private def addItem(
+    userInput: AdditionalInformation,
+    cachedData: AdditionalInformationData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    (userInput, cachedData.items) match {
+      case (_, items) if items.length >= maxNumberOfItems =>
+        handleErrorPage(
+          Seq(("", "supplementary.additionalInformation.maximumAmount.error")),
+          userInput,
+          cachedData.items
+        )
+
+      case (item, items) if items.contains(item) =>
+        handleErrorPage(Seq(("", "supplementary.additionalInformation.duplicated")), userInput, cachedData.items)
+
+      case (item, items) if item.code.isDefined && item.description.isDefined =>
+        val updatedCache = AdditionalInformationData(items :+ item)
+
+        customsCacheService.cache[AdditionalInformationData](supplementaryCacheId, formId, updatedCache).map { _ =>
+          Redirect(controllers.supplementary.routes.AdditionalInformationController.displayForm())
+        }
+
+      case (AdditionalInformation(code, description), _) =>
+        val codeError =
+          code.fold(Seq(("code", "supplementary.additionalInformation.code.empty")))(_ => Seq[(String, String)]())
+        val descriptionError = description.fold(
+          Seq(("description", "supplementary.additionalInformation.description.empty"))
+        )(_ => Seq[(String, String)]())
+
+        handleErrorPage(codeError ++ descriptionError, userInput, cachedData.items)
+    }
+
+  private def removeItem(
+    itemToRemove: AdditionalInformation,
+    cachedData: AdditionalInformationData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    if (cachedData.containsItem(itemToRemove)) {
+      val updatedCache = cachedData.copy(items = cachedData.items.filterNot(_ == itemToRemove))
+
+      customsCacheService.cache[AdditionalInformationData](supplementaryCacheId, formId, updatedCache).map { _ =>
+        Redirect(controllers.supplementary.routes.AdditionalInformationController.displayForm())
+      }
+    } else errorHandler.displayErrorPage()
+
+  private def handleErrorPage(
+    fieldWithError: Seq[(String, String)],
+    userInput: AdditionalInformation,
+    items: Seq[AdditionalInformation]
+  )(implicit request: Request[_]): Future[Result] = {
+    val updatedErrors = fieldWithError.map((FormError.apply(_: String, _: String)).tupled)
+
+    val formWithError = form.fill(userInput).copy(errors = updatedErrors)
+
+    Future.successful(BadRequest(additional_information(appConfig, formWithError, items)))
+  }
+
+  private def retrieveItem(values: Seq[String]): AdditionalInformation =
+    AdditionalInformation.buildFromString(values.headOption.getOrElse(""))
 }

--- a/app/forms/supplementary/AdditionalInformation.scala
+++ b/app/forms/supplementary/AdditionalInformation.scala
@@ -16,22 +16,14 @@
 
 package forms.supplementary
 
-import forms.MetadataPropertiesConvertable
 import play.api.data.Forms._
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
 import utils.validators.FormFieldValidator._
 
-case class AdditionalInformation(code: Option[String], description: Option[String])
-    extends MetadataPropertiesConvertable {
 
-  override def toMetadataProperties(): Map[String, String] =
-    Map(
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementCode" -> code
-        .getOrElse(""),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementDescription" -> description
-        .getOrElse("")
-    )
+case class AdditionalInformation(code: Option[String], description: Option[String]) {
+  override def toString: String = s"${code.getOrElse("")}-${description.getOrElse("")}"
 }
 
 object AdditionalInformation {
@@ -52,4 +44,12 @@ object AdditionalInformation {
   )(AdditionalInformation.apply)(AdditionalInformation.unapply)
 
   def form(): Form[AdditionalInformation] = Form(mapping)
+
+  def buildFromString(value: String): AdditionalInformation = {
+    val dividedString = value.split('-')
+
+    if (dividedString.length == 0) AdditionalInformation(None, None)
+    else if (dividedString.length == 1) AdditionalInformation(Some(value.split('-')(0)), None)
+    else AdditionalInformation(Some(value.split('-')(0)), Some(value.split('-')(1)))
+  }
 }

--- a/app/models/declaration/supplementary/AdditionalInformationData.scala
+++ b/app/models/declaration/supplementary/AdditionalInformationData.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.declaration.supplementary
+
+import forms.MetadataPropertiesConvertable
+import forms.supplementary.AdditionalInformation
+import play.api.libs.json.Json
+
+case class AdditionalInformationData(items: Seq[AdditionalInformation]) extends MetadataPropertiesConvertable {
+  override def toMetadataProperties(): Map[String, String] =
+    items.zipWithIndex.map { itemWithId =>
+      Map(
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[" + itemWithId._2 + "].statementCode" -> itemWithId._1.code
+          .getOrElse(""),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[" + itemWithId._2 + "].statementDescription" -> itemWithId._1.description
+          .getOrElse("")
+      )
+    }.fold(Map.empty)(_ ++ _)
+
+  def containsItem(item: AdditionalInformation): Boolean = items.contains(item)
+}
+
+object AdditionalInformationData {
+  implicit val format = Json.format[AdditionalInformationData]
+
+  val formId = "AdditionalInformationData"
+
+  val maxNumberOfItems = 99
+}
+

--- a/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
+++ b/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
@@ -28,7 +28,7 @@ case class SupplementaryDeclarationData(
   transportInformation: Option[TransportInformation] = None,
   items: Option[Items] = None,
   previousDocuments: Option[PreviousDocuments] = None,
-  additionalInformation: Option[AdditionalInformation] = None,
+  additionalInformationData: Option[AdditionalInformationData] = None,
   documentsProduced: Option[DocumentsProduced] = None
 ) extends SummaryContainer with MetadataPropertiesConvertable {
   import SupplementaryDeclarationData._
@@ -48,7 +48,7 @@ case class SupplementaryDeclarationData(
       transportInformation.isEmpty &&
       items.isEmpty &&
       previousDocuments.isEmpty &&
-      additionalInformation.isEmpty &&
+      additionalInformationData.isEmpty &&
       documentsProduced.isEmpty
 
   def toMap: Map[String, MetadataPropertiesConvertable] =
@@ -60,7 +60,7 @@ case class SupplementaryDeclarationData(
       TransportInformation.id -> transportInformation,
       Items.id -> items,
       PreviousDocuments.formId -> previousDocuments,
-      AdditionalInformation.formId -> additionalInformation,
+      AdditionalInformationData.formId -> additionalInformationData,
       DocumentsProduced.formId -> documentsProduced
     ).collect { case (key, Some(data)) => (key, data) }
 }
@@ -77,7 +77,7 @@ object SupplementaryDeclarationData {
       transportInformation = cacheMap.getEntry[TransportInformation](TransportInformation.id),
       items = flattenIfEmpty(Items(cacheMap)),
       previousDocuments = cacheMap.getEntry[PreviousDocuments](PreviousDocuments.formId),
-      additionalInformation = cacheMap.getEntry[AdditionalInformation](AdditionalInformation.formId),
+      additionalInformationData = cacheMap.getEntry[AdditionalInformationData](AdditionalInformationData.formId),
       documentsProduced = cacheMap.getEntry[DocumentsProduced](DocumentsProduced.formId)
     )
 

--- a/app/views/supplementary/additional_information.scala.html
+++ b/app/views/supplementary/additional_information.scala.html
@@ -19,7 +19,7 @@
 @import forms.supplementary.AdditionalInformation
 @import uk.gov.hmrc.play.views.html._
 
-@(appConfig: AppConfig, form: Form[AdditionalInformation])(implicit request: Request[_], messages: Messages)
+@(appConfig: AppConfig, form: Form[AdditionalInformation], items: Seq[AdditionalInformation])(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("supplementary.additionalInformation"),
@@ -32,6 +32,8 @@
 
         @components.page_title(Some("supplementary.additionalInformation.title"))
 
+        @components.single_value_elements_table(items.map(_.toString))
+
         @components.input_text(
             field = form("code"),
             label = messages("supplementary.additionalInformation.code")
@@ -42,6 +44,6 @@
             label = messages("supplementary.additionalInformation.description")
         )
 
-        @components.submit_button()
+        @components.add_save_button()
     }
 }

--- a/app/views/supplementary/summary/additional_information_section.scala.html
+++ b/app/views/supplementary/summary/additional_information_section.scala.html
@@ -14,18 +14,14 @@
  * limitations under the License.
  *@
 
-@import forms.supplementary.AdditionalInformation
+@import models.declaration.supplementary.AdditionalInformationData
 @import models.viewmodels.HtmlTableRow
-
-@(additionalInformation: Option[AdditionalInformation])(implicit messages: Messages)
+@(additionalInformationData: Option[AdditionalInformationData])(implicit messages: Messages)
 
 @components.summary_list(Some(messages("supplementary.summary.additionalInformation.header"))) {
+
     @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalInformation.code"),
-        value = additionalInformation.flatMap(_.code)
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalInformation.description"),
-        value = additionalInformation.flatMap(_.description)
+        label = messages("supplementary.summary.additionalInformation.header"),
+        value = additionalInformationData.map(_.items.map(_.toString))
     ))
 }

--- a/app/views/supplementary/summary/summary_page.scala.html
+++ b/app/views/supplementary/summary/summary_page.scala.html
@@ -65,10 +65,9 @@
 
     @previous_documents_section(suppDecData.previousDocuments)
 
-    @additional_information_section(suppDecData.additionalInformation)
+    @additional_information_section(suppDecData.additionalInformationData)
 
     @additional_documentation_section(suppDecData.documentsProduced)
-
 
     @helpers.form(action = SummaryPageController.submitSupplementaryDeclaration()) {
         @components.submit_button("Accept and submit declaration")

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -470,8 +470,12 @@ supplementary.additionalInformation = Additional information
 supplementary.additionalInformation.title = 2/2 Additional information
 supplementary.additionalInformation.code = Enter the union or national code
 supplementary.additionalInformation.code.error = Code is incorrect
+supplementary.additionalInformation.code.empty = Code cannot be empty
 supplementary.additionalInformation.description = Enter the information required
-supplementary.additionalInformation.description.error = Information is incorrect
+supplementary.additionalInformation.description.error = Information description is incorrect
+supplementary.additionalInformation.description.empty = Information description cannot be empty
+supplementary.additionalInformation.maximumAmount.error = You cannot have more than 99 items
+supplementary.additionalInformation.duplicated = You cannot add the same item
 
 supplementary.transactionType.documentTypeCode.title = Transaction type
 supplementary.transactionType.documentTypeCode.header = 8/5 Transaction type

--- a/test/controllers/supplementary/SummaryPageControllerSpec.scala
+++ b/test/controllers/supplementary/SummaryPageControllerSpec.scala
@@ -168,8 +168,6 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.previousDocuments.documentReference"))
         resultAsString must include(messages("supplementary.summary.previousDocuments.goodsItemIdentifier"))
         resultAsString must include(messages("supplementary.summary.additionalInformation.header"))
-        resultAsString must include(messages("supplementary.summary.additionalInformation.code"))
-        resultAsString must include(messages("supplementary.summary.additionalInformation.description"))
         resultAsString must include(messages("supplementary.summary.additionalDocumentation.header"))
         resultAsString must include(messages("supplementary.summary.additionalDocumentation.documentTypeCode"))
         resultAsString must include(messages("supplementary.summary.additionalDocumentation.documentId"))

--- a/test/forms/supplementary/AdditionalInformationSpec.scala
+++ b/test/forms/supplementary/AdditionalInformationSpec.scala
@@ -15,8 +15,9 @@
  */
 
 package forms.supplementary
+import models.declaration.supplementary.AdditionalInformationData
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json.{JsObject, JsString, JsValue}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 class AdditionalInformationSpec extends WordSpec with MustMatchers {
   import AdditionalInformationSpec._
@@ -25,11 +26,17 @@ class AdditionalInformationSpec extends WordSpec with MustMatchers {
     "return proper Metadata Properties" in {
       val additionalInformation = correctAdditionalInformation
       val expectedProperties: Map[String, String] = Map(
-        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementCode" -> additionalInformation.code.get,
-        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementDescription" -> additionalInformation.description.get
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementCode" -> additionalInformation.items.head.code.get,
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalInformations[0].statementDescription" -> additionalInformation.items.head.description.get
       )
 
       additionalInformation.toMetadataProperties() must equal(expectedProperties)
+    }
+  }
+
+  "Declaration object" should {
+    "contains correct limit value" in {
+      AdditionalInformationData.maxNumberOfItems must be(99)
     }
   }
 
@@ -37,12 +44,19 @@ class AdditionalInformationSpec extends WordSpec with MustMatchers {
 
 object AdditionalInformationSpec {
   val correctAdditionalInformation =
-    AdditionalInformation(code = Some("12345"), description = Some("Description for Additional Information"))
+    AdditionalInformationData(
+      Seq(AdditionalInformation(code = Some("M1l3s"), description = Some("Description for Additional Information: Davis"))))
+
   val emptyAdditionalInformation = AdditionalInformation(None, None)
 
   val correctAdditionalInformationJSON: JsValue = JsObject(
-    Map("code" -> JsString("12345"), "description" -> JsString("Description for Additional Information"))
-  )
+    Map("code" -> JsString("M1l3s"), "description" -> JsString("Description for Additional Information: Davis")))
+
+  val incorrectAdditionalInformationJSON: JsValue = JsObject(
+    Map("code" -> JsString("Miles"), "description" -> JsString("Description for Additional Information: Davis")))
+
   val emptyAdditionalInformationJSON: JsValue = JsObject(Map("code" -> JsString(""), "description" -> JsString("")))
 
+  val correctAdditionalInformationDataJSON: JsValue = JsObject(
+    Map("items" -> JsArray(Seq(correctAdditionalInformationJSON))))
 }

--- a/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
+++ b/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
@@ -77,7 +77,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.transportInformation mustNot be(defined)
           supplementaryDeclarationData.items mustNot be(defined)
           supplementaryDeclarationData.previousDocuments mustNot be(defined)
-          supplementaryDeclarationData.additionalInformation mustNot be(defined)
+          supplementaryDeclarationData.additionalInformationData mustNot be(defined)
           supplementaryDeclarationData.documentsProduced mustNot be(defined)
         }
       }
@@ -244,7 +244,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.items.get.itemType must be(defined)
           supplementaryDeclarationData.items.get.packageInformation must be(defined)
           supplementaryDeclarationData.previousDocuments must be(defined)
-          supplementaryDeclarationData.additionalInformation must be(defined)
+          supplementaryDeclarationData.additionalInformationData must be(defined)
           supplementaryDeclarationData.documentsProduced must be(defined)
         }
       }
@@ -281,11 +281,11 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       "return Map with 3 elements" in {
         val declarationType = correctDeclarationType
         val parties = Parties(exporterDetails = Some(correctExporterDetails))
-        val additionalInformation = correctAdditionalInformation
+        val additionalInformationData = correctAdditionalInformation
         val supplementaryDeclarationData = SupplementaryDeclarationData(
           declarationType = Some(declarationType),
           parties = Some(parties),
-          additionalInformation = Some(additionalInformation)
+          additionalInformationData = Some(additionalInformationData)
         )
 
         val map = supplementaryDeclarationData.toMap
@@ -297,9 +297,9 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         map.keys must contain(Parties.id)
         map.get(Parties.id) must be(defined)
         map(Parties.id) must equal(parties)
-        map.keys must contain(AdditionalInformation.formId)
-        map.get(AdditionalInformation.formId) must be(defined)
-        map(AdditionalInformation.formId) must equal(additionalInformation)
+        map.keys must contain(AdditionalInformationData.formId)
+        map.get(AdditionalInformationData.formId) must be(defined)
+        map(AdditionalInformationData.formId) must equal(additionalInformationData)
       }
     }
 
@@ -326,8 +326,8 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         map(Items.id) must equal(data.items.get)
         map.keys must contain(PreviousDocuments.formId)
         map(PreviousDocuments.formId) must equal(data.previousDocuments.get)
-        map.keys must contain(AdditionalInformation.formId)
-        map(AdditionalInformation.formId) must equal(data.additionalInformation.get)
+        map.keys must contain(AdditionalInformationData.formId)
+        map(AdditionalInformationData.formId) must equal(data.additionalInformationData.get)
         map.keys must contain(DocumentsProduced.formId)
         map(DocumentsProduced.formId) must equal(data.documentsProduced.get)
       }
@@ -346,7 +346,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       verify(transportInformationMock, times(1)).toMetadataProperties()
       verify(itemsMock, times(1)).toMetadataProperties()
       verify(previousDocumentsMock, times(1)).toMetadataProperties()
-      verify(additionalInformationMock, times(1)).toMetadataProperties()
+      verify(additionalInformationDataMock, times(1)).toMetadataProperties()
       verify(documentsProducedMock, times(1)).toMetadataProperties()
     }
 
@@ -364,7 +364,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       val transportInformationMock = mock(classOf[TransportInformation])
       val itemsMock = mock(classOf[Items])
       val previousDocumentsMock = mock(classOf[PreviousDocuments])
-      val additionalInformationMock = mock(classOf[AdditionalInformation])
+      val additionalInformationDataMock = mock(classOf[AdditionalInformationData])
       val documentsProducedMock = mock(classOf[DocumentsProduced])
       val supplementaryDeclarationData = SupplementaryDeclarationData(
         declarationType = Some(declarationTypeMock),
@@ -374,7 +374,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         transportInformation = Some(transportInformationMock),
         items = Some(itemsMock),
         previousDocuments = Some(previousDocumentsMock),
-        additionalInformation = Some(additionalInformationMock),
+        additionalInformationData = Some(additionalInformationDataMock),
         documentsProduced = Some(documentsProducedMock)
       )
 
@@ -385,7 +385,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       when(transportInformationMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(itemsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(previousDocumentsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
-      when(additionalInformationMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
+      when(additionalInformationDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(documentsProducedMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
     }
 
@@ -407,7 +407,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       when(transportInformationMock.toMetadataProperties()).thenReturn(transportInformationMap)
       when(itemsMock.toMetadataProperties()).thenReturn(itemsMap)
       when(previousDocumentsMock.toMetadataProperties()).thenReturn(previousDocumentsMap)
-      when(additionalInformationMock.toMetadataProperties()).thenReturn(additionalInformationMap)
+      when(additionalInformationDataMock.toMetadataProperties()).thenReturn(additionalInformationMap)
       when(documentsProducedMock.toMetadataProperties()).thenReturn(documentsProducedMap)
     }
   }
@@ -441,7 +441,7 @@ object SupplementaryDeclarationDataSpec {
       ItemType.id -> correctItemTypeJSON,
       PackageInformation.formId -> correctPackageInformationDecimalValuesJSON,
       PreviousDocuments.formId -> correctPreviousDocumentsJSON,
-      AdditionalInformation.formId -> correctAdditionalInformationJSON,
+      AdditionalInformationData.formId -> correctAdditionalInformationDataJSON,
       DocumentsProduced.formId -> correctDocumentsProducedJSON
     )
   )
@@ -479,7 +479,7 @@ object SupplementaryDeclarationDataSpec {
       )
     ),
     previousDocuments = Some(correctPreviousDocuments),
-    additionalInformation = Some(correctAdditionalInformation),
+    additionalInformationData = Some(correctAdditionalInformation),
     documentsProduced = Some(correctDocumentsProduced)
   )
 


### PR DESCRIPTION
 * User should be able to enter up to 99 entries as per existing
   validations for this data element
 * User should not be able to enter the same value more than once
 * This data element is made up of 2 fields. Both fields must be
   populated for user to add the entry
 * The entries should be displayed as a list and show that the two
   fields are associated. E.g. 'field1-field2'