### PR TITLE
CEDS-949 Add multiplicity to 2/3 DocumentsProduced

### DIFF
--- a/app/controllers/supplementary/DocumentsProducedController.scala
+++ b/app/controllers/supplementary/DocumentsProducedController.scala
@@ -18,13 +18,22 @@ package controllers.supplementary
 
 import config.AppConfig
 import controllers.actions.AuthAction
+import controllers.supplementary.routes.{DocumentsProducedController, SummaryPageController}
 import controllers.util.CacheIdGenerator.supplementaryCacheId
+import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
 import forms.supplementary.DocumentsProduced
+import forms.supplementary.DocumentsProduced.form
+import handlers.ErrorHandler
 import javax.inject.Inject
-import play.api.data.Form
+import models.declaration.supplementary.DocumentsProducedData
+import models.declaration.supplementary.DocumentsProducedData.{formId, maxNumberOfItems}
+import models.requests.AuthenticatedRequest
+import play.api.data.{Form, FormError}
 import play.api.i18n.{I18nSupport, MessagesApi}
-import play.api.mvc.{Action, AnyContent}
+import play.api.libs.json.{JsValue, Json}
+import play.api.mvc.{Action, AnyContent, Request, Result}
 import services.CustomsCacheService
+import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.supplementary.documents_produced
 
@@ -34,29 +43,121 @@ class DocumentsProducedController @Inject()(
   appConfig: AppConfig,
   override val messagesApi: MessagesApi,
   authenticate: AuthAction,
+  errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService
 )(implicit ec: ExecutionContext)
     extends FrontendController with I18nSupport {
 
-  import forms.supplementary.DocumentsProduced._
-
   def displayForm(): Action[AnyContent] = authenticate.async { implicit request =>
-    customsCacheService.fetchAndGetEntry[DocumentsProduced](supplementaryCacheId, formId).map {
-      case Some(data) => Ok(documents_produced(appConfig, form.fill(data)))
-      case _          => Ok(documents_produced(appConfig, form))
-    }
+    customsCacheService
+      .fetchAndGetEntry[DocumentsProducedData](supplementaryCacheId, formId)
+      .map {
+        case Some(data) => Ok(documents_produced(appConfig, form, data.documents))
+        case _          => Ok(documents_produced(appConfig, form, Seq()))
+      }
   }
 
   def saveForm(): Action[AnyContent] = authenticate.async { implicit request =>
-    form
-      .bindFromRequest()
-      .fold(
-        (formWithErrors: Form[DocumentsProduced]) =>
-          Future.successful(BadRequest(documents_produced(appConfig, formWithErrors))),
-        form =>
-          customsCacheService.cache[DocumentsProduced](supplementaryCacheId, formId, form).map { _ =>
-            Redirect(controllers.supplementary.routes.SummaryPageController.displayPage())
-        }
-      )
+    val boundForm = form.bindFromRequest()
+    val actionTypeOpt = request.body.asFormUrlEncoded.flatMap(FormAction.fromUrlEncoded(_))
+    val cachedData = customsCacheService
+      .fetchAndGetEntry[DocumentsProducedData](supplementaryCacheId, formId)
+      .map(_.getOrElse(DocumentsProducedData(Seq())))
+
+    cachedData.flatMap { cache =>
+      boundForm
+        .fold(
+          (formWithErrors: Form[DocumentsProduced]) =>
+            Future.successful(BadRequest(documents_produced(appConfig, formWithErrors, cache.documents))),
+          validForm =>
+            actionTypeOpt match {
+              case Some(Add)             => addItem(validForm, cache)
+              case Some(SaveAndContinue) => saveAndContinue(validForm, cache)
+              case Some(Remove(values))  => removeItem(retrieveItem(Json.parse(values.headOption.get)), cache)
+              case _                     => errorHandler.displayErrorPage()
+          }
+        )
+    }
   }
+
+  private def saveAndContinue(
+    userInput: DocumentsProduced,
+    cachedData: DocumentsProducedData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    (userInput, cachedData.documents) match {
+      case (document, Seq())     => saveAndRedirect(document, Seq())
+      case (document, documents) => handleSaveAndContinueCache(document, documents)
+    }
+
+  private def handleSaveAndContinueCache(document: DocumentsProduced, documents: Seq[DocumentsProduced])(
+    implicit request: AuthenticatedRequest[_]
+  ) =
+    document match {
+      case _ if documents.length >= maxNumberOfItems =>
+        handleErrorPage(Seq(("", "supplementary.addDocument.maximumAmount.error")), document, documents)
+
+      case _ if documents.contains(document) =>
+        handleErrorPage(Seq(("", "supplementary.addDocument.duplicated")), document, documents)
+
+      case _ => saveAndRedirect(document, documents)
+    }
+
+  private def saveAndRedirect(
+    document: DocumentsProduced,
+    documents: Seq[DocumentsProduced]
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    if (document.isDefined)
+      customsCacheService
+        .cache[DocumentsProducedData](supplementaryCacheId, formId, DocumentsProducedData(documents :+ document))
+        .map { _ =>
+          Redirect(SummaryPageController.displayPage())
+        } else Future.successful(Redirect(SummaryPageController.displayPage()))
+
+  private def addItem(
+    userInput: DocumentsProduced,
+    cachedData: DocumentsProducedData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    (userInput, cachedData.documents) match {
+      case (_, documents) if documents.length >= maxNumberOfItems =>
+        handleErrorPage(Seq(("", "supplementary.addDocument.maximumAmount.error")), userInput, cachedData.documents)
+
+      case (document, documents) if documents.contains(document) =>
+        handleErrorPage(Seq(("", "supplementary.addDocument.duplicated")), userInput, cachedData.documents)
+
+      case (document, documents) => {
+        if (document.isDefined) {
+          val updatedCache = DocumentsProducedData(documents :+ document)
+          customsCacheService
+            .cache[DocumentsProducedData](supplementaryCacheId, formId, updatedCache)
+            .map(_ => Redirect(DocumentsProducedController.displayForm()))
+        } else handleErrorPage(Seq(("", "supplementary.addDocument.isNotDefined")), userInput, cachedData.documents)
+      }
+    }
+
+  private def removeItem(
+    docToRemove: DocumentsProduced,
+    cachedData: DocumentsProducedData
+  )(implicit request: AuthenticatedRequest[_], hc: HeaderCarrier): Future[Result] =
+    if (cachedData.containsItem(docToRemove)) {
+      val updatedCache = cachedData.copy(documents = cachedData.documents.filterNot(_ == docToRemove))
+
+      customsCacheService.cache[DocumentsProducedData](supplementaryCacheId, formId, updatedCache).map { _ =>
+        Redirect(DocumentsProducedController.displayForm())
+      }
+    } else errorHandler.displayErrorPage()
+
+  private def handleErrorPage(
+    fieldWithError: Seq[(String, String)],
+    userInput: DocumentsProduced,
+    documents: Seq[DocumentsProduced]
+  )(implicit request: Request[_]): Future[Result] = {
+    val updatedErrors = fieldWithError.map((FormError.apply(_: String, _: String)).tupled)
+
+    val formWithError = form.fill(userInput).copy(errors = updatedErrors)
+
+    Future.successful(BadRequest(documents_produced(appConfig, formWithError, documents)))
+  }
+
+  private def retrieveItem(value: JsValue): DocumentsProduced = DocumentsProduced.fromJson(value)
+
 }

--- a/app/controllers/supplementary/ProcedureCodesPageController.scala
+++ b/app/controllers/supplementary/ProcedureCodesPageController.scala
@@ -188,7 +188,7 @@ class ProcedureCodesPageController @Inject()(
             }
         }
     }
-  //scalastyle:on methodLength
+  //scalastyle:on method.length
 
   private def retrieveProcedureCode(values: Seq[String]): String = values.headOption.getOrElse("")
 

--- a/app/forms/supplementary/DocumentsProduced.scala
+++ b/app/forms/supplementary/DocumentsProduced.scala
@@ -16,10 +16,9 @@
 
 package forms.supplementary
 
-import forms.MetadataPropertiesConvertable
 import play.api.data.Forms._
 import play.api.data.{Form, Forms}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import utils.validators.FormFieldValidator._
 
 case class DocumentsProduced(
@@ -29,32 +28,25 @@ case class DocumentsProduced(
   documentStatus: Option[String],
   documentStatusReason: Option[String],
   documentQuantity: Option[String]
-) extends MetadataPropertiesConvertable {
+) {
+  implicit val writes = Json.writes[DocumentsProduced]
+  
+  def isDefined: Boolean =
+    List(documentTypeCode, documentIdentifier, documentPart, documentStatus, documentStatusReason, documentQuantity)
+      .exists(_.isDefined)
 
-  override def toMetadataProperties(): Map[String, String] =
-    Map(
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].categoryCode" ->
-        documentTypeCode.flatMap(_.headOption).fold("")(_.toString),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].typeCode" ->
-        documentTypeCode.map(_.drop(1).toString).getOrElse(""),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].id" ->
-        (documentIdentifier.getOrElse("") + documentPart.getOrElse("")),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].lpcoExemptionCode" ->
-        documentStatus.getOrElse(""),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].name" ->
-        documentStatusReason.getOrElse(""),
-      "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].writeOff.quantity" ->
-        documentQuantity.getOrElse("")
-    )
+  def toJson: JsValue = Json.toJson(this)
 }
 
 object DocumentsProduced {
+
   implicit val format = Json.format[DocumentsProduced]
 
   val formId = "Document"
 
   private val documentQuantityMaxLength = 16
   private val documentQuantityMaxDecimalPlaces = 6
+
   val mapping = Forms.mapping(
     "documentTypeCode" -> optional(
       text().verifying("supplementary.addDocument.documentTypeCode.error", hasSpecificLength(4) and isAlphanumeric)
@@ -80,4 +72,6 @@ object DocumentsProduced {
   )(DocumentsProduced.apply)(DocumentsProduced.unapply)
 
   def form(): Form[DocumentsProduced] = Form(mapping)
+
+  def fromJson(str: JsValue): DocumentsProduced = Json.fromJson(str).get
 }

--- a/app/models/declaration/supplementary/DocumentsProducedData.scala
+++ b/app/models/declaration/supplementary/DocumentsProducedData.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.declaration.supplementary
+
+import forms.MetadataPropertiesConvertable
+import forms.supplementary.DocumentsProduced
+import play.api.libs.json.Json
+
+case class DocumentsProducedData(documents: Seq[DocumentsProduced]) extends MetadataPropertiesConvertable {
+  override def toMetadataProperties(): Map[String, String] =
+    documents.zipWithIndex.map { document =>
+      Map(
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].categoryCode" ->
+          document._1.documentTypeCode.flatMap(_.headOption).fold("")(_.toString),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].typeCode" ->
+          document._1.documentTypeCode.map(_.drop(1).toString).getOrElse(""),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].id" ->
+          (document._1.documentIdentifier.getOrElse("") + document._1.documentPart.getOrElse("")),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].lpcoExemptionCode" ->
+          document._1.documentStatus.getOrElse(""),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].name" ->
+          document._1.documentStatusReason.getOrElse(""),
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[" + document._2 + "].writeOff.quantity" ->
+          document._1.documentQuantity.getOrElse("")
+      )
+    }.fold(Map.empty)(_ ++ _)
+
+  def containsItem(document: DocumentsProduced): Boolean = documents.contains(document)
+}
+
+object DocumentsProducedData {
+  implicit val format = Json.format[DocumentsProducedData]
+
+  val formId = "DocumentsProducedData"
+
+  val maxNumberOfItems = 99
+}
+
+
+

--- a/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
+++ b/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
@@ -29,7 +29,7 @@ case class SupplementaryDeclarationData(
   items: Option[Items] = None,
   previousDocuments: Option[PreviousDocuments] = None,
   additionalInformationData: Option[AdditionalInformationData] = None,
-  documentsProduced: Option[DocumentsProduced] = None
+  documentsProducedData: Option[DocumentsProducedData] = None
 ) extends SummaryContainer with MetadataPropertiesConvertable {
   import SupplementaryDeclarationData._
 
@@ -49,7 +49,7 @@ case class SupplementaryDeclarationData(
       items.isEmpty &&
       previousDocuments.isEmpty &&
       additionalInformationData.isEmpty &&
-      documentsProduced.isEmpty
+      documentsProducedData.isEmpty
 
   def toMap: Map[String, MetadataPropertiesConvertable] =
     Map(
@@ -61,7 +61,7 @@ case class SupplementaryDeclarationData(
       Items.id -> items,
       PreviousDocuments.formId -> previousDocuments,
       AdditionalInformationData.formId -> additionalInformationData,
-      DocumentsProduced.formId -> documentsProduced
+      DocumentsProducedData.formId -> documentsProducedData
     ).collect { case (key, Some(data)) => (key, data) }
 }
 
@@ -78,7 +78,7 @@ object SupplementaryDeclarationData {
       items = flattenIfEmpty(Items(cacheMap)),
       previousDocuments = cacheMap.getEntry[PreviousDocuments](PreviousDocuments.formId),
       additionalInformationData = cacheMap.getEntry[AdditionalInformationData](AdditionalInformationData.formId),
-      documentsProduced = cacheMap.getEntry[DocumentsProduced](DocumentsProduced.formId)
+      documentsProducedData = cacheMap.getEntry[DocumentsProducedData](DocumentsProducedData.formId)
     )
 
   private def flattenIfEmpty[A <: SummaryContainer](container: A): Option[A] =

--- a/app/views/supplementary/documents_produced.scala.html
+++ b/app/views/supplementary/documents_produced.scala.html
@@ -16,10 +16,11 @@
 
 @import config.AppConfig
 @import controllers.supplementary.routes._
+@import controllers.util.Remove
 @import forms.supplementary.DocumentsProduced
 @import uk.gov.hmrc.play.views.html._
 
-@(appConfig: AppConfig, form: Form[DocumentsProduced])(implicit request: Request[_], messages: Messages)
+@(appConfig: AppConfig, form: Form[DocumentsProduced], documents: Seq[DocumentsProduced])(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("supplementary.addDocument.title"),
@@ -29,6 +30,35 @@
     @helpers.form(DocumentsProducedController.saveForm(), 'autoComplete -> "off") {
 
         @components.back_link("/customs-declare-exports/declaration/supplementary/additional-information")
+
+        @if(documents.nonEmpty) {
+            <table class="form-group">
+                <thead>
+                    <tr>
+                        <th scope="col">@messages("supplementary.addDocument.documentTypeCode")</th>
+                        <th scope="col">@messages("supplementary.addDocument.documentIdentifier")</th>
+                        <th scope="col">@messages("supplementary.addDocument.documentPart")</th>
+                        <th scope="col">@messages("supplementary.addDocument.documentStatus")</th>
+                        <th scope="col">@messages("supplementary.addDocument.documentStatusReason")</th>
+                        <th scope="col">@messages("supplementary.addDocument.documentQuantity")</th>
+                        <th></th>
+                    </tr>
+                </thead>
+                <tbody>
+                @for(item <- documents) {
+                    <tr>
+                        <td scope="row">@item.documentTypeCode</td>
+                        <td>@item.documentIdentifier</td>
+                        <td>@item.documentPart</td>
+                        <td>@item.documentStatus</td>
+                        <td>@item.documentStatusReason</td>
+                        <td>@item.documentQuantity</td>
+                        <td><button class="button" name="@Remove.toString" value="@item.toJson">@messages("site.remove")</button></td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        }
 
         @components.error_summary(form.errors)
 
@@ -64,6 +94,6 @@
             label = messages("supplementary.addDocument.documentQuantity")
         )
 
-        @components.submit_button()
+        @components.add_save_button()
     }
 }

--- a/app/views/supplementary/summary/additional_documentation_section.scala.html
+++ b/app/views/supplementary/summary/additional_documentation_section.scala.html
@@ -14,34 +14,34 @@
  * limitations under the License.
  *@
 
-@import forms.supplementary.DocumentsProduced
+@import models.declaration.supplementary.DocumentsProducedData
 @import models.viewmodels.HtmlTableRow
-
-@(additionalDocumentation: Option[DocumentsProduced])(implicit messages: Messages)
+@(additionalDocumentationData: Option[DocumentsProducedData])(implicit messages: Messages)
 
 @components.summary_list(Some(messages("supplementary.summary.additionalDocumentation.header"))) {
+
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentTypeCode"),
-        value = additionalDocumentation.flatMap(_.documentTypeCode)
+        value = additionalDocumentationData.map(_.documents.map(_.documentTypeCode))
     ))
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentId"),
-        value = additionalDocumentation.flatMap(_.documentIdentifier)
+        value = additionalDocumentationData.map(_.documents.map(_.documentIdentifier))
     ))
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentPart"),
-        value = additionalDocumentation.flatMap(_.documentPart)
+        value = additionalDocumentationData.map(_.documents.map(_.documentPart))
     ))
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentStatus"),
-        value = additionalDocumentation.flatMap(_.documentStatus)
+        value = additionalDocumentationData.map(_.documents.map(_.documentStatus))
     ))
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentStatusReason"),
-        value = additionalDocumentation.flatMap(_.documentStatusReason)
+        value = additionalDocumentationData.map(_.documents.map(_.documentStatusReason))
     ))
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.additionalDocumentation.documentQuantity"),
-        value = additionalDocumentation.flatMap(_.documentQuantity)
+        value = additionalDocumentationData.map(_.documents.map(_.documentQuantity))
     ))
 }

--- a/app/views/supplementary/summary/summary_page.scala.html
+++ b/app/views/supplementary/summary/summary_page.scala.html
@@ -67,7 +67,7 @@
 
     @additional_information_section(suppDecData.additionalInformationData)
 
-    @additional_documentation_section(suppDecData.documentsProduced)
+    @additional_documentation_section(suppDecData.documentsProducedData)
 
     @helpers.form(action = SummaryPageController.submitSupplementaryDeclaration()) {
         @components.submit_button("Accept and submit declaration")

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -362,6 +362,9 @@ supplementary.addDocument.documentStatusReason = Document status reason
 supplementary.addDocument.documentStatusReason.error = Incorrect document status reason
 supplementary.addDocument.documentQuantity = Quantity
 supplementary.addDocument.documentQuantity.error = Incorrect quantity value
+supplementary.addDocument.maximumAmount.error = You cannot have more than 99 documents
+supplementary.addDocument.duplicated = You cannot add an already existent document
+supplementary.addDocument.isNotDefined = Please provide some document information
 
 supplementary.totalNumberOfItems = 1/9 What is the total number of items?
 supplementary.totalNumberOfItems.title = Total number of items

--- a/test/controllers/supplementary/DocumentsProducedControllerSpec.scala
+++ b/test/controllers/supplementary/DocumentsProducedControllerSpec.scala
@@ -17,28 +17,33 @@
 package controllers.supplementary
 
 import base.{CustomExportsBaseSpec, TestHelper}
-import forms.supplementary.DocumentsProduced
-import forms.supplementary.DocumentsProducedSpec._
+import controllers.util.{Add, Remove, SaveAndContinue}
+import forms.supplementary.DocumentsProducedSpec.{correctDocumentsProducedMap, _}
+import models.declaration.supplementary.DocumentsProducedData
+import models.declaration.supplementary.DocumentsProducedData.formId
 import org.scalatest.BeforeAndAfter
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
 
 class DocumentsProducedControllerSpec extends CustomExportsBaseSpec with BeforeAndAfter {
 
+  private val uri = uriWithContextPath("/declaration/supplementary/add-document")
+  private val addActionUrlEncoded = (Add.toString, "")
+  private val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
+  private def removeActionUrlEncoded(value: String) = (Remove.toString, value)
+
   before {
     authorizedUser()
-    withCaching[DocumentsProduced](None)
+    withCaching[DocumentsProducedData](None, formId)
   }
 
-  val uri = uriWithContextPath("/declaration/supplementary/add-document")
-
-  "DocumentsProducedController" should {
+  "Documents Produced Controller when getting the page" should {
     "return 200 with a success" in {
       val result = route(app, getRequest(uri)).get
       status(result) must be(OK)
     }
 
-    "display add document form" in {
+    "display add document form with no documents" in {
       val result = route(app, getRequest(uri)).get
       val stringResult = contentAsString(result)
 
@@ -53,7 +58,39 @@ class DocumentsProducedControllerSpec extends CustomExportsBaseSpec with BeforeA
       stringResult must include(messages("supplementary.addDocument.documentQuantity"))
     }
 
-    "display page with errors" when {
+    "display add document form with added documents" in {
+      withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+
+      val result = route(app, getRequest(uri)).get
+      val stringResult = contentAsString(result)
+
+      status(result) must be(OK)
+      stringResult must include("AB12")
+      stringResult must include("DocumentStatusReason")
+      stringResult must include("1234567890.123456")
+      stringResult must include("Remove")
+      stringResult must include(messages("supplementary.addDocument.title"))
+      stringResult must include(messages("supplementary.addDocument.hint"))
+      stringResult must include(messages("supplementary.addDocument.documentTypeCode"))
+      stringResult must include(messages("supplementary.addDocument.documentIdentifier"))
+      stringResult must include(messages("supplementary.addDocument.documentPart"))
+      stringResult must include(messages("supplementary.addDocument.documentStatus"))
+      stringResult must include(messages("supplementary.addDocument.documentStatusReason"))
+      stringResult must include(messages("supplementary.addDocument.documentQuantity"))
+    }
+
+    "display back button that links to additional information page" in {
+      val result = route(app, getRequest(uri)).get
+      val stringResult = contentAsString(result)
+
+      status(result) must be(OK)
+      stringResult must include(messages("site.back"))
+      stringResult must include(messages("/declaration/supplementary/additional-information"))
+    }
+  }
+
+  "Documents Produced Controller handling a post" should {
+    "display page with an error" when {
       "provided with incorrect document status" in {
         val incorrectDocumentStatus: JsValue = JsObject(Map("documentStatus" -> JsString("as")))
 
@@ -97,19 +134,125 @@ class DocumentsProducedControllerSpec extends CustomExportsBaseSpec with BeforeA
         status(result) must be(BAD_REQUEST)
         contentAsString(result) must include(messages("supplementary.addDocument.documentQuantity.error"))
       }
+
+      "try to remove a non existent document" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+        val body = ("action", "Remove:123-123-123-123-123-123")
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body)).get
+        val stringResult = contentAsString(result)
+
+        status(result) must be(BAD_REQUEST)
+        stringResult must include(messages("global.error.title"))
+        stringResult must include(messages("global.error.heading"))
+        stringResult must include(messages("global.error.message"))
+      }
+
+      "try to add duplicated document" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+
+        val duplicatedDocument: Map[String, String] = Map(
+          "documentTypeCode" -> "AB12",
+          "documentIdentifier" -> "ABCDEF1234567890",
+          "documentPart" -> "ABC12",
+          "documentStatus" -> "AB",
+          "documentStatusReason" -> "DocumentStatusReason",
+          "documentQuantity" -> "1234567890.123456")
+
+        val body = duplicatedDocument.toSeq :+ addActionUrlEncoded
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(BAD_REQUEST)
+        contentAsString(result) must include(messages("supplementary.addDocument.duplicated"))
+      }
+
+      "try to add an undefined document" in {
+
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+
+        val undefinedDocument: Map[String, String] = Map(
+          "documentTypeCode" -> "",
+          "documentIdentifier" -> "",
+          "documentPart" -> "",
+          "documentStatus" -> "",
+          "documentStatusReason" -> "",
+          "documentQuantity" -> "")
+
+        val body = undefinedDocument.toSeq :+ addActionUrlEncoded
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(BAD_REQUEST)
+        contentAsString(result) must include(messages("supplementary.addDocument.isNotDefined"))
+      }
+    }
+
+    "add a document sucessfully" when {
+      "with an empty cache" in {
+        withCaching[DocumentsProducedData](None, formId)
+        val body = correctDocumentsProducedMap.toSeq :+ addActionUrlEncoded
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(SEE_OTHER)
+      }
+
+      "that does not exist in cache" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+        val body = correctDocumentsProducedMap.toSeq :+ addActionUrlEncoded
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(SEE_OTHER)
+      }
+    }
+
+    "remove a document successfully" when {
+      "exists in cache" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+
+        val body = removeActionUrlEncoded(correctDocumentsProducedData.documents.head.toJson.toString())
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body)).get
+
+        status(result) must be(SEE_OTHER)
+      }
     }
 
     "redirect to summary page" when {
-      "provided with empty form" in {
-        val result = route(app, postRequest(uri, emptyDocumentsProducedJSON)).get
+      "provided with empty form and with empty cache" in {
+        val body = emptyDocumentsProducedMap.toSeq :+ saveAndContinueActionUrlEncoded
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        val header = result.futureValue.header
+        status(result) must be(SEE_OTHER)
+        header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/supplementary/summary"))
+      }
+
+      "provided with empty form and with existing cache" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+        val body = emptyDocumentsProducedMap.toSeq :+ saveAndContinueActionUrlEncoded
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        val header = result.futureValue.header
+        status(result) must be(SEE_OTHER)
+        header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/supplementary/summary"))
+      }
+
+      "provided with a valid document and with empty cache" in {
+        val body = correctDocumentsProducedMap.toSeq :+ saveAndContinueActionUrlEncoded
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/supplementary/summary"))
       }
 
-      "provided with correct form" in {
-        val result = route(app, postRequest(uri, correctDocumentsProducedJSON)).get
+      "provided with a valid document and with existing cache" in {
+        withCaching[DocumentsProducedData](Some(correctDocumentsProducedData), formId)
+        val body = correctDocumentsProducedMap.toSeq :+ saveAndContinueActionUrlEncoded
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)

--- a/test/forms/supplementary/AdditionalInformationSpec.scala
+++ b/test/forms/supplementary/AdditionalInformationSpec.scala
@@ -34,7 +34,7 @@ class AdditionalInformationSpec extends WordSpec with MustMatchers {
     }
   }
 
-  "Declaration object" should {
+  "Additional Information object" should {
     "contains correct limit value" in {
       AdditionalInformationData.maxNumberOfItems must be(99)
     }

--- a/test/forms/supplementary/DocumentsProducedSpec.scala
+++ b/test/forms/supplementary/DocumentsProducedSpec.scala
@@ -16,26 +16,36 @@
 
 package forms.supplementary
 
+import models.declaration.supplementary.DocumentsProducedData
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json.{JsObject, JsString, JsValue}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 class DocumentsProducedSpec extends WordSpec with MustMatchers {
   import DocumentsProducedSpec._
 
   "Method toMetadataProperties" should {
     "return proper Metadata Properties" in {
-      val documentsProduced = correctDocumentsProduced
-      val expectedID = documentsProduced.documentIdentifier.get + documentsProduced.documentPart.get
+      val documentsProducedData = correctDocumentsProducedData
+      val expectedID = documentsProducedData.documents.head.documentIdentifier.get + documentsProducedData.documents.head.documentPart.get
       val expectedMetadataProperties: Map[String, String] = Map(
         "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].categoryCode" -> categoryCode,
         "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].typeCode" -> typeCode,
         "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].id" -> expectedID,
-        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].lpcoExemptionCode" -> documentsProduced.documentStatus.get,
-        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].name" -> documentsProduced.documentStatusReason.get,
-        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].writeOff.quantity" -> documentsProduced.documentQuantity.get
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].lpcoExemptionCode"
+          -> documentsProducedData.documents.head.documentStatus.get,
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].name"
+          -> documentsProducedData.documents.head.documentStatusReason.get,
+        "declaration.goodsShipment.governmentAgencyGoodsItems[0].additionalDocuments[0].writeOff.quantity"
+          -> documentsProducedData.documents.head.documentQuantity.get
       )
 
-      documentsProduced.toMetadataProperties() must equal(expectedMetadataProperties)
+      documentsProducedData.toMetadataProperties() must equal(expectedMetadataProperties)
+    }
+  }
+
+  "Documents Produced object" should {
+    "contains correct limit value" in {
+      DocumentsProducedData.maxNumberOfItems must be(99)
     }
   }
 
@@ -45,14 +55,19 @@ object DocumentsProducedSpec {
   private val categoryCode = "A"
   private val typeCode = "B12"
 
-  val correctDocumentsProduced = DocumentsProduced(
-    documentTypeCode = Some(categoryCode + typeCode),
-    documentIdentifier = Some("ABCDEF1234567890"),
-    documentPart = Some("ABC12"),
-    documentStatus = Some("AB"),
-    documentStatusReason = Some("DocumentStatusReason"),
-    documentQuantity = Some("1234567890.123456")
+  val correctDocumentsProducedData = DocumentsProducedData(
+    Seq(
+      DocumentsProduced(
+        documentTypeCode = Some(categoryCode + typeCode),
+        documentIdentifier = Some("ABCDEF1234567890"),
+        documentPart = Some("ABC12"),
+        documentStatus = Some("AB"),
+        documentStatusReason = Some("DocumentStatusReason"),
+        documentQuantity = Some("1234567890.123456")
+      )
+    )
   )
+
   val emptyDocumentsProduced = DocumentsProduced(
     documentTypeCode = None,
     documentIdentifier = None,
@@ -60,6 +75,15 @@ object DocumentsProducedSpec {
     documentStatus = None,
     documentStatusReason = None,
     documentQuantity = None
+  )
+
+  val correctDocumentsProducedMap: Map[String, String] = Map(
+    "documentTypeCode" -> "AB13",
+    "documentIdentifier" -> "ABCDEF1234567890",
+    "documentPart" -> "ABC12",
+    "documentStatus" -> "AB",
+    "documentStatusReason" -> "DocumentStatusReason",
+    "documentQuantity" -> "1234567890.123456"
   )
 
   val correctDocumentsProducedJSON: JsValue = JsObject(
@@ -72,6 +96,20 @@ object DocumentsProducedSpec {
       "documentQuantity" -> JsString("1234567890.123456")
     )
   )
+
+  val correctDocumentsProducedDataJSON: JsValue = JsObject(
+    Map("documents" -> JsArray(Seq(correctDocumentsProducedJSON)))
+  )
+
+  val emptyDocumentsProducedMap: Map[String, String] = Map(
+    "documentTypeCode" -> "",
+    "documentIdentifier" -> "",
+    "documentPart" -> "",
+    "documentStatus" -> "",
+    "documentStatusReason" -> "",
+    "documentQuantity" -> ""
+  )
+
   val emptyDocumentsProducedJSON: JsValue = JsObject(
     Map(
       "documentTypeCode" -> JsString(""),
@@ -83,4 +121,5 @@ object DocumentsProducedSpec {
     )
   )
 
+  val emptyDocumentsProducedDataJSON: JsValue = JsObject(Map("documents" -> JsArray(Seq(correctDocumentsProducedJSON))))
 }

--- a/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
+++ b/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
@@ -78,7 +78,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.items mustNot be(defined)
           supplementaryDeclarationData.previousDocuments mustNot be(defined)
           supplementaryDeclarationData.additionalInformationData mustNot be(defined)
-          supplementaryDeclarationData.documentsProduced mustNot be(defined)
+          supplementaryDeclarationData.documentsProducedData mustNot be(defined)
         }
       }
 
@@ -245,7 +245,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.items.get.packageInformation must be(defined)
           supplementaryDeclarationData.previousDocuments must be(defined)
           supplementaryDeclarationData.additionalInformationData must be(defined)
-          supplementaryDeclarationData.documentsProduced must be(defined)
+          supplementaryDeclarationData.documentsProducedData must be(defined)
         }
       }
 
@@ -328,8 +328,8 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         map(PreviousDocuments.formId) must equal(data.previousDocuments.get)
         map.keys must contain(AdditionalInformationData.formId)
         map(AdditionalInformationData.formId) must equal(data.additionalInformationData.get)
-        map.keys must contain(DocumentsProduced.formId)
-        map(DocumentsProduced.formId) must equal(data.documentsProduced.get)
+        map.keys must contain(DocumentsProducedData.formId)
+        map(DocumentsProducedData.formId) must equal(data.documentsProducedData.get)
       }
     }
 
@@ -347,7 +347,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       verify(itemsMock, times(1)).toMetadataProperties()
       verify(previousDocumentsMock, times(1)).toMetadataProperties()
       verify(additionalInformationDataMock, times(1)).toMetadataProperties()
-      verify(documentsProducedMock, times(1)).toMetadataProperties()
+      verify(documentsProducedDataMock, times(1)).toMetadataProperties()
     }
 
     "return Map being summary of all data elements returned Maps" in new TestMapConcatenation {
@@ -365,7 +365,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       val itemsMock = mock(classOf[Items])
       val previousDocumentsMock = mock(classOf[PreviousDocuments])
       val additionalInformationDataMock = mock(classOf[AdditionalInformationData])
-      val documentsProducedMock = mock(classOf[DocumentsProduced])
+      val documentsProducedDataMock = mock(classOf[DocumentsProducedData])
       val supplementaryDeclarationData = SupplementaryDeclarationData(
         declarationType = Some(declarationTypeMock),
         consignmentReferences = Some(consignmentReferencesMock),
@@ -375,7 +375,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         items = Some(itemsMock),
         previousDocuments = Some(previousDocumentsMock),
         additionalInformationData = Some(additionalInformationDataMock),
-        documentsProduced = Some(documentsProducedMock)
+        documentsProducedData = Some(documentsProducedDataMock)
       )
 
       when(declarationTypeMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
@@ -386,7 +386,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       when(itemsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(previousDocumentsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(additionalInformationDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
-      when(documentsProducedMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
+      when(documentsProducedDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
     }
 
     trait TestMapConcatenation extends SimpleTest {
@@ -408,7 +408,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       when(itemsMock.toMetadataProperties()).thenReturn(itemsMap)
       when(previousDocumentsMock.toMetadataProperties()).thenReturn(previousDocumentsMap)
       when(additionalInformationDataMock.toMetadataProperties()).thenReturn(additionalInformationMap)
-      when(documentsProducedMock.toMetadataProperties()).thenReturn(documentsProducedMap)
+      when(documentsProducedDataMock.toMetadataProperties()).thenReturn(documentsProducedMap)
     }
   }
 
@@ -442,7 +442,7 @@ object SupplementaryDeclarationDataSpec {
       PackageInformation.formId -> correctPackageInformationDecimalValuesJSON,
       PreviousDocuments.formId -> correctPreviousDocumentsJSON,
       AdditionalInformationData.formId -> correctAdditionalInformationDataJSON,
-      DocumentsProduced.formId -> correctDocumentsProducedJSON
+      DocumentsProducedData.formId -> correctDocumentsProducedDataJSON
     )
   )
 
@@ -480,7 +480,7 @@ object SupplementaryDeclarationDataSpec {
     ),
     previousDocuments = Some(correctPreviousDocuments),
     additionalInformationData = Some(correctAdditionalInformation),
-    documentsProduced = Some(correctDocumentsProduced)
+    documentsProducedData = Some(correctDocumentsProducedData)
   )
 
 }


### PR DESCRIPTION
 * User should be able to enter up to 99 entries as per existing
   validations for this data element
 * User should not be able to enter the same value more than once
 * This data element is made up of 6 fields
 * The entries should be displayed as a list and show that the 6
   fields are associated