### PR TITLE
CEDS-992 Add mandatory info validation before displaying Summary page

### DIFF
--- a/app/views/supplementary/summary/summary_page.scala.html
+++ b/app/views/supplementary/summary/summary_page.scala.html
@@ -21,7 +21,7 @@
 @import uk.gov.hmrc.play.views.html._
 @import views.html.supplementary.summary._
 
-@(appConfig: AppConfig, suppDecData: SupplementaryDeclarationData)(implicit request: Request[_], messages: Messages)
+@(suppDecData: SupplementaryDeclarationData)(implicit appConfig: AppConfig, request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("supplementary.summary.title"),
@@ -68,7 +68,7 @@
     @additional_documentation_section(suppDecData.documentsProducedData)
 
     @helpers.form(action = SummaryPageController.submitSupplementaryDeclaration()) {
-        @components.submit_button("Accept and submit declaration")
+        @components.submit_button(messages("site.acceptAndSubmitDeclaration"))
     }
 
 }

--- a/app/views/supplementary/summary/summary_page_no_data.scala.html
+++ b/app/views/supplementary/summary/summary_page_no_data.scala.html
@@ -16,7 +16,7 @@
 
 @import config.AppConfig
 
-@(appConfig: AppConfig)(implicit request: Request[_], messages: Messages)
+@()(implicit appConfig: AppConfig, request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("supplementary.summary.title"),

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -43,6 +43,7 @@ site.hidden-edit = Change {0}
 site.no = No
 site.yes = Yes
 site.save_and_continue = Save and continue
+site.acceptAndSubmitDeclaration = Accept and submit declaration
 site.save_and_come_back_later = Save and come back later
 site.service_name = Declare an Export
 site.textarea.char_limit = (Limit is {0} characters)


### PR DESCRIPTION
If the user does not provide information we consider mandatory, they
should not be able to access Summary page. Currently it is LRN only.