### PR TITLE
CEDS-950 Additional Documentation fixes

### DIFF
--- a/app/views/supplementary/documents_produced.scala.html
+++ b/app/views/supplementary/documents_produced.scala.html
@@ -41,7 +41,7 @@
                         <th scope="col">@messages("supplementary.addDocument.documentStatus")</th>
                         <th scope="col">@messages("supplementary.addDocument.documentStatusReason")</th>
                         <th scope="col">@messages("supplementary.addDocument.documentQuantity")</th>
-                        <th></th>
+                        <td></td>
                     </tr>
                 </thead>
                 <tbody>

--- a/app/views/supplementary/summary/additional_documentation_section.scala.html
+++ b/app/views/supplementary/summary/additional_documentation_section.scala.html
@@ -20,28 +20,30 @@
 
 @components.summary_list(Some(messages("supplementary.summary.additionalDocumentation.header"))) {
 
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentTypeCode"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentTypeCode))
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentId"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentIdentifier))
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentPart"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentPart))
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentStatus"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentStatus))
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentStatusReason"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentStatusReason))
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.additionalDocumentation.documentQuantity"),
-        value = additionalDocumentationData.map(_.documents.map(_.documentQuantity))
-    ))
+    @if(additionalDocumentationData.map(_.documents.nonEmpty)) {
+        <table class="form-group">
+            <thead>
+                <tr>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentTypeCode")</th>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentId")</th>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentPart")</th>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentStatus")</th>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentStatusReason")</th>
+                    <th scope="col">@messages("supplementary.summary.additionalDocumentation.documentQuantity")</th>
+                </tr>
+            </thead>
+            <tbody>
+            @for(item <- additionalDocumentationData.map(_.documents).get) {
+                <tr>
+                    <td scope="row">@item.documentTypeCode</td>
+                    <td>@item.documentIdentifier</td>
+                    <td>@item.documentPart</td>
+                    <td>@item.documentStatus</td>
+                    <td>@item.documentStatusReason</td>
+                    <td>@item.documentQuantity</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
 }

--- a/test/controllers/supplementary/SummaryPageControllerSpec.scala
+++ b/test/controllers/supplementary/SummaryPageControllerSpec.scala
@@ -18,6 +18,7 @@ package controllers.supplementary
 
 import base.CustomExportsBaseSpec
 import forms.supplementary.{ConsignmentReferences, ConsignmentReferencesSpec}
+import models.declaration.supplementary.SupplementaryDeclarationDataSpec
 import models.{CustomsDeclarationsResponse, CustomsDeclareExportsResponse}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -160,6 +161,26 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
       }
 
       "display content for Documents module" in new Test {
+        val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
+
+        resultAsString must include(messages("supplementary.summary.previousDocuments.header"))
+        resultAsString must include(messages("supplementary.summary.previousDocuments.documentCategory"))
+        resultAsString must include(messages("supplementary.summary.previousDocuments.documentType"))
+        resultAsString must include(messages("supplementary.summary.previousDocuments.documentReference"))
+        resultAsString must include(messages("supplementary.summary.previousDocuments.goodsItemIdentifier"))
+        resultAsString must include(messages("supplementary.summary.additionalInformation.header"))
+        resultAsString must include(messages("supplementary.summary.additionalDocumentation.header"))
+        resultAsString must not include messages("supplementary.summary.additionalDocumentation.documentTypeCode")
+        resultAsString must not include messages("supplementary.summary.additionalDocumentation.documentId")
+        resultAsString must not include messages("supplementary.summary.additionalDocumentation.documentPart")
+        resultAsString must not include messages("supplementary.summary.additionalDocumentation.documentStatus")
+        resultAsString must not include messages("supplementary.summary.additionalDocumentation.documentStatusReason")
+      }
+
+      "display content for Documents module with cache available" in new Test {
+        when(mockCustomsCacheService.fetch(anyString())(any(), any()))
+          .thenReturn(Future.successful(Some(SupplementaryDeclarationDataSpec.cacheMapAllRecords)))
+
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.previousDocuments.header"))


### PR DESCRIPTION
* **Display Additional Documentation on a table**
Due to multiplicity we need to display multiple documents and after speaking with @raghu1978 we have agreed that we would use a table format.
In the future we also need to think about ability to change and add documents from the summary page.

* **Replace <th> with <td> for an emtpy table header**
According to guidelines we should not have empty table headers replacing it with `<td>`