### PR TITLE
CEDS-976 Add multiple transport containers

### DIFF
--- a/app/controllers/supplementary/TransportInformationContainersPageController.scala
+++ b/app/controllers/supplementary/TransportInformationContainersPageController.scala
@@ -18,22 +18,21 @@ package controllers.supplementary
 
 import config.AppConfig
 import controllers.actions.AuthAction
-import controllers.supplementary.routes.{TotalNumberOfItemsController, TransportInformationContainersPageController}
 import controllers.util.CacheIdGenerator.supplementaryCacheId
-import forms.supplementary.TransportInformation
-import forms.supplementary.TransportInformation.form
+import forms.supplementary.TransportInformationContainer.form
 import handlers.ErrorHandler
 import javax.inject.Inject
-import play.api.data.Form
+import models.declaration.supplementary.TransportInformationContainerData
+import models.declaration.supplementary.TransportInformationContainerData.formId
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc.{Action, AnyContent}
 import services.CustomsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.supplementary.transport_information
+import views.html.supplementary.add_transport_containers
 
-import scala.concurrent.{ExecutionContext, Future}
+import scala.concurrent.ExecutionContext
 
-class TransportInformationPageController @Inject()(
+class TransportInformationContainersPageController @Inject()(
   appConfig: AppConfig,
   override val messagesApi: MessagesApi,
   authenticate: AuthAction,
@@ -46,29 +45,13 @@ class TransportInformationPageController @Inject()(
 
   def displayPage(): Action[AnyContent] = authenticate.async { implicit request =>
     customsCacheService
-      .fetchAndGetEntry[TransportInformation](supplementaryCacheId, TransportInformation.id)
+      .fetchAndGetEntry[TransportInformationContainerData](supplementaryCacheId, formId)
       .map {
-        case Some(data) => Ok(transport_information(appConfig, form.fill(data)))
-        case _          => Ok(transport_information(appConfig, form))
+        case Some(data) => Ok(add_transport_containers(appConfig, form, data.containers))
+        case _          => Ok(add_transport_containers(appConfig, form, Seq()))
       }
   }
 
-  def submitTransportInformation(): Action[AnyContent] = authenticate.async { implicit request =>
-    form
-      .bindFromRequest()
-      .fold(
-        (formWithErrors: Form[TransportInformation]) =>
-          Future.successful(BadRequest(transport_information(appConfig, formWithErrors))),
-        validTransportInformation =>
-          customsCacheService
-            .cache[TransportInformation](supplementaryCacheId, TransportInformation.id, validTransportInformation)
-            .map(_ => {
-              if (validTransportInformation.container)
-                Redirect(TransportInformationContainersPageController.displayPage())
-              else
-                Redirect(TotalNumberOfItemsController.displayForm())
-            })
-      )
-  }
+  def submitTransportInformation(): Action[AnyContent] = ???
 
 }

--- a/app/forms/supplementary/TransportInformation.scala
+++ b/app/forms/supplementary/TransportInformation.scala
@@ -32,8 +32,7 @@ case class TransportInformation(
   meansOfTransportCrossingTheBorderType: String,
   meansOfTransportCrossingTheBorderIDNumber: Option[String],
   meansOfTransportCrossingTheBorderNationality: Option[String],
-  container: Boolean,
-  containerId: Option[String]
+  container: Boolean
 ) extends MetadataPropertiesConvertable {
 
   override def toMetadataProperties(): Map[String, String] =
@@ -50,8 +49,7 @@ case class TransportInformation(
           .find(country => meansOfTransportCrossingTheBorderNationality.contains(country.countryName))
           .map(_.countryCode)
           .getOrElse(""),
-      "declaration.goodsShipment.consignment.containerCode" -> (if (container) "1" else "0"),
-      "declaration.goodsShipment.governmentAgencyGoodsItem.commodity.transportEquipment.id" -> containerId.getOrElse("")
+      "declaration.goodsShipment.consignment.containerCode" -> (if (container) "1" else "0")
     )
 }
 
@@ -137,13 +135,7 @@ object TransportInformation {
           isContainedIn(allCountries.map(_.countryName))
         )
     ),
-    "container" -> boolean,
-    "containerId" -> mandatoryIfTrue(
-      "container",
-      text()
-        .verifying("supplementary.transportInfo.containerId.empty", nonEmpty)
-        .verifying("supplementary.transportInfo.containerId.error", isEmpty or (isAlphanumeric and noLongerThan(17)))
-    )
+    "container" -> boolean
   )(TransportInformation.apply)(TransportInformation.unapply)
 
   object ModeOfTransportCodes {

--- a/app/forms/supplementary/TransportInformationContainer.scala
+++ b/app/forms/supplementary/TransportInformationContainer.scala
@@ -28,11 +28,14 @@ object TransportInformationContainer {
 
   val formId = "TransportInformationContainer"
 
+  val maxContainerIdLength = 17
+
   val mapping = Forms.mapping(
     "id" ->
       text()
         .verifying("supplementary.transportInfo.containerId.empty", nonEmpty)
-        .verifying("supplementary.transportInfo.containerId.error", isEmpty or (isAlphanumeric and noLongerThan(17)))
+        .verifying("supplementary.transportInfo.containerId.error.alphanumeric", isAlphanumeric)
+        .verifying("supplementary.transportInfo.containerId.error.length", noLongerThan(maxContainerIdLength))
   )(TransportInformationContainer.apply)(TransportInformationContainer.unapply)
 
   def form(): Form[TransportInformationContainer] = Form(mapping)

--- a/app/forms/supplementary/TransportInformationContainer.scala
+++ b/app/forms/supplementary/TransportInformationContainer.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.supplementary
+
+import play.api.data.Forms.text
+import play.api.data.{Form, Forms}
+import play.api.libs.json.Json
+import utils.validators.forms.FieldValidator._
+
+case class TransportInformationContainer(id: String)
+
+object TransportInformationContainer {
+  implicit val format = Json.format[TransportInformationContainer]
+
+  val formId = "TransportInformationContainer"
+
+  val mapping = Forms.mapping(
+    "id" ->
+      text()
+        .verifying("supplementary.transportInfo.containerId.empty", nonEmpty)
+        .verifying("supplementary.transportInfo.containerId.error", isEmpty or (isAlphanumeric and noLongerThan(17)))
+  )(TransportInformationContainer.apply)(TransportInformationContainer.unapply)
+
+  def form(): Form[TransportInformationContainer] = Form(mapping)
+}

--- a/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
+++ b/app/models/declaration/supplementary/SupplementaryDeclarationData.scala
@@ -26,6 +26,7 @@ case class SupplementaryDeclarationData(
   parties: Option[Parties] = None,
   locations: Option[Locations] = None,
   transportInformation: Option[TransportInformation] = None,
+  transportInformationContainerData: Option[TransportInformationContainerData] = None,
   items: Option[Items] = None,
   additionalInformationData: Option[AdditionalInformationData] = None,
   documentsProducedData: Option[DocumentsProducedData] = None
@@ -45,6 +46,7 @@ case class SupplementaryDeclarationData(
       parties.isEmpty &&
       locations.isEmpty &&
       transportInformation.isEmpty &&
+      transportInformationContainerData.isEmpty &&
       items.isEmpty &&
       additionalInformationData.isEmpty &&
       documentsProducedData.isEmpty
@@ -56,6 +58,7 @@ case class SupplementaryDeclarationData(
       Parties.id -> parties,
       Locations.id -> locations,
       TransportInformation.id -> transportInformation,
+      TransportInformationContainerData.id -> transportInformationContainerData,
       Items.id -> items,
       AdditionalInformationData.formId -> additionalInformationData,
       DocumentsProducedData.formId -> documentsProducedData
@@ -72,6 +75,8 @@ object SupplementaryDeclarationData {
       parties = flattenIfEmpty(Parties(cacheMap)),
       locations = flattenIfEmpty(Locations(cacheMap)),
       transportInformation = cacheMap.getEntry[TransportInformation](TransportInformation.id),
+      transportInformationContainerData =
+        cacheMap.getEntry[TransportInformationContainerData](TransportInformationContainerData.id),
       items = flattenIfEmpty(Items(cacheMap)),
       additionalInformationData = cacheMap.getEntry[AdditionalInformationData](AdditionalInformationData.formId),
       documentsProducedData = cacheMap.getEntry[DocumentsProducedData](DocumentsProducedData.formId)

--- a/app/models/declaration/supplementary/TransportInformationContainerData.scala
+++ b/app/models/declaration/supplementary/TransportInformationContainerData.scala
@@ -25,7 +25,7 @@ case class TransportInformationContainerData(containers: Seq[TransportInformatio
   override def toMetadataProperties(): Map[String, String] =
     containers.zipWithIndex.map { container =>
       Map(
-        "declaration.goodsShipment.consignment.transportEquipment[" + container._2 + "].id" -> container._1.id
+        "declaration.goodsShipment.consignment.transportEquipments[" + container._2 + "].id" -> container._1.id
       )
     }.fold(Map.empty)(_ ++ _)
 
@@ -35,7 +35,7 @@ case class TransportInformationContainerData(containers: Seq[TransportInformatio
 object TransportInformationContainerData {
   implicit val format = Json.format[TransportInformationContainerData]
 
-  val formId = "TransportInformationContainerData"
+  val id = "TransportInformationContainerData"
 
   val maxNumberOfItems = 9999
 }

--- a/app/models/declaration/supplementary/TransportInformationContainerData.scala
+++ b/app/models/declaration/supplementary/TransportInformationContainerData.scala
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.declaration.supplementary
+
+import forms.MetadataPropertiesConvertable
+import forms.supplementary.TransportInformationContainer
+import play.api.libs.json.Json
+
+case class TransportInformationContainerData(containers: Seq[TransportInformationContainer])
+    extends MetadataPropertiesConvertable {
+  override def toMetadataProperties(): Map[String, String] =
+    containers.zipWithIndex.map { container =>
+      Map(
+        "declaration.goodsShipment.consignment.transportEquipment[" + container._2 + "].id" -> container._1.id
+      )
+    }.fold(Map.empty)(_ ++ _)
+
+  def containsItem(container: TransportInformationContainer): Boolean = containers.contains(container)
+}
+
+object TransportInformationContainerData {
+  implicit val format = Json.format[TransportInformationContainerData]
+
+  val formId = "TransportInformationContainerData"
+
+  val maxNumberOfItems = 9999
+}

--- a/app/views/components/add_save_button.scala.html
+++ b/app/views/components/add_save_button.scala.html
@@ -22,6 +22,6 @@
 )(implicit messages: Messages)
 
 <div class="section align='right'">
-    <button id="add" class="button" name="@Add.toString">@messages(addKey)</button>
+    <button id="add" class="button--secondary" name="@Add.toString">@messages(addKey)</button>
     <button id="submit" class="button" name="@SaveAndContinue.toString">@messages(saveKey)</button>
 </div>

--- a/app/views/components/single_value_elements_table.scala.html
+++ b/app/views/components/single_value_elements_table.scala.html
@@ -28,7 +28,7 @@
             <tr>
                 <th>@elem</th>
                 <th>
-                    <button class="button" name="@Remove.toString" value="@elem">@messages(buttonMessagesKey)</button>
+                    <button class="button--secondary" name="@Remove.toString" value="@elem">@messages(buttonMessagesKey)</button>
                 </th>
             </tr>
         }

--- a/app/views/supplementary/add_transport_containers.scala.html
+++ b/app/views/supplementary/add_transport_containers.scala.html
@@ -50,7 +50,7 @@
                     <tr>
                         <td>@container.id</td>
                         <td>
-                            <button class="button" name="@Remove.toString" value="@index">@messages("site.remove")</button>
+                            <button class="button--secondary" name="@Remove.toString" value="@index">@messages("site.remove")</button>
                         </td>
                     </tr>
                 }

--- a/app/views/supplementary/add_transport_containers.scala.html
+++ b/app/views/supplementary/add_transport_containers.scala.html
@@ -1,0 +1,46 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import config.AppConfig
+@import controllers.supplementary.routes._
+@import forms.supplementary.TransportInformationContainer
+@import services.Country
+@import uk.gov.hmrc.play.views.html._
+@import utils.RadioOption
+@(appConfig: AppConfig, form: Form[TransportInformationContainer], containers: Seq[TransportInformationContainer])(implicit request: Request[_], messages: Messages, countries: List[Country])
+
+@main_template(
+    title = messages("supplementary.transportInfo.containers.title"),
+    appConfig = appConfig
+) {
+
+    @components.back_link("/customs-declare-exports/declaration/supplementary/transport-information")
+
+    @helpers.form(TransportInformationContainersPageController.submitTransportInformation(), 'autoComplete -> "off") {
+
+        @components.error_summary(form.errors)
+
+        @components.page_title(Some("supplementary.transportInfo.containers.title"), None)
+
+        @components.input_text(
+            field = form("containerId"),
+            label = messages("supplementary.transportInfo.containerId")
+        )
+
+        @components.add_save_button()
+    }
+
+}

--- a/app/views/supplementary/add_transport_containers.scala.html
+++ b/app/views/supplementary/add_transport_containers.scala.html
@@ -20,7 +20,8 @@
 @import services.Country
 @import uk.gov.hmrc.play.views.html._
 @import utils.RadioOption
-@(appConfig: AppConfig, form: Form[TransportInformationContainer], containers: Seq[TransportInformationContainer])(implicit request: Request[_], messages: Messages, countries: List[Country])
+@import controllers.util.Remove
+@(form: Form[TransportInformationContainer], containers: Seq[TransportInformationContainer])(implicit appConfig: AppConfig, request: Request[_], messages: Messages, countries: List[Country])
 
 @main_template(
     title = messages("supplementary.transportInfo.containers.title"),
@@ -29,14 +30,38 @@
 
     @components.back_link("/customs-declare-exports/declaration/supplementary/transport-information")
 
-    @helpers.form(TransportInformationContainersPageController.submitTransportInformation(), 'autoComplete -> "off") {
+    @helpers.form(TransportInformationContainersPageController.handlePost(), 'autoComplete -> "off") {
 
         @components.error_summary(form.errors)
 
         @components.page_title(Some("supplementary.transportInfo.containers.title"), None)
 
+
+        @if(containers.nonEmpty) {
+            <div class="field-group">
+                <table >
+                    <thead>
+                        <tr>
+                            <th scope="col">@messages("supplementary.transportInfo.containerId.title")</th>
+                            <td></td>
+                        </tr>
+                    </thead>
+                @containers.zipWithIndex.map { case (container, index) =>
+                    <tr>
+                        <td>@container.id</td>
+                        <td>
+                            <button class="button" name="@Remove.toString" value="@index">@messages("site.remove")</button>
+                        </td>
+                    </tr>
+                }
+                </table>
+                <br><br>
+            </div>
+        }
+
+
         @components.input_text(
-            field = form("containerId"),
+            field = form("id"),
             label = messages("supplementary.transportInfo.containerId")
         )
 

--- a/app/views/supplementary/additional_information.scala.html
+++ b/app/views/supplementary/additional_information.scala.html
@@ -40,7 +40,7 @@
                 <tr>
                     <th>@item</th>
                     <th>
-                        <button class="button" name="@Remove.toString" value="@index">@messages("site.remove")</button>
+                        <button class="button--secondary" name="@Remove.toString" value="@index">@messages("site.remove")</button>
                 </th>
                 </tr>
                 }

--- a/app/views/supplementary/declaration_additional_actors.scala.html
+++ b/app/views/supplementary/declaration_additional_actors.scala.html
@@ -50,7 +50,7 @@
                     <tr>
                         <td scope="row">@actor.eori</td>
                         <td>@actor.partyType</td>
-                        <td><button class="button" name="@Remove.toString" value="@actor.toJson">@messages("site.remove")</button></td>
+                        <td><button class="button--secondary" name="@Remove.toString" value="@actor.toJson">@messages("site.remove")</button></td>
                     </tr>
                 }
                 </tbody>

--- a/app/views/supplementary/documents_produced.scala.html
+++ b/app/views/supplementary/documents_produced.scala.html
@@ -53,7 +53,7 @@
                         <td>@item.documentStatus</td>
                         <td>@item.documentStatusReason</td>
                         <td>@item.documentQuantity</td>
-                        <td><button class="button" name="@Remove.toString" value="@item.toJson">@messages("site.remove")</button></td>
+                        <td><button class="button--secondary" name="@Remove.toString" value="@item.toJson">@messages("site.remove")</button></td>
                     </tr>
                 }
                 </tbody>

--- a/app/views/supplementary/summary/summary_page.scala.html
+++ b/app/views/supplementary/summary/summary_page.scala.html
@@ -61,6 +61,8 @@
 
     @transport_section(suppDecData.transportInformation)
 
+    @transport_containers_section(suppDecData.transportInformationContainerData)
+
     @items_section(suppDecData.items)
 
     @additional_information_section(suppDecData.additionalInformationData)

--- a/app/views/supplementary/summary/transport_containers_section.scala.html
+++ b/app/views/supplementary/summary/transport_containers_section.scala.html
@@ -1,0 +1,40 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import forms.supplementary.TransportInformation
+@import models.viewmodels.HtmlTableRow
+
+@import models.declaration.supplementary.TransportInformationContainerData
+@(containersData: Option[TransportInformationContainerData])(implicit messages: Messages)
+
+@components.summary_list(Some(messages("supplementary.transportInfo.containers.title"))) {
+    @if(containersData.map(_.containers.nonEmpty)) {
+        <table class="form-group">
+            <thead>
+                <tr>
+                    <th scope="col">@messages("supplementary.transportInfo.containerId.title")</th>
+                </tr>
+            </thead>
+            <tbody>
+            @for(container <- containersData.map(_.containers).get) {
+                <tr>
+                    <td scope="row">@container.id</td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    }
+}

--- a/app/views/supplementary/summary/transport_section.scala.html
+++ b/app/views/supplementary/summary/transport_section.scala.html
@@ -48,8 +48,4 @@
         label = messages("supplementary.summary.transport.meansOfTransportCrossingBorderNationality"),
         value = transportInformation.flatMap(_.meansOfTransportCrossingTheBorderNationality)
     ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.transport.containerId"),
-        value = transportInformation.flatMap(_.containerId)
-    ))
 }

--- a/app/views/supplementary/transport_information.scala.html
+++ b/app/views/supplementary/transport_information.scala.html
@@ -128,11 +128,6 @@
             inputs = Seq(RadioOption("Yes", "true", messages("site.yes")), RadioOption("No", "false", messages("site.no")))
         )
 
-        @components.input_text(
-            field = form("containerId"),
-            label = messages("supplementary.transportInfo.containerId")
-        )
-
         @components.submit_button()
     }
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -432,7 +432,10 @@ supplementary.transportInfo.meansOfTransport.idNumber.error.specialCharacters = 
 supplementary.transportInfo.container = 7/2 Will the goods be in a container?
 supplementary.transportInfo.containers.title = 7/10 Transport Information Containers
 supplementary.transportInfo.containerId = 7/10 Enter the container ID
+supplementary.transportInfo.containerId.title = Container ID
 supplementary.transportInfo.containerId.empty = Container ID cannot be empty
+supplementary.transportInfo.containerId.error.alphanumeric = Only alphanumeric characters allowed
+supplementary.transportInfo.containerId.error.length = Only 17 alphanumeric characters are allowed
 supplementary.transportInfo.containerId.error = Container ID is incorrect
 
 supplementary.totalAmountInvoiced.error = Total amount of invoiced items is incorrect

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -430,6 +430,7 @@ supplementary.transportInfo.meansOfTransport.crossingTheBorder.nationality.error
 supplementary.transportInfo.meansOfTransport.idNumber.error.length = Reference is too long
 supplementary.transportInfo.meansOfTransport.idNumber.error.specialCharacters = Reference cannot contain special characters
 supplementary.transportInfo.container = 7/2 Will the goods be in a container?
+supplementary.transportInfo.containers.title = 7/10 Transport Information Containers
 supplementary.transportInfo.containerId = 7/10 Enter the container ID
 supplementary.transportInfo.containerId.empty = Container ID cannot be empty
 supplementary.transportInfo.containerId.error = Container ID is incorrect

--- a/conf/supplementary.routes
+++ b/conf/supplementary.routes
@@ -97,6 +97,12 @@ GET         /transport-information          controllers.supplementary.TransportI
 
 POST        /transport-information          controllers.supplementary.TransportInformationPageController.submitTransportInformation()
 
+# Transport Information Containers
+
+GET         /add-transport-containers       controllers.supplementary.TransportInformationContainersPageController.displayPage()
+
+POST        /add-transport-containers       controllers.supplementary.TransportInformationContainersPageController.submitTransportInformation()
+
 # Total number of items
 
 GET         /total-numbers-of-items         controllers.supplementary.TotalNumberOfItemsController.displayForm()

--- a/conf/supplementary.routes
+++ b/conf/supplementary.routes
@@ -101,7 +101,7 @@ POST        /transport-information          controllers.supplementary.TransportI
 
 GET         /add-transport-containers       controllers.supplementary.TransportInformationContainersPageController.displayPage()
 
-POST        /add-transport-containers       controllers.supplementary.TransportInformationContainersPageController.submitTransportInformation()
+POST        /add-transport-containers       controllers.supplementary.TransportInformationContainersPageController.handlePost()
 
 # Total number of items
 

--- a/test/controllers/supplementary/ProcedureCodesPageControllerSpec.scala
+++ b/test/controllers/supplementary/ProcedureCodesPageControllerSpec.scala
@@ -94,7 +94,7 @@ class ProcedureCodesPageControllerSpec extends CustomExportsBaseSpec with Before
       val resultAsString = contentAsString(result)
 
       resultAsString must include(messages("site.add"))
-      resultAsString must include("button id=\"add\" class=\"button\"")
+      resultAsString must include("button id=\"add\" class=\"button--secondary\"")
     }
   }
 

--- a/test/controllers/supplementary/SummaryPageControllerSpec.scala
+++ b/test/controllers/supplementary/SummaryPageControllerSpec.scala
@@ -191,6 +191,17 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.additionalDocumentation.documentStatusReason"))
       }
 
+      "display containers content with cache available" in new Test {
+        when(mockCustomsCacheService.fetch(anyString())(any(), any()))
+          .thenReturn(Future.successful(Some(SupplementaryDeclarationDataSpec.cacheMapAllRecords)))
+
+        val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
+
+        resultAsString must include(messages("supplementary.transportInfo.containers.title"))
+        resultAsString must include(messages("supplementary.transportInfo.containerId.title"))
+        resultAsString must include(messages("container-M1l3s"))
+      }
+
       "get the whole supplementary declaration data from cache" in new Test {
         route(app, getRequest(summaryPageUri)).get.futureValue
         verify(mockCustomsCacheService, onlyOnce).fetch(any())(any(), any())

--- a/test/controllers/supplementary/SummaryPageControllerSpec.scala
+++ b/test/controllers/supplementary/SummaryPageControllerSpec.scala
@@ -144,7 +144,6 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(
           messages("supplementary.summary.transport.meansOfTransportCrossingBorderNationality")
         )
-        resultAsString must include(messages("supplementary.summary.transport.containerId"))
       }
 
       "display content for Item module" in new Test {

--- a/test/controllers/supplementary/TransportInformationContainersPageControllerSpec.scala
+++ b/test/controllers/supplementary/TransportInformationContainersPageControllerSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.supplementary
+import base.CustomExportsBaseSpec
+import models.declaration.supplementary.TransportInformationContainerData
+import models.declaration.supplementary.TransportInformationContainerData.formId
+import org.scalatest.BeforeAndAfter
+import play.api.test.Helpers._
+
+class TransportInformationContainersPageControllerSpec extends CustomExportsBaseSpec with BeforeAndAfter {
+
+  private val uri = uriWithContextPath("/declaration/supplementary/add-transport-containers")
+
+  before {
+    authorizedUser()
+    withCaching[TransportInformationContainerData](None, formId)
+  }
+
+  "Transport Information Containers Page Controller on display" should {
+
+    "display the whole content" in {
+      val result = route(app, getRequest(uri)).get
+      val resultAsString = contentAsString(result)
+
+      resultAsString must include(messages("supplementary.transportInfo.containers.title"))
+      resultAsString must include(messages("supplementary.transportInfo.containerId"))
+    }
+
+    "display 'Save and continue' button on page" in {
+
+      val result = route(app, getRequest(uri)).get
+      val resultAsString = contentAsString(result)
+
+      resultAsString must include(messages("site.save_and_continue"))
+      resultAsString must include("button id=\"submit\" class=\"button\"")
+    }
+
+    "display 'Back' button that links to 'Office-of-exit' page" in {
+      val result = route(app, getRequest(uri)).get
+
+      contentAsString(result) must include(messages("site.back"))
+      contentAsString(result) must include("/declaration/supplementary/transport-information")
+    }
+  }
+
+}

--- a/test/controllers/supplementary/TransportInformationContainersPageControllerSpec.scala
+++ b/test/controllers/supplementary/TransportInformationContainersPageControllerSpec.scala
@@ -16,8 +16,12 @@
 
 package controllers.supplementary
 import base.CustomExportsBaseSpec
+import base.TestHelper.createRandomString
+import controllers.supplementary.TransportInformationContainersPageControllerSpec.cacheWithMaximumAmountOfHolders
+import controllers.util.{Add, Remove, SaveAndContinue}
+import forms.supplementary.TransportInformationContainer
 import models.declaration.supplementary.TransportInformationContainerData
-import models.declaration.supplementary.TransportInformationContainerData.formId
+import models.declaration.supplementary.TransportInformationContainerData.id
 import org.scalatest.BeforeAndAfter
 import play.api.test.Helpers._
 
@@ -25,16 +29,22 @@ class TransportInformationContainersPageControllerSpec extends CustomExportsBase
 
   private val uri = uriWithContextPath("/declaration/supplementary/add-transport-containers")
 
+  private val addActionURLEncoded = (Add.toString, "")
+  private val saveAndContinueActionURLEncoded = (SaveAndContinue.toString, "")
+  private def removeActionURLEncoded(value: String) = (Remove.toString, value)
+
   before {
     authorizedUser()
-    withCaching[TransportInformationContainerData](None, formId)
+    withCaching[TransportInformationContainerData](None, id)
   }
 
-  "Transport Information Containers Page Controller on display" should {
+  "Transport Information Containers Page Controller on GET" should {
 
-    "display the whole content" in {
+    "display the whole content and return a 200 HTTP code" in {
       val result = route(app, getRequest(uri)).get
       val resultAsString = contentAsString(result)
+
+      status(result) must be(OK)
 
       resultAsString must include(messages("supplementary.transportInfo.containers.title"))
       resultAsString must include(messages("supplementary.transportInfo.containerId"))
@@ -55,6 +65,187 @@ class TransportInformationContainersPageControllerSpec extends CustomExportsBase
       contentAsString(result) must include(messages("site.back"))
       contentAsString(result) must include("/declaration/supplementary/transport-information")
     }
+
+    "display additional information form with added items" in {
+
+      val cachedData = TransportInformationContainerData(
+        Seq(TransportInformationContainer("M1l3s"), TransportInformationContainer("X4rlz"))
+      )
+      withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+      val result = route(app, getRequest(uri)).get
+      val resultAsString = contentAsString(result)
+
+      status(result) must be(OK)
+
+      resultAsString must include(messages("supplementary.transportInfo.containerId"))
+      resultAsString must include(messages("supplementary.transportInfo.containers.title"))
+      resultAsString must include(messages("supplementary.transportInfo.containerId.title"))
+    }
   }
 
+  "Additional Information Controller on POST" should {
+
+    "add a container successfully" when {
+
+      "with an empty cache" in {
+        withCaching[TransportInformationContainerData](None, id)
+        val body = Seq(("id", "J0ohn"), addActionURLEncoded)
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(SEE_OTHER)
+      }
+
+      "that does not exist in cache" in {
+        val cachedData = TransportInformationContainerData(Seq(TransportInformationContainer("M1l3s")))
+        withCaching[TransportInformationContainerData](Some(cachedData), id)
+        val body = Seq(("id", "x4rlz"), addActionURLEncoded)
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(SEE_OTHER)
+      }
+    }
+
+    "remove an item successfully" when {
+
+      "exists in cache based on id" in {
+
+        val cachedData = TransportInformationContainerData(
+          Seq(TransportInformationContainer("M1l3s"), TransportInformationContainer("J00hn"))
+        )
+        withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+        val body = removeActionURLEncoded("0")
+        val result = route(app, postRequestFormUrlEncoded(uri, body)).get
+
+        status(result) must be(SEE_OTHER)
+      }
+    }
+
+    "display the form page with an error" when {
+
+      "try to add a container without any data" in {
+
+        withCaching[TransportInformationContainerData](None, id)
+        val body = Seq(("id", ""), addActionURLEncoded)
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+        val stringResult = contentAsString(result)
+
+        status(result) must be(BAD_REQUEST)
+        stringResult must include(messages("supplementary.transportInfo.containerId.empty"))
+      }
+
+      "try to save and continue without any data" in {
+
+        val body = Seq(("id", ""), saveAndContinueActionURLEncoded)
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+        val stringResult = contentAsString(result)
+
+        status(result) must be(BAD_REQUEST)
+        stringResult must include(messages("supplementary.continue.mandatory"))
+      }
+
+      "try to add duplicated container" in {
+
+        val cachedData = TransportInformationContainerData(Seq(TransportInformationContainer("M1l3s")))
+        withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+        val body = Seq(("id", "M1l3s"), addActionURLEncoded)
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(BAD_REQUEST)
+        contentAsString(result) must include(messages("supplementary.duplication"))
+      }
+
+      "try to add more than 9999 containers" in {
+        withCaching[TransportInformationContainerData](Some(cacheWithMaximumAmountOfHolders), id)
+
+        val body = Seq(("id", "M1l3s"), addActionURLEncoded)
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(BAD_REQUEST)
+        contentAsString(result) must include(messages("supplementary.limit"))
+      }
+
+      "try to save more than 9999 containers" in {
+        withCaching[TransportInformationContainerData](Some(cacheWithMaximumAmountOfHolders), id)
+
+        val body = Seq(("id", "M1l3s"), saveAndContinueActionURLEncoded)
+        val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+
+        status(result) must be(BAD_REQUEST)
+        contentAsString(result) must include(messages("supplementary.limit"))
+      }
+
+      "try to remove a non existent container" in {
+        val cachedData = TransportInformationContainerData(Seq(TransportInformationContainer("M1l3s")))
+        withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+        val body = ("action", "Remove:J0ohn-Coltrane")
+
+        val result = route(app, postRequestFormUrlEncoded(uri, body)).get
+        val stringResult = contentAsString(result)
+
+        status(result) must be(BAD_REQUEST)
+        stringResult must include(messages("global.error.title"))
+        stringResult must include(messages("global.error.heading"))
+        stringResult must include(messages("global.error.message"))
+      }
+    }
+  }
+  "redirect to the next page" when {
+
+    "user provide container with empty cache" in {
+
+      val body = Seq(("id", "M1l3s"), saveAndContinueActionURLEncoded)
+
+      val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+      val header = result.futureValue.header
+
+      status(result) must be(SEE_OTHER)
+      header.headers.get("Location") must be(
+        Some("/customs-declare-exports/declaration/supplementary/total-numbers-of-items")
+      )
+    }
+
+    "user doesn't fill form but some containers already exist in the cache" in {
+      val cachedData = TransportInformationContainerData(Seq(TransportInformationContainer("Jo0hn")))
+      withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+      val result = route(app, postRequestFormUrlEncoded(uri, saveAndContinueActionURLEncoded)).get
+      val header = result.futureValue.header
+
+      status(result) must be(SEE_OTHER)
+      header.headers.get("Location") must be(
+        Some("/customs-declare-exports/declaration/supplementary/total-numbers-of-items")
+      )
+    }
+
+    "user provide container with some different container in cache" in {
+      val cachedData = TransportInformationContainerData(Seq(TransportInformationContainer("x4rlz")))
+      withCaching[TransportInformationContainerData](Some(cachedData), id)
+
+      val body = Seq(("id", "M1l3s"), saveAndContinueActionURLEncoded)
+
+      val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
+      val header = result.futureValue.header
+
+      status(result) must be(SEE_OTHER)
+      header.headers.get("Location") must be(
+        Some("/customs-declare-exports/declaration/supplementary/total-numbers-of-items")
+      )
+    }
+  }
+}
+
+object TransportInformationContainersPageControllerSpec {
+  val cacheWithMaximumAmountOfHolders = TransportInformationContainerData(
+    Seq
+      .range[Int](1, 10000, 1)
+      .map(elem => TransportInformationContainer(elem.toString))
+  )
 }

--- a/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
+++ b/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
@@ -161,7 +161,6 @@ class TransportInformationPageControllerSpec extends CustomExportsBaseSpec with 
           meansOfTransportCrossingTheBorderIDNumber = "123456789012345678901234567890ABCDEF"
         )
         val result = route(app, postRequest(uri, emptyForm)).get
-
         contentAsString(result) must include(
           messages("supplementary.transportInfo.meansOfTransport.idNumber.error.length")
         )
@@ -174,20 +173,6 @@ class TransportInformationPageControllerSpec extends CustomExportsBaseSpec with 
         contentAsString(result) must include(
           messages("supplementary.transportInfo.meansOfTransport.idNumber.error.specialCharacters")
         )
-      }
-
-      "choose container and not provide container ID" in {
-        val emptyForm = buildTransportInformationForm(container = true)
-        val result = route(app, postRequest(uri, emptyForm)).get
-
-        contentAsString(result) must include(messages("supplementary.transportInfo.containerId.empty"))
-      }
-
-      "choose container and provide incorrect container ID" in {
-        val emptyForm = buildTransportInformationForm(container = true, containerId = TestHelper.createRandomString(18))
-        val result = route(app, postRequest(uri, emptyForm)).get
-
-        contentAsString(result) must include(messages("supplementary.transportInfo.containerId.error"))
       }
     }
 

--- a/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
+++ b/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.supplementary
 
-import base.{CustomExportsBaseSpec, TestHelper}
+import base.CustomExportsBaseSpec
 import forms.supplementary.TransportInformation
 import forms.supplementary.TransportInformation.MeansOfTransportTypeCodes.NameOfVessel
 import forms.supplementary.TransportInformation.ModeOfTransportCodes.Road
@@ -185,17 +185,14 @@ class TransportInformationPageControllerSpec extends CustomExportsBaseSpec with 
         .cache[TransportInformation](any(), ArgumentMatchers.eq(TransportInformation.id), any())(any(), any(), any())
     }
 
-    "return 303 code" in {
+    "redirect to 'Total number of items' page" in {
       val result = route(app, postRequest(uri, correctTransportInformationJSON)).get
       status(result) must be(SEE_OTHER)
-    }
 
-    "redirect to \"Total number of items\" page" in {
-      val result = route(app, postRequest(uri, correctTransportInformationJSON)).get
       val header = result.futureValue.header
 
       header.headers.get("Location") must be(
-        Some("/customs-declare-exports/declaration/supplementary/total-numbers-of-items")
+        Some("/customs-declare-exports/declaration/supplementary/add-transport-containers")
       )
     }
   }

--- a/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
+++ b/test/controllers/supplementary/TransportInformationPageControllerSpec.scala
@@ -209,8 +209,7 @@ object TransportInformationPageControllerSpec {
     meansOfTransportCrossingTheBorderType: String = "",
     meansOfTransportCrossingTheBorderIDNumber: String = "",
     meansOfTransportCrossingTheBorderNationality: String = "",
-    container: Boolean = false,
-    containerId: String = ""
+    container: Boolean = false
   ): JsValue = JsObject(
     Map(
       "inlandModeOfTransportCode" -> JsString(inlandModeOfTransportCode),
@@ -220,8 +219,7 @@ object TransportInformationPageControllerSpec {
       "meansOfTransportCrossingTheBorderType" -> JsString(meansOfTransportCrossingTheBorderType),
       "meansOfTransportCrossingTheBorderIDNumber" -> JsString(meansOfTransportCrossingTheBorderIDNumber),
       "meansOfTransportCrossingTheBorderNationality" -> JsString(meansOfTransportCrossingTheBorderNationality),
-      "container" -> JsBoolean(container),
-      "containerId" -> JsString(containerId)
+      "container" -> JsBoolean(container)
     )
   )
 

--- a/test/forms/supplementary/TransportInformationContainerSpec.scala
+++ b/test/forms/supplementary/TransportInformationContainerSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.supplementary
+import forms.supplementary.TransportInformationContainerSpec._
+import models.declaration.supplementary.TransportInformationContainerData
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
+class TransportInformationContainerSpec extends WordSpec with MustMatchers {
+
+  "Method toMetadataProperties" should {
+
+    "return proper Metadata Properties" in {
+
+      val transportInformationContainerData = correctTransportInformationContainerData
+
+      val expectedProperties: Map[String, String] = Map(
+        "declaration.goodsShipment.consignment.transportEquipment[0].id" -> transportInformationContainerData.containers.head.id
+      )
+
+      transportInformationContainerData.toMetadataProperties() must equal(expectedProperties)
+    }
+  }
+
+  "Transport Information Object object" should {
+    "contains correct limit value" in {
+      TransportInformationContainerData.maxNumberOfItems must be(9999)
+    }
+  }
+
+}
+
+object TransportInformationContainerSpec {
+  private val containerId = "containerId"
+
+  val correctTransportInformationContainerData =
+    TransportInformationContainerData(Seq(TransportInformationContainer(id = "M1l3s")))
+
+  val emptyTransportInformationContainerData = TransportInformationContainer("")
+
+  val correctTransportInformationContainerJSON: JsValue = JsObject(Map(containerId -> JsString("M1l3s")))
+
+  val incorrectTransportInformationContainerJSON: JsValue = JsObject(Map(containerId -> JsString("123456789012345678")))
+
+  val emptyTransportInformationContainerJSON: JsValue = JsObject(Map(containerId -> JsString("")))
+
+  val correctTransportInformationContainerDataJSON: JsValue = JsObject(
+    Map("containers" -> JsArray(Seq(correctTransportInformationContainerJSON)))
+  )
+}

--- a/test/forms/supplementary/TransportInformationSpec.scala
+++ b/test/forms/supplementary/TransportInformationSpec.scala
@@ -35,8 +35,7 @@ class TransportInformationSpec extends WordSpec with MustMatchers {
         "declaration.borderTransportMeans.identificationTypeCode" -> transportInformation.meansOfTransportCrossingTheBorderType,
         "declaration.borderTransportMeans.id" -> transportInformation.meansOfTransportCrossingTheBorderIDNumber.get,
         "declaration.borderTransportMeans.registrationNationalityCode" -> "GB",
-        "declaration.goodsShipment.consignment.containerCode" -> "1",
-        "declaration.goodsShipment.governmentAgencyGoodsItem.commodity.transportEquipment.id" -> transportInformation.containerId.get
+        "declaration.goodsShipment.consignment.containerCode" -> "1"
       )
 
       transportInformation.toMetadataProperties() must equal(expectedTransportInformationProperties)
@@ -169,8 +168,7 @@ object TransportInformationSpec {
     meansOfTransportCrossingTheBorderType = NameOfVessel,
     meansOfTransportCrossingTheBorderIDNumber = Some("QWERTY"),
     meansOfTransportCrossingTheBorderNationality = Some("United Kingdom"),
-    container = true,
-    containerId = Some("ContainerID")
+    container = true
   )
   val emptyTransportInformation = TransportInformation(
     inlandModeOfTransportCode = None,
@@ -180,8 +178,7 @@ object TransportInformationSpec {
     meansOfTransportCrossingTheBorderType = "",
     meansOfTransportCrossingTheBorderIDNumber = None,
     meansOfTransportCrossingTheBorderNationality = None,
-    container = false,
-    containerId = None
+    container = false
   )
 
   val correctTransportInformationJSON: JsValue = JsObject(
@@ -193,8 +190,7 @@ object TransportInformationSpec {
       "meansOfTransportCrossingTheBorderType" -> JsString(NameOfVessel),
       "meansOfTransportCrossingTheBorderIDNumber" -> JsString("QWERTY"),
       "meansOfTransportCrossingTheBorderNationality" -> JsString("United Kingdom"),
-      "container" -> JsBoolean(true),
-      "containerId" -> JsString("ContainerID")
+      "container" -> JsBoolean(true)
     )
   )
   val emptyTransportInformationJSON: JsValue = JsObject(
@@ -206,8 +202,7 @@ object TransportInformationSpec {
       "meansOfTransportCrossingTheBorderType" -> JsString(""),
       "meansOfTransportCrossingTheBorderIDNumber" -> JsString(""),
       "meansOfTransportCrossingTheBorderNationality" -> JsString(""),
-      "container" -> JsBoolean(false),
-      "containerId" -> JsString("")
+      "container" -> JsBoolean(false)
     )
   )
 }

--- a/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
+++ b/test/models/declaration/supplementary/SupplementaryDeclarationDataSpec.scala
@@ -35,6 +35,10 @@ import forms.supplementary.RepresentativeDetailsSpec._
 import forms.supplementary.SupervisingCustomsOfficeSpec._
 import forms.supplementary.TotalNumberOfItemsSpec._
 import forms.supplementary.TransactionTypeSpec._
+import forms.supplementary.TransportInformationContainerSpec.{
+  correctTransportInformationContainerData,
+  correctTransportInformationContainerDataJSON
+}
 import forms.supplementary.TransportInformationSpec._
 import forms.supplementary.WarehouseIdentificationSpec._
 import forms.supplementary._
@@ -75,6 +79,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.parties mustNot be(defined)
           supplementaryDeclarationData.locations mustNot be(defined)
           supplementaryDeclarationData.transportInformation mustNot be(defined)
+          supplementaryDeclarationData.transportInformationContainerData mustNot be(defined)
           supplementaryDeclarationData.items mustNot be(defined)
           supplementaryDeclarationData.additionalInformationData mustNot be(defined)
           supplementaryDeclarationData.documentsProducedData mustNot be(defined)
@@ -236,6 +241,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
           supplementaryDeclarationData.locations.get.warehouseIdentification must be(defined)
           supplementaryDeclarationData.locations.get.officeOfExit must be(defined)
           supplementaryDeclarationData.transportInformation must be(defined)
+          supplementaryDeclarationData.transportInformationContainerData must be(defined)
           supplementaryDeclarationData.items must be(defined)
           supplementaryDeclarationData.items.get.totalNumberOfItems must be(defined)
           supplementaryDeclarationData.items.get.transactionType must be(defined)
@@ -306,7 +312,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
 
         val map = data.toMap
 
-        val supplementaryDeclarationDataFieldsAmount = 8
+        val supplementaryDeclarationDataFieldsAmount = 9
         map.size must equal(supplementaryDeclarationDataFieldsAmount)
 
         map.keys must contain(DeclarationType.id)
@@ -319,6 +325,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         map(Locations.id) must equal(data.locations.get)
         map.keys must contain(TransportInformation.id)
         map(TransportInformation.id) must equal(data.transportInformation.get)
+        map(TransportInformationContainerData.id) must equal(data.transportInformationContainerData.get)
         map.keys must contain(Items.id)
         map(Items.id) must equal(data.items.get)
         map.keys must contain(AdditionalInformationData.formId)
@@ -356,6 +363,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       val partiesMock = mock(classOf[Parties])
       val locationsMock = mock(classOf[Locations])
       val transportInformationMock = mock(classOf[TransportInformation])
+      val transportInformationContainerDataMock = mock(classOf[TransportInformationContainerData])
       val itemsMock = mock(classOf[Items])
       val additionalInformationDataMock = mock(classOf[AdditionalInformationData])
       val documentsProducedDataMock = mock(classOf[DocumentsProducedData])
@@ -365,6 +373,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
         parties = Some(partiesMock),
         locations = Some(locationsMock),
         transportInformation = Some(transportInformationMock),
+        transportInformationContainerData = Some(transportInformationContainerDataMock),
         items = Some(itemsMock),
         additionalInformationData = Some(additionalInformationDataMock),
         documentsProducedData = Some(documentsProducedDataMock)
@@ -375,6 +384,7 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       when(partiesMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(locationsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(transportInformationMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
+      when(transportInformationContainerDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(itemsMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(additionalInformationDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
       when(documentsProducedDataMock.toMetadataProperties()).thenReturn(Map.empty[String, String])
@@ -387,6 +397,8 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
       val partiesMap = Map("Parties" -> "PartiesValue")
       val locationsMap = Map("Locations" -> "LocationsValue")
       val transportInformationMap = Map("TransportInformation" -> "TransportInformationValue")
+      val transportInformationContainerMap =
+        Map("TransportInformationContainer" -> "TransportInformationContainerValue")
       val itemsMap = Map("Items" -> "ItemsValue")
       val additionalInformationMap = Map("AdditionalInformation" -> "AdditionalInformationValue")
       val documentsProducedMap = Map("DocumentsProduced" -> "DocumentsProducedValue")
@@ -424,6 +436,7 @@ object SupplementaryDeclarationDataSpec {
       WarehouseIdentification.formId -> correctWarehouseIdentificationJSON,
       OfficeOfExit.formId -> correctOfficeOfExitJSON,
       TransportInformation.id -> correctTransportInformationJSON,
+      TransportInformationContainerData.id -> correctTransportInformationContainerDataJSON,
       TotalNumberOfItems.formId -> correctTotalNumberOfItemsDecimalValuesJSON,
       TransactionType.formId -> correctTransactionTypeJSON,
       GoodsItemNumber.formId -> correctGoodsItemNumberJSON,
@@ -456,6 +469,7 @@ object SupplementaryDeclarationDataSpec {
       )
     ),
     transportInformation = Some(correctTransportInformation),
+    transportInformationContainerData = Some(correctTransportInformationContainerData),
     items = Some(
       Items(
         totalNumberOfItems = Some(correctTotalNumberOfItemsDecimalValues),


### PR DESCRIPTION
**THIS IS WORK IN PROGRESS. DO NOT MERGE.** 

* **Remove the 'Container ID' input field from the `/transport-information` page**
This removes the text input field from the Transport Information page.
This was requested by @raghu1978. From now on, pages with single and
multiple items will be separated. Multiple items will be asked in a
separate page.

* **Route user to add-transport-containers page**
If the user has selected that he is using any container, then the
next page being presented will the /add-transport-caontainers where
we present the add to list pattern and the user can enter multiple
container ids.
If the user does not have any container to enter then the journey will
proceed to the /total-numbers-of-items page.

* **Provide ability to add multiple containers**
This is loosely following the pattern already in place

* **Grey out the 'Remove' and 'Add' buttons**
This is part of our progressive enhacemente on accessibility concerns.
The HMRC Front-End team will have to iterate on this as this might not
be the final solution, but it removes the confusion of having several
call to action green buttons on the same page.