### PR TITLE
CEDS-1102 Update WCO-DEC to use the Java Schema Model

### DIFF
--- a/app/services/mapping/CachingMappingHelper.scala
+++ b/app/services/mapping/CachingMappingHelper.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import forms.declaration.{CommodityMeasure, ItemType}
+import forms.declaration.ItemType.IdentificationTypeCodes.{
+  CUSCode,
+  CombinedNomenclatureCode,
+  NationalAdditionalCode,
+  TARICAdditionalCode
+}
+import services.ExportsItemsCacheIds.defaultMeasureCode
+import uk.gov.hmrc.wco.dec._
+
+object CachingMappingHelper {
+
+  def commodityFromItemTypes(itemType: ItemType): Commodity =
+    Commodity(
+      description = Some(itemType.descriptionOfGoods),
+      classifications = getClassificationsFromItemTypes(itemType),
+      dangerousGoods = itemType.unDangerousGoodsCode.map(code => Seq(DangerousGoods(Some(code)))).getOrElse(Seq.empty)
+    )
+
+  def getClassificationsFromItemTypes(itemType: ItemType): Seq[Classification] =
+    Seq(
+      Classification(Some(itemType.combinedNomenclatureCode), identificationTypeCode = Some(CombinedNomenclatureCode))
+    ) ++ itemType.cusCode.map(id => Classification(Some(id), identificationTypeCode = Some(CUSCode))) ++
+      itemType.nationalAdditionalCodes.map(
+        code => Classification(Some(code), identificationTypeCode = Some(NationalAdditionalCode))
+      ) ++ itemType.taricAdditionalCodes
+      .map(code => Classification(Some(code), identificationTypeCode = Some(TARICAdditionalCode)))
+
+  def mapGoodsMeasure(data: CommodityMeasure) =
+    Commodity(
+      goodsMeasure = Some(
+        GoodsMeasure(
+          Some(createMeasure(data.grossMass)),
+          Some(createMeasure(data.netMass)),
+          data.supplementaryUnits.map(createMeasure(_))
+        )
+      )
+    )
+
+  private def createMeasure(unitValue: String) =
+    Measure(Some(defaultMeasureCode), value = Some(BigDecimal(unitValue)))
+
+}

--- a/app/services/mapping/DeclarationTypeCodeMapping.scala
+++ b/app/services/mapping/DeclarationTypeCodeMapping.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import forms.declaration.DispatchLocation
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
+import wco.datamodel.wco.declaration_ds.dms._2.DeclarationTypeCodeType
+
+object DeclarationTypeCodeMapping {
+
+  def additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(
+    dispatchLocation: Option[DispatchLocation],
+    additionalDeclarationType: Option[AdditionalDeclarationType]
+  ): DeclarationTypeCodeType = {
+    val declarationTypeCodeType = new DeclarationTypeCodeType
+    val typeCode: String = dispatchLocation.map(_.dispatchLocation).getOrElse("") +
+      additionalDeclarationType.map(_.additionalDeclarationType).getOrElse("")
+    declarationTypeCodeType.setValue(typeCode)
+    declarationTypeCodeType
+  }
+}

--- a/app/services/mapping/MetaDataBuilder.scala
+++ b/app/services/mapping/MetaDataBuilder.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues
+import wco.datamodel.wco.documentmetadata_dms._2.MetaData
+import wco.datamodel.wco.metadata_ds_dms._2._
+
+object MetaDataBuilder {
+
+  def build() : MetaData = {
+    buildMetaData()
+  }
+
+  private def buildMetaData(): MetaData = {
+    val metaData = new MetaData
+    populateMetaDataMandatoryDefaults(metaData)
+    metaData
+  }
+
+  private def populateMetaDataMandatoryDefaults(metaData : MetaData){
+    val agencyAssignedCustomizationCodeType = new MetaDataAgencyAssignedCustomizationCodeType
+    agencyAssignedCustomizationCodeType.setValue(
+      SchemaMandatoryValues.agencyAssignedCustomizationVersionCode
+    )
+
+    val metaDataResponsibleAgencyNameTextType = new MetaDataResponsibleAgencyNameTextType
+    metaDataResponsibleAgencyNameTextType.setValue(SchemaMandatoryValues.responsibleAgencyName)
+
+    val metaDataResponsibleCountryCodeType = new MetaDataResponsibleCountryCodeType
+    metaDataResponsibleCountryCodeType.setValue(SchemaMandatoryValues.responsibleCountryCode)
+
+    val metaDataWCODataModelVersionCodeType = new MetaDataWCODataModelVersionCodeType
+    metaDataWCODataModelVersionCodeType.setValue(SchemaMandatoryValues.wcoDataModelVersionCode)
+
+    val metaDataWCOTypeNameTextType = new MetaDataWCOTypeNameTextType
+    metaDataWCOTypeNameTextType.setValue(SchemaMandatoryValues.wcoTypeName)
+
+    metaData.setAgencyAssignedCustomizationCode(agencyAssignedCustomizationCodeType)
+    metaData.setResponsibleAgencyName(metaDataResponsibleAgencyNameTextType)
+    metaData.setResponsibleCountryCode(metaDataResponsibleCountryCodeType)
+    metaData.setWCODataModelVersionCode(metaDataWCODataModelVersionCodeType)
+    metaData.setWCOTypeName(metaDataWCOTypeNameTextType)
+  }
+
+
+}

--- a/app/services/mapping/goodsshipment/ConsigneeBuilder.scala
+++ b/app/services/mapping/goodsshipment/ConsigneeBuilder.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.{ConsigneeDetails, EntityDetails}
+import services.Countries.allCountries
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+import wco.datamodel.wco.declaration_ds.dms._2._
+
+object ConsigneeBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipment.Consignee =
+    cacheMap
+      .getEntry[ConsigneeDetails](ConsigneeDetails.id)
+      .map(consigneeDetails => createConsignee(consigneeDetails.details))
+      .orNull
+
+  private def createConsignee(details: EntityDetails): GoodsShipment.Consignee = {
+    val id = new ConsigneeIdentificationIDType()
+    id.setValue(details.eori.orNull)
+
+    val name = new ConsigneeNameTextType()
+
+    val consigneeAddress = new GoodsShipment.Consignee.Address()
+    details.address.map(address => {
+      name.setValue(address.fullName)
+
+      val line = new AddressLineTextType()
+      line.setValue(address.addressLine)
+
+      val city = new AddressCityNameTextType
+      city.setValue(address.townOrCity)
+
+      val postcode = new AddressPostcodeIDType()
+      postcode.setValue(address.postCode)
+
+      val countryCode = new AddressCountryCodeType
+      countryCode.setValue(
+        allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
+      )
+
+      consigneeAddress.setLine(line)
+      consigneeAddress.setCityName(city)
+      consigneeAddress.setCountryCode(countryCode)
+      consigneeAddress.setPostcodeID(postcode)
+    })
+
+    val consignee = new GoodsShipment.Consignee()
+    consignee.setID(id)
+    consignee.setName(name)
+    consignee.setAddress(consigneeAddress)
+    consignee
+  }
+}

--- a/app/services/mapping/goodsshipment/ConsignmentBuilder.scala
+++ b/app/services/mapping/goodsshipment/ConsignmentBuilder.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.{CarrierDetails, EntityDetails}
+import services.Countries.allCountries
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Consignment
+import wco.datamodel.wco.declaration_ds.dms._2._
+
+object ConsignmentBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipment.Consignment =
+    cacheMap
+      .getEntry[CarrierDetails](CarrierDetails.id)
+      .map(carrierDetails => createConsignment(carrierDetails.details))
+      .orNull
+
+  private def createConsignment(details: EntityDetails): GoodsShipment.Consignment = {
+    val id = new GoodsLocationIdentificationIDType()
+    id.setValue(details.eori.orNull)
+
+    val name = new GoodsLocationNameTextType()
+
+    val goodsAddress = new Consignment.GoodsLocation.Address()
+    details.address.map(address => {
+      name.setValue(address.fullName)
+
+      val line = new AddressLineTextType()
+      line.setValue(address.addressLine)
+
+      val city = new AddressCityNameTextType
+      city.setValue(address.townOrCity)
+
+      val postcode = new AddressPostcodeIDType()
+      postcode.setValue(address.postCode)
+
+      val countryCode = new AddressCountryCodeType
+      countryCode.setValue(
+        allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
+      )
+
+      goodsAddress.setLine(line)
+      goodsAddress.setCityName(city)
+      goodsAddress.setCountryCode(countryCode)
+      goodsAddress.setPostcodeID(postcode)
+    })
+
+    val goodsLocation = new GoodsShipment.Consignment.GoodsLocation()
+    goodsLocation.setID(id)
+    goodsLocation.setName(name)
+    goodsLocation.setAddress(goodsAddress)
+
+    val consignment = new GoodsShipment.Consignment()
+    consignment.setGoodsLocation(goodsLocation)
+    consignment
+  }
+}

--- a/app/services/mapping/goodsshipment/DestinationBuilder.scala
+++ b/app/services/mapping/goodsshipment/DestinationBuilder.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesSupplementary}
+import services.Countries.allCountries
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Destination
+import wco.datamodel.wco.declaration_ds.dms._2.{DestinationCountryCodeType, DestinationRegionIDType}
+
+object DestinationBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipment.Destination =
+    cacheMap
+      .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
+      .map(createExportCountry)
+      .orNull
+
+  private def createExportCountry(data: DestinationCountriesSupplementary): GoodsShipment.Destination = {
+
+    val countryCode = new DestinationCountryCodeType()
+    countryCode.setValue(
+      allCountries
+        .find(country => data.countryOfDestination.contains(country.countryName))
+        .map(_.countryCode)
+        .getOrElse("")
+    )
+
+    var regionId = new DestinationRegionIDType()
+
+    val destination = new Destination()
+    destination.setCountryCode(countryCode)
+    destination.setRegionID(regionId)
+    destination
+  }
+}

--- a/app/services/mapping/goodsshipment/ExportCountryBuilder.scala
+++ b/app/services/mapping/goodsshipment/ExportCountryBuilder.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesSupplementary}
+import services.Countries.allCountries
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.ExportCountry
+import wco.datamodel.wco.declaration_ds.dms._2.ExportCountryCountryCodeType
+
+object ExportCountryBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipment.ExportCountry =
+    cacheMap
+      .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
+      .map(createExportCountry)
+      .orNull
+
+  private def createExportCountry(data: DestinationCountriesSupplementary): GoodsShipment.ExportCountry = {
+
+    val id = new ExportCountryCountryCodeType()
+    id.setValue(
+      allCountries
+        .find(country => data.countryOfDispatch.contains(country.countryName))
+        .map(_.countryCode)
+        .getOrElse("")
+    )
+
+    val exportCountry = new ExportCountry()
+    exportCountry.setID(id)
+    exportCountry
+  }
+}

--- a/app/services/mapping/goodsshipment/ExporterBuilder.scala
+++ b/app/services/mapping/goodsshipment/ExporterBuilder.scala
@@ -1,0 +1,70 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.{EntityDetails, ExporterDetails}
+import services.Countries.allCountries
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.Exporter
+import wco.datamodel.wco.declaration_ds.dms._2._
+
+object ExporterBuilder {
+
+  def build(implicit cacheMap: CacheMap): Exporter =
+    cacheMap
+      .getEntry[ExporterDetails](ExporterDetails.id)
+      .map(data => createExporter(data.details))
+      .orNull
+
+  private def createExporter(details: EntityDetails): Exporter = {
+    val name = new ExporterNameTextType()
+
+    val exporterId = new ExporterIdentificationIDType()
+    val exporterName = new ExporterNameTextType()
+    val exporterAddress = new Exporter.Address()
+
+    exporterId.setValue(details.eori.orNull)
+
+    details.address.map(address => {
+      exporterName.setValue(address.fullName)
+
+      val line = new AddressLineTextType()
+      line.setValue(address.addressLine)
+
+      val city = new AddressCityNameTextType
+      city.setValue(address.townOrCity)
+
+      val postcode = new AddressPostcodeIDType()
+      postcode.setValue(address.postCode)
+
+      val countryCode = new AddressCountryCodeType
+      countryCode.setValue(
+        allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
+      )
+
+      exporterAddress.setLine(line)
+      exporterAddress.setCityName(city)
+      exporterAddress.setCountryCode(countryCode)
+      exporterAddress.setPostcodeID(postcode)
+    })
+
+    val exporter = new Exporter()
+    exporter.setID(exporterId)
+    exporter.setName(exporterName)
+    exporter.setAddress(exporterAddress)
+    exporter
+  }
+}

--- a/app/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
+++ b/app/services/mapping/goodsshipment/GoodsShipmentBuilder.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.{EntityDetails, ExporterDetails}
+
+import scala.collection.JavaConverters._
+import services.mapping.governmentagencygoodsitem.GovernmentAgencyGoodsItemBuilder
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+
+object GoodsShipmentBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipment =
+    cacheMap
+      .getEntry[ExporterDetails](ExporterDetails.id)
+      .map(data => createGoodsShipment(data.details))
+      .orNull
+
+  private def createGoodsShipment(details: EntityDetails)(implicit cacheMap: CacheMap): GoodsShipment = {
+    val goodsShipment = new GoodsShipment()
+    goodsShipment.setTransactionNatureCode(GoodsShipmentTransactionTypeBuilder.build)
+    goodsShipment.setConsignee(ConsigneeBuilder.build)
+    goodsShipment.setConsignment(ConsignmentBuilder.build)
+    goodsShipment.setDestination(DestinationBuilder.build)
+    goodsShipment.setExportCountry(ExportCountryBuilder.build)
+    goodsShipment.setUCR(UCRBuilder.build)
+    goodsShipment.setWarehouse(WarehouseBuilder.build)
+    goodsShipment.getPreviousDocument
+      .addAll(PreviousDocumentsBuilder.build)
+    goodsShipment.getGovernmentAgencyGoodsItem.addAll(GovernmentAgencyGoodsItemBuilder.build.asJava) //TODO: Placeholder for Matt to hook his stuff here
+
+    goodsShipment
+  }
+}

--- a/app/services/mapping/goodsshipment/PreviousDocumentsBuilder.scala
+++ b/app/services/mapping/goodsshipment/PreviousDocumentsBuilder.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import java.util
+
+import forms.declaration.{Document, PreviousDocumentsData}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+import scala.collection.JavaConverters._
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
+import wco.datamodel.wco.declaration_ds.dms._2.{PreviousDocumentCategoryCodeType, PreviousDocumentIdentificationIDType, PreviousDocumentTypeCodeType}
+
+object PreviousDocumentsBuilder {
+
+  def build(implicit cacheMap: CacheMap): util.List[GoodsShipment.PreviousDocument] =
+    cacheMap
+      .getEntry[PreviousDocumentsData](Document.formId)
+      .map(_.documents.map(createPreviousDocuments))
+      .getOrElse(Seq.empty)
+      .toList
+      .asJava
+
+  private def createPreviousDocuments(document: Document): GoodsShipment.PreviousDocument = {
+    val categoryCode = new PreviousDocumentCategoryCodeType()
+    categoryCode.setValue(document.documentCategory)
+
+    val id = new PreviousDocumentIdentificationIDType()
+    id.setValue(document.documentReference)
+
+    val lineNumeric = new java.math.BigDecimal(document.goodsItemIdentifier.orNull)
+
+    val typeCode = new PreviousDocumentTypeCodeType()
+    typeCode.setValue(document.documentType)
+
+    val previousDocument = new GoodsShipment.PreviousDocument()
+    previousDocument.setCategoryCode(categoryCode)
+    previousDocument.setID(id)
+    previousDocument.setLineNumeric(lineNumeric)
+    previousDocument.setTypeCode(typeCode)
+    previousDocument
+  }
+}

--- a/app/services/mapping/goodsshipment/TransactionNatureCodeBuilder.scala
+++ b/app/services/mapping/goodsshipment/TransactionNatureCodeBuilder.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.TransactionType
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.declaration_ds.dms._2.GoodsShipmentTransactionNatureCodeType
+
+object GoodsShipmentTransactionTypeBuilder {
+
+  def build(implicit cacheMap: CacheMap): GoodsShipmentTransactionNatureCodeType =
+    cacheMap
+      .getEntry[TransactionType](TransactionType.formId)
+      .map(createTransactionNatureCode)
+      .orNull
+
+  private def createTransactionNatureCode(data: TransactionType): GoodsShipmentTransactionNatureCodeType = {
+
+    val transactionType = new GoodsShipmentTransactionNatureCodeType()
+    transactionType.setValue(data.documentTypeCode + data.identifier.getOrElse(""))
+
+    transactionType
+  }
+
+}

--- a/app/services/mapping/goodsshipment/UCRBuilder.scala
+++ b/app/services/mapping/goodsshipment/UCRBuilder.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.Ducr
+import forms.declaration.ConsignmentReferences
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.UCR
+import wco.datamodel.wco.declaration_ds.dms._2.{UCRIdentificationIDType, UCRTraderAssignedReferenceIDType}
+
+object UCRBuilder {
+
+  def build(implicit cacheMap: CacheMap): UCR =
+    cacheMap
+      .getEntry[ConsignmentReferences](ConsignmentReferences.id)
+      .map(createUCR)
+      .orNull
+
+  private def createUCR(data: ConsignmentReferences): UCR = {
+
+    val id = new UCRIdentificationIDType()
+
+    val traderAssignedReferenceID = new UCRTraderAssignedReferenceIDType()
+    traderAssignedReferenceID.setValue(data.ducr.getOrElse(Ducr("")).ducr)
+
+    val warehouse = new UCR()
+    warehouse.setID(id)
+    warehouse.setTraderAssignedReferenceID(traderAssignedReferenceID)
+    warehouse
+  }
+
+}

--- a/app/services/mapping/goodsshipment/WarehouseBuilder.scala
+++ b/app/services/mapping/goodsshipment/WarehouseBuilder.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+import forms.declaration.WarehouseIdentification
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Warehouse
+import wco.datamodel.wco.declaration_ds.dms._2.{WarehouseIdentificationIDType, WarehouseTypeCodeType}
+
+object WarehouseBuilder {
+
+  def build(implicit cacheMap: CacheMap): Warehouse =
+    cacheMap
+      .getEntry[WarehouseIdentification](WarehouseIdentification.formId)
+      .map(createWarehouse)
+      .orNull
+
+  private def createWarehouse(data: WarehouseIdentification): Warehouse = {
+
+    val id = new WarehouseIdentificationIDType()
+    id.setValue(data.identificationNumber.map(_.drop(1).toString).getOrElse(""))
+
+    val typeCode = new WarehouseTypeCodeType()
+    typeCode.setValue(data.identificationNumber.flatMap(_.headOption).fold("")(_.toString))
+
+    val warehouse = new Warehouse()
+    warehouse.setID(id)
+    warehouse.setTypeCode(typeCode)
+    warehouse
+  }
+}

--- a/app/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilder.scala
@@ -1,0 +1,110 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.DocumentsProduced
+import models.declaration.DocumentsProducedData
+import services.ExportsItemsCacheIds.dateTimeCode
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.AdditionalDocument
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.AdditionalDocument.{
+  Submitter,
+  WriteOff
+}
+import wco.datamodel.wco.declaration_ds.dms._2.{
+  AdditionalDocumentEffectiveDateTimeType,
+  SubmitterNameTextType,
+  WriteOffQuantityQuantityType,
+  _
+}
+import wco.datamodel.wco.declaration_ds.dms._2.AdditionalDocumentEffectiveDateTimeType.{
+  DateTimeString => WCODateTimeString
+}
+
+object AdditionalDocumentsBuilder {
+
+  def build()(implicit cachedMap: CacheMap): Option[Seq[AdditionalDocument]] =
+    cachedMap
+      .getEntry[DocumentsProducedData](DocumentsProducedData.formId)
+      .map(_.documents.map(mapWCOAdditionalDocument(_)))
+
+  private def mapWCOAdditionalDocument(doc: DocumentsProduced): AdditionalDocument = {
+    val additionalDocument = new AdditionalDocument
+    val additionalDocumentCategoryCodeType = new AdditionalDocumentCategoryCodeType
+    additionalDocumentCategoryCodeType.setValue(doc.documentTypeCode.map(_.substring(0, 1)).orNull)
+
+    val additionalDocumentTypeCodeType = new AdditionalDocumentTypeCodeType
+    additionalDocumentTypeCodeType.setValue(doc.documentTypeCode.map(_.substring(1)).orNull)
+
+    val additionalDocumentIdentificationIDType = new AdditionalDocumentIdentificationIDType
+    additionalDocumentIdentificationIDType.setValue(
+      doc.documentIdentifier.map(_ + doc.documentPart.getOrElse("")).orNull
+    )
+
+    val additionalDocumentLPCOExemptionCodeType = new AdditionalDocumentLPCOExemptionCodeType
+    additionalDocumentLPCOExemptionCodeType.setValue(doc.documentStatus.orNull)
+
+    val additionalDocumentNameTextType = new AdditionalDocumentNameTextType
+    additionalDocumentNameTextType.setValue(doc.documentStatusReason.orNull)
+
+    val dateFormat = new java.text.SimpleDateFormat("yyyyMMdd")
+    val additionalDocumentEffectiveDateTimeType = new AdditionalDocumentEffectiveDateTimeType
+    val dateTimeString = new WCODateTimeString
+    dateTimeString.setFormatCode(dateTimeCode)
+    dateTimeString.setValue(doc.dateOfValidity.map(date => date.toString).orNull)
+
+    additionalDocumentEffectiveDateTimeType.setDateTimeString(dateTimeString)
+
+    additionalDocument.setCategoryCode(additionalDocumentCategoryCodeType)
+    additionalDocument.setTypeCode(additionalDocumentTypeCodeType)
+    additionalDocument.setID(additionalDocumentIdentificationIDType)
+    additionalDocument.setLPCOExemptionCode(additionalDocumentLPCOExemptionCodeType)
+    additionalDocument.setName(additionalDocumentNameTextType)
+    additionalDocument.setSubmitter(doc.issuingAuthorityName.map(name => mapSubmitter(name = Some(name))).orNull)
+    additionalDocument.setEffectiveDateTime(additionalDocumentEffectiveDateTimeType)
+
+    additionalDocument.setWriteOff(mapWriteOff(doc.documentQuantity.map(q => q.bigDecimal), doc.measurementUnit))
+
+    additionalDocument
+  }
+
+  private def mapWriteOff(quantity: Option[BigDecimal], measurementUnit: Option[String]): WriteOff = {
+    val writeoff = new WriteOff
+    val quantityType = new WriteOffQuantityQuantityType
+    quantityType.setValue(quantity.map(value => value.bigDecimal).orNull)
+    quantityType.setUnitCode(measurementUnit.orNull)
+
+    writeoff.setQuantityQuantity(quantityType)
+    writeoff
+  }
+
+  private def mapSubmitter(name: Option[String], role: Option[String] = None): Submitter = {
+    val submitter = new Submitter
+
+    val submitterNameTextType = new SubmitterNameTextType
+    submitterNameTextType.setValue(name.orNull)
+
+    val submitterRoleCodeType = new SubmitterRoleCodeType
+    submitterRoleCodeType.setValue(role.orNull)
+
+    submitter.setName(submitterNameTextType)
+    submitter.setRoleCode(submitterRoleCodeType)
+
+    submitter
+  }
+
+
+}

--- a/app/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilder.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.AdditionalInformation
+import models.declaration.AdditionalInformationData
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.{AdditionalInformation => WCOAdditionalInformation}
+import wco.datamodel.wco.declaration_ds.dms._2.{AdditionalInformationStatementCodeType, AdditionalInformationStatementDescriptionTextType}
+
+object AdditionalInformationBuilder {
+
+  def build()(implicit cacheMap: CacheMap): Option[Seq[WCOAdditionalInformation]] =
+    cacheMap
+      .getEntry[AdditionalInformationData](AdditionalInformationData.formId)
+      .map(_.items.map(mapToWCOAdditionalInformation))
+
+  def mapToWCOAdditionalInformation(info: AdditionalInformation): WCOAdditionalInformation ={
+    val wcoAdditionalInformation = new WCOAdditionalInformation
+
+    val additionalInformationStatementCodeType = new AdditionalInformationStatementCodeType
+    additionalInformationStatementCodeType.setValue(info.code)
+
+    val additionalInformationStatementDescriptionTextType = new AdditionalInformationStatementDescriptionTextType
+    additionalInformationStatementDescriptionTextType.setValue(info.description)
+
+
+    wcoAdditionalInformation.setStatementCode(additionalInformationStatementCodeType)
+    wcoAdditionalInformation.setStatementDescription(additionalInformationStatementDescriptionTextType)
+    wcoAdditionalInformation
+  }
+}

--- a/app/services/mapping/governmentagencygoodsitem/CommodityBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/CommodityBuilder.scala
@@ -1,0 +1,116 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.{CommodityMeasure, ItemType}
+import services.ExportsItemsCacheIds
+import services.mapping.CachingMappingHelper.getClassificationsFromItemTypes
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.wco.dec._
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.Commodity.{
+  Classification => WCOClassification,
+  DangerousGoods => WCODangerousGoods,
+  GoodsMeasure => WCOGoodsMeasure
+}
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.{Commodity => WCOCommodity}
+import wco.datamodel.wco.declaration_ds.dms._2._
+
+object CommodityBuilder {
+
+
+  def build(implicit cacheMap: CacheMap): Option[WCOCommodity] = {
+    cacheMap
+      .getEntry[ItemType](ItemType.id)
+      .map(
+    item => // get all codes create classification
+    mapCommodity(item)
+    )
+  }
+
+  private def mapCommodity(item: ItemType)(implicit cacheMap: CacheMap): WCOCommodity = {
+    val commodity = new WCOCommodity
+
+    val classifications = getClassificationsFromItemTypes(item)
+    val dangerousGoods: Option[Seq[WCODangerousGoods]] = item.unDangerousGoodsCode.map(code => Seq(mapDangerousGoods(code)))
+
+    val commodityDescriptionTextType = new CommodityDescriptionTextType
+    commodityDescriptionTextType.setValue(item.descriptionOfGoods)
+
+    commodity.setDescription(commodityDescriptionTextType)
+
+    dangerousGoods.getOrElse(Seq.empty).foreach(commodity.getDangerousGoods.add(_))
+
+    classifications.foreach(classification => commodity.getClassification.add(mapClassification(classification)))
+
+    commodity.setGoodsMeasure(buildMeasures.orNull)
+    commodity
+  }
+
+  private def buildMeasures(implicit cacheMap: CacheMap): Option[WCOGoodsMeasure] = {
+    cacheMap.getEntry[CommodityMeasure](CommodityMeasure.commodityFormId)
+      .map(mapGoodsMeasure)
+  }
+
+  private def mapClassification(classification: Classification): WCOClassification ={
+    val wcoClassification = new WCOClassification
+
+    val typeCode = new ClassificationIdentificationTypeCodeType
+    typeCode.setValue(classification.identificationTypeCode.orNull)
+
+    val id = new ClassificationIdentificationIDType
+    id.setValue(classification.id.orNull)
+
+    wcoClassification.setIdentificationTypeCode(typeCode)
+    wcoClassification
+  }
+
+  private def mapDangerousGoods(code: String) : WCODangerousGoods ={
+    val dangerousGoods = new WCODangerousGoods
+    val goodsUNDGIDType = new DangerousGoodsUNDGIDType
+    goodsUNDGIDType.setValue(code)
+    dangerousGoods.setUNDGID(goodsUNDGIDType)
+
+    dangerousGoods
+  }
+
+  private def mapGoodsMeasure(data: CommodityMeasure) : WCOGoodsMeasure = {
+
+    val goodsMeasure = new WCOGoodsMeasure()
+
+    val grossMassMeasureType = new GoodsMeasureGrossMassMeasureType
+    grossMassMeasureType.setValue(BigDecimal(data.grossMass).bigDecimal)
+    grossMassMeasureType.setUnitCode(ExportsItemsCacheIds.defaultMeasureCode)
+
+    val netWeightMeasureType = new GoodsMeasureNetNetWeightMeasureType
+    netWeightMeasureType.setUnitCode(ExportsItemsCacheIds.defaultMeasureCode)
+    netWeightMeasureType.setValue(BigDecimal(data.netMass).bigDecimal)
+
+    val tarriffQuantity = data.supplementaryUnits.map(quantity => {
+      val mappedQuantity = new GoodsMeasureTariffQuantityType
+      mappedQuantity.setUnitCode(ExportsItemsCacheIds.defaultMeasureCode)
+      mappedQuantity.setValue(BigDecimal(quantity).bigDecimal)
+      mappedQuantity
+    })
+
+    goodsMeasure.setGrossMassMeasure(grossMassMeasureType)
+    goodsMeasure.setNetNetWeightMeasure(netWeightMeasureType)
+    goodsMeasure.setTariffQuantity(tarriffQuantity.orNull)
+
+    goodsMeasure
+  }
+
+
+}

--- a/app/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.ItemType
+import services.ExportsItemsCacheIds
+import services.ExportsItemsCacheIds.defaultCurrencyCode
+import models.DeclarationFormats._
+import services.mapping.CachingMappingHelper
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.wco.dec.{Amount, GovernmentAgencyGoodsItem}
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.{GovernmentAgencyGoodsItem => WCOGovernmentAgencyGoodsItem}
+import wco.datamodel.wco.declaration_ds.dms._2.GovernmentAgencyGoodsItemStatisticalValueAmountType
+
+object GovernmentAgencyGoodsItemBuilder {
+
+  def build(implicit cacheMap: CacheMap): List[WCOGovernmentAgencyGoodsItem] =
+    cacheMap
+      .getEntry[Seq[GovernmentAgencyGoodsItem]](ExportsItemsCacheIds.itemsId)
+      .getOrElse(Seq.empty)
+      .map(goodsItem => createWCOGovernmentAgencyGoodsItem(goodsItem))
+      .toList
+
+  def createWCOGovernmentAgencyGoodsItem(
+    governmentAgencyGoodsItem: GovernmentAgencyGoodsItem
+  )(implicit cacheMap: CacheMap): WCOGovernmentAgencyGoodsItem = {
+
+    val itemTypeData = goodsItemFromItemTypes(cacheMap)
+
+    val maybeStatisticalValueAmount = itemTypeData.flatMap(_.statisticalValueAmount)
+
+    val wcoGovernmentAgencyGoodsItem = new WCOGovernmentAgencyGoodsItem
+
+    val statisticalValueAmountType = new GovernmentAgencyGoodsItemStatisticalValueAmountType
+    statisticalValueAmountType.setCurrencyID(maybeStatisticalValueAmount.flatMap(_.currencyId).orNull)
+    statisticalValueAmountType.setValue(maybeStatisticalValueAmount.flatMap(_.value).orNull.bigDecimal)
+
+    wcoGovernmentAgencyGoodsItem.setSequenceNumeric(
+      BigDecimal(governmentAgencyGoodsItem.sequenceNumeric).bigDecimal
+    )
+
+    PackageBuilder.build
+      .getOrElse(Seq.empty)
+      .foreach(packingItem => wcoGovernmentAgencyGoodsItem.getPackaging.add(packingItem))
+
+    ProcedureCodesBuilder.build.getOrElse(Seq.empty)
+      .foreach(procedureCode => wcoGovernmentAgencyGoodsItem.getGovernmentProcedure.add(procedureCode))
+
+    AdditionalInformationBuilder.build.getOrElse(Seq.empty)
+      .foreach(info => wcoGovernmentAgencyGoodsItem.getAdditionalInformation.add(info))
+
+    AdditionalDocumentsBuilder.build().getOrElse(Seq.empty)
+      .foreach(doc => wcoGovernmentAgencyGoodsItem.getAdditionalDocument.add(doc))
+
+    wcoGovernmentAgencyGoodsItem.setStatisticalValueAmount(statisticalValueAmountType)
+    wcoGovernmentAgencyGoodsItem.setCommodity(CommodityBuilder.build.orNull)
+    wcoGovernmentAgencyGoodsItem
+  }
+
+  def goodsItemFromItemTypes(cachedData: CacheMap): Option[GovernmentAgencyGoodsItem] =
+    cachedData
+      .getEntry[ItemType](ItemType.id)
+      .map(
+        item => // get all codes create classification
+          GovernmentAgencyGoodsItem(
+            sequenceNumeric = 1,
+            statisticalValueAmount =
+              Some(Amount(Some(defaultCurrencyCode), value = Some(BigDecimal(item.statisticalValue)))),
+            commodity = Some(CachingMappingHelper.commodityFromItemTypes(item))
+        )
+      )
+
+}

--- a/app/services/mapping/governmentagencygoodsitem/PackageBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/PackageBuilder.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.PackageInformation
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.Packaging
+import wco.datamodel.wco.declaration_ds.dms._2.{PackagingMarksNumbersIDType, PackagingQuantityQuantityType, PackagingTypeCodeType}
+
+object PackageBuilder {
+
+  def build(implicit cacheMap: CacheMap): Option[Seq[Packaging]] =
+    cacheMap
+      .getEntry[Seq[PackageInformation]](PackageInformation.formId)
+      .map(_.zipWithIndex.map {
+        case (packageInfo, index) =>
+          createWcoPackaging(packageInfo, index)
+      })
+
+  private def createWcoPackaging(packageInfo: PackageInformation, index: Int): Packaging = {
+    val wcoPackaging = new Packaging
+    val packagingTypeCodeType = new PackagingTypeCodeType
+    packagingTypeCodeType.setValue(packageInfo.typesOfPackages.orNull)
+
+    val packagingQuantityQuantityType = new PackagingQuantityQuantityType
+    //TODO noticed here that quantity type in old scala wco is not captured.. no cannot set :-
+    // packagingQuantityQuantityType.setUnitCode(????)
+    packagingQuantityQuantityType.setValue(BigDecimal(packageInfo.numberOfPackages.getOrElse(0)).bigDecimal)
+
+    val packagingMarksNumbersIDType = new PackagingMarksNumbersIDType
+    packagingMarksNumbersIDType.setValue(packageInfo.shippingMarks.orNull)
+
+    wcoPackaging.setMarksNumbersID(packagingMarksNumbersIDType)
+    wcoPackaging.setQuantityQuantity(packagingQuantityQuantityType)
+    wcoPackaging.setSequenceNumeric(BigDecimal(index).bigDecimal)
+    wcoPackaging.setTypeCode(packagingTypeCodeType)
+    wcoPackaging
+  }
+}

--- a/app/services/mapping/governmentagencygoodsitem/ProcedureCodesBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/ProcedureCodesBuilder.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import models.declaration.ProcedureCodesData
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem.GovernmentProcedure
+import wco.datamodel.wco.declaration_ds.dms._2.{GovernmentProcedureCurrentCodeType, GovernmentProcedurePreviousCodeType}
+
+object ProcedureCodesBuilder {
+
+  def build(implicit cacheMap: CacheMap): Option[Seq[GovernmentProcedure]] = {
+    cacheMap
+        .getEntry[ProcedureCodesData](ProcedureCodesData.formId)
+        .map(
+          form =>
+            Seq(createGovernmentProcedure(form.procedureCode.map(_.substring(0, 2)), form.procedureCode.map(_.substring(2, 4))))
+              ++ form.additionalProcedureCodes.map(code => createGovernmentProcedure(Some(code)))
+        )
+  }
+
+  private def createGovernmentProcedure(currentCode : Option[String] = None, previousCode: Option[String] = None): GovernmentProcedure ={
+    val governmentProcedure = new GovernmentProcedure
+
+    val currentCodeType = new GovernmentProcedureCurrentCodeType
+    currentCodeType.setValue(currentCode.orNull)
+
+    val previousCodeType = new GovernmentProcedurePreviousCodeType
+    previousCodeType.setValue(previousCode.orNull)
+
+    governmentProcedure.setCurrentCode(currentCodeType)
+    governmentProcedure.setPreviousCode(previousCodeType)
+
+    governmentProcedure
+  }
+}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-play-25" % "4.6.0",
     "uk.gov.hmrc" %% "play-language" % "3.4.0",
     "com.thoughtworks.xstream" % "xstream" % "1.4.10",
-    "uk.gov.hmrc" %% "wco-dec" % "0.28.0",
+    "uk.gov.hmrc" %% "wco-dec" % "0.29.0",
     "ai.x"         %% "play-json-extensions" % "0.9.0"
   )
 

--- a/test/forms/declaration/DocumentSpec.scala
+++ b/test/forms/declaration/DocumentSpec.scala
@@ -17,8 +17,9 @@
 package forms.declaration
 
 import base.TestHelper
+import forms.declaration.DocumentsProducedSpec.correctDocumentsProducedJSON
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json.{JsObject, JsString, JsValue}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 class DocumentSpec extends WordSpec with MustMatchers {
   import DocumentSpec._
@@ -103,6 +104,9 @@ object DocumentSpec {
       "goodsItemIdentifier" -> JsString("123")
     )
   )
+
+  val correctPreviousDocumentsJSONList = JsObject(Map("documents" -> JsArray(Seq(correctPreviousDocumentsJSON))))
+
   val emptyPreviousDocumentsJSON: JsValue = JsObject(
     Map(
       "documentCategory" -> JsString(""),

--- a/test/models/declaration/SupplementaryDeclarationDataSpec.scala
+++ b/test/models/declaration/SupplementaryDeclarationDataSpec.scala
@@ -385,6 +385,8 @@ object SupplementaryDeclarationDataSpec {
       ExporterDetails.id -> correctExporterDetailsJSON,
       DeclarantDetails.id -> correctDeclarantDetailsJSON,
       RepresentativeDetails.formId -> correctRepresentativeDetailsJSON,
+      Document.formId -> DocumentSpec.correctPreviousDocumentsJSONList,
+      CarrierDetails.id-> CarrierDetailsSpec.correctCarrierDetailsJSON,
       ConsigneeDetails.id -> correctConsigneeDetailsJSON,
       DeclarationAdditionalActorsData.formId -> correctAdditionalActorsDataJSON,
       DeclarationHoldersData.formId -> correctDeclarationHoldersDataJSON,

--- a/test/services/mapping/CachingMappingHelperSpec.scala
+++ b/test/services/mapping/CachingMappingHelperSpec.scala
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import forms.declaration.CommodityMeasure
+import org.scalatest.{Matchers, WordSpec}
+
+class CachingMappingHelperSpec extends WordSpec with Matchers {
+
+  "CachingMappingHelper" should {
+    "mapGoodsMeasure correctly When tariffQuantity grossMassMeasure netWeightMeasure provided" in {
+
+      val commodityMeasure = CommodityMeasure(Some("10"), "100.00", "100.00")
+      val goodsMeasure =  CachingMappingHelper.mapGoodsMeasure(commodityMeasure).goodsMeasure.get
+
+      goodsMeasure.tariffQuantity.get.value.get shouldBe 10
+      goodsMeasure.grossMassMeasure.get.value.get shouldBe 100.00
+      goodsMeasure.netWeightMeasure.get.value.get shouldBe 100.00
+    }
+
+    "mapGoodsMeasure correctly When grossMassMeasure netWeightMeasure provided but no tariffQuantity" in {
+
+      val commodityMeasure = CommodityMeasure(None, "100.00", "100.00")
+
+      val goodsMeasure =  CachingMappingHelper.mapGoodsMeasure(commodityMeasure).goodsMeasure.get
+      goodsMeasure.tariffQuantity shouldBe None
+      goodsMeasure.grossMassMeasure.get.value.get shouldBe 100.00
+      goodsMeasure.netWeightMeasure.get.value.get shouldBe 100.00
+    }
+
+  }
+}

--- a/test/services/mapping/DeclarationTypeCodeMappingSpec.scala
+++ b/test/services/mapping/DeclarationTypeCodeMappingSpec.scala
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import forms.declaration.DispatchLocation
+import forms.declaration.DispatchLocation.AllowedDispatchLocations
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDec.AllowedAdditionalDeclarationTypes
+import org.scalatest.{Matchers, WordSpec}
+import services.mapping.DeclarationTypeCodeMapping.additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode
+
+class DeclarationTypeCodeMappingSpec extends WordSpec with Matchers{
+
+
+
+ "DeclarationTypeCodeMapping" should {
+
+   "return CodeType with value EXZ for OutsideEU and Standard" in {
+     val dispatchLocation = DispatchLocation(AllowedDispatchLocations.OutsideEU)
+     val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Standard)
+     val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(Some(dispatchLocation), Some(additionalDeclarationTypeCode))
+     codeType.getValue should be("EXZ")
+   }
+
+   "return CodeType with value COY for SpecialFiscalTerritory and Simplified" in {
+     val dispatchLocation = DispatchLocation(AllowedDispatchLocations.SpecialFiscalTerritory)
+     val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Simplified)
+     val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(Some(dispatchLocation), Some(additionalDeclarationTypeCode))
+     codeType.getValue should be("COY")
+   }
+
+   "return CodeType with value Y for None and Simplified" in {
+     val additionalDeclarationTypeCode = AdditionalDeclarationType(AllowedAdditionalDeclarationTypes.Simplified)
+     val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(None, Some(additionalDeclarationTypeCode))
+     codeType.getValue should be("Y")
+   }
+
+   "return CodeType with value EX for OutsideEU and None" in {
+     val dispatchLocation = DispatchLocation(AllowedDispatchLocations.OutsideEU)
+     val codeType = additionalDeclarationTypeAndDispatchLocationToDeclarationTypeCode(Some(dispatchLocation), None)
+     codeType.getValue should be("EX")
+   }
+ }
+
+}

--- a/test/services/mapping/MetaDataBuilderSpec.scala
+++ b/test/services/mapping/MetaDataBuilderSpec.scala
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues
+import org.scalatest.{Matchers, WordSpec}
+
+class MetaDataBuilderSpec extends WordSpec with Matchers {
+
+  "MetaDataBuilder" should {
+    "build wco MetaData with correct defaultValues" in {
+      val emptyDefaultMetaData = MetaDataBuilder.build
+      emptyDefaultMetaData.getWCOTypeName.getValue shouldBe SchemaMandatoryValues.wcoTypeName
+      emptyDefaultMetaData.getWCODataModelVersionCode.getValue shouldBe SchemaMandatoryValues.wcoDataModelVersionCode
+      emptyDefaultMetaData.getResponsibleAgencyName.getValue shouldBe SchemaMandatoryValues.responsibleAgencyName
+      emptyDefaultMetaData.getResponsibleCountryCode.getValue shouldBe SchemaMandatoryValues.responsibleCountryCode
+      emptyDefaultMetaData.getAgencyAssignedCustomizationCode.getValue shouldBe SchemaMandatoryValues.agencyAssignedCustomizationVersionCode
+
+    }
+  }
+
+}

--- a/test/services/mapping/XmlMarshallingSpec.scala
+++ b/test/services/mapping/XmlMarshallingSpec.scala
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import wco.datamodel.wco.documentmetadata_dms._2.MetaData
+
+class XmlMarshallingSpec extends WordSpec with Matchers with MockitoSugar{
+
+  val expectedPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n<MetaData xmlns=\"urn:wco:datamodel:WCO:DocumentMetaData-DMS:2\"/>\n"
+
+  "XmlMarshalling" should {
+    "generate correct xml payload section when marshalled" in {
+      val metaData  = new MetaData
+
+      import java.io.StringWriter
+
+      import javax.xml.bind.{JAXBContext, JAXBException, Marshaller}
+      try { //Create JAXB Context
+        val jaxbContext = JAXBContext.newInstance(classOf[MetaData])
+        //Create Marshaller
+        val jaxbMarshaller = jaxbContext.createMarshaller
+        //Required formatting??
+        jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true)
+        //Print XML String to Console
+        val sw = new StringWriter
+        //Write XML to StringWriter
+        jaxbMarshaller.marshal(metaData, sw)
+        //Verify XML Content
+        val xmlContent = sw.toString
+        xmlContent should be(expectedPayload)
+      } catch {
+        case e: JAXBException =>
+          e.printStackTrace()
+      }
+    }
+  }
+}
+

--- a/test/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{ConsigneeDetails, ConsigneeDetailsSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class ConsigneeBuilderSpec extends WordSpec with Matchers {
+
+  "ConsigneeBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.Consignee instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.correctConsigneeDetailsJSON))
+      val consignee = ConsigneeBuilder.build(cacheMap)
+      consignee.getID.getValue should be("9GB1234567ABCDEF")
+      consignee.getName.getValue should be("Full Name")
+      consignee.getAddress.getLine.getValue should be("Address Line")
+      consignee.getAddress.getCityName.getValue should be("Town or City")
+      consignee.getAddress.getCountryCode.getValue should be("PL")
+      consignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/ConsignmentBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ConsignmentBuilderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{CarrierDetails, CarrierDetailsSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class ConsignmentBuilderSpec extends WordSpec with Matchers {
+
+  "ConsignmentBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.Consignment instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap("CacheID", Map(CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsJSON))
+      val consignment = ConsignmentBuilder.build(cacheMap)
+      consignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
+      consignment.getGoodsLocation.getName.getValue should be("Full Name")
+      consignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
+      consignment.getGoodsLocation.getAddress.getCityName.getValue should be("Town or City")
+      consignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
+      consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.DestinationCountriesSupplementarySpec
+import forms.declaration.destinationCountries.DestinationCountries
+import org.scalatest.{Matchers, WordSpec}
+
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class DestinationBuilderSpec extends WordSpec with Matchers {
+
+  "DestinationBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.Destination instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap(
+          "CacheID",
+          Map(
+            DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+          )
+        )
+      val destination = DestinationBuilder.build(cacheMap)
+      destination.getCountryCode.getValue should be("PL")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.DestinationCountriesSupplementarySpec
+import forms.declaration.destinationCountries.DestinationCountries
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class ExportCountryBuilderSpec extends WordSpec with Matchers {
+
+  "ExportCountryBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.ExportCountries instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap(
+          "CacheID",
+          Map(
+            DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+          )
+        )
+      val obj = ExportCountryBuilder.build(cacheMap)
+      obj.getID.getValue should be("PL")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/ExporterBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ExporterBuilderSpec.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{ExporterDetails, ExporterDetailsSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class ExporterBuilderSpec extends WordSpec with Matchers {
+
+  "ExporterBuilder" should {
+    "correctly map to the WCO-DEC Exporter instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap("CacheID", Map(ExporterDetails.id -> ExporterDetailsSpec.correctExporterDetailsJSON))
+      val exporter = ExporterBuilder.build(cacheMap)
+      exporter.getID.getValue should be("9GB1234567ABCDEF")
+      exporter.getName.getValue should be("Full Name")
+      exporter.getAddress.getLine.getValue should be("Address Line")
+      exporter.getAddress.getCityName.getValue should be("Town or City")
+      exporter.getAddress.getCountryCode.getValue should be("PL")
+      exporter.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import models.declaration.SupplementaryDeclarationDataSpec
+import org.scalatest.{Matchers, WordSpec}
+
+class GoodsShipmentBuilderSpec extends WordSpec with Matchers {
+
+  "GoodsShipmentBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment instance" in {
+      val goodsShipment = GoodsShipmentBuilder.build(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+      goodsShipment.getTransactionNatureCode.getValue should be("11")
+      
+      goodsShipment.getConsignee.getID.getValue should be("9GB1234567ABCDEF")
+      goodsShipment.getConsignee.getName.getValue should be("Full Name")
+      goodsShipment.getConsignee.getAddress.getLine.getValue should be("Address Line")
+      goodsShipment.getConsignee.getAddress.getCityName.getValue should be("Town or City")
+      goodsShipment.getConsignee.getAddress.getCountryCode.getValue should be("PL")
+      goodsShipment.getConsignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+
+      goodsShipment.getConsignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
+      goodsShipment.getConsignment.getGoodsLocation.getName.getValue should be("Full Name")
+      goodsShipment.getConsignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
+      goodsShipment.getConsignment.getGoodsLocation.getAddress.getCityName.getValue should be("Town or City")
+      goodsShipment.getConsignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
+      goodsShipment.getConsignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+
+      goodsShipment.getDestination.getCountryCode.getValue should be("PL")
+
+      goodsShipment.getExportCountry.getID.getValue should be("PL")
+
+      goodsShipment.getUCR.getID.getValue should be(null)
+      goodsShipment.getUCR.getTraderAssignedReferenceID.getValue should be("8GB123456789012-1234567890QWERTYUIO")
+
+      goodsShipment.getWarehouse.getID.getValue should be("1234567GB")
+      goodsShipment.getWarehouse.getTypeCode.getValue should be("R")
+      
+      goodsShipment.getPreviousDocument.size should be(1)
+      goodsShipment.getPreviousDocument.get(0).getID.getValue should be("DocumentReference")
+      goodsShipment.getPreviousDocument.get(0).getCategoryCode.getValue should be("X")
+      goodsShipment.getPreviousDocument.get(0).getLineNumeric.intValue() should be(123)
+      goodsShipment.getPreviousDocument.get(0).getTypeCode.getValue should be("ABC")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import org.mockito.Mockito.when
+import forms.declaration.{Document, DocumentSpec, PreviousDocumentsData}
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class PreviousDocumentsBuilderSpec extends WordSpec with Matchers with MockitoSugar{
+
+  "PreviousDocumentsBuilder " should {
+    "correctly map to a WCO-DEC GoodsShipment.PreviousDocuments instance" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap("CacheID", Map(Document.formId -> DocumentSpec.correctPreviousDocumentsJSONList))
+      val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+      previousDoc.size should be(1)
+      previousDoc.get(0).getID.getValue should be("DocumentReference")
+      previousDoc.get(0).getCategoryCode.getValue should be("X")
+      previousDoc.get(0).getLineNumeric.intValue() should be(123)
+      previousDoc.get(0).getTypeCode.getValue should be("ABC")
+    }
+
+    "handle empty documents when mapping to WCO-DEC GoodsShipment.PreviousDocuments" in {
+      implicit val cacheMap: CacheMap = mock[CacheMap]
+      when(cacheMap.getEntry[PreviousDocumentsData](Document.formId))
+          .thenReturn(None)
+
+      val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+      previousDoc.isEmpty shouldBe true
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/TransactionTypeBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/TransactionTypeBuilderSpec.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{TransactionType, TransactionTypeSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class TransactionTypeBuilderSpec extends WordSpec with Matchers {
+
+  "TransactionTypeBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.TransactionNatureCodeType instance" in {
+      implicit val cacheMap =
+        CacheMap("CacheID", Map(TransactionType.formId -> TransactionTypeSpec.correctTransactionTypeJSON))
+      val transactionNatureCodeType = GoodsShipmentTransactionTypeBuilder.build(cacheMap)
+      transactionNatureCodeType.getValue should be("11")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/UCRBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/UCRBuilderSpec.scala
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{ConsignmentReferences, ConsignmentReferencesSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class UCRBuilderSpec extends WordSpec with Matchers {
+
+  "UCRBuilder" should {
+    "correctly map to the WCO-DEC GoodsShipment.UCR instance" in {
+      implicit val cacheMap =
+        CacheMap("CacheID", Map(ConsignmentReferences.id -> ConsignmentReferencesSpec.correctConsignmentReferencesJSON))
+      val ucrObject = UCRBuilder.build(cacheMap)
+      ucrObject.getID.getValue should be(null)
+      ucrObject.getTraderAssignedReferenceID.getValue should be("8GB123456789012-1234567890QWERTYUIO")
+    }
+  }
+}

--- a/test/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.goodsshipment
+
+import forms.declaration.{WarehouseIdentification, WarehouseIdentificationSpec}
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class WarehouseBuilderSpec extends WordSpec with Matchers {
+
+  "WarehouseBuilder" should {
+    "correctly map to the WCO-DEC Warehouse instance" in {
+      implicit val cacheMap =
+        CacheMap(
+          "CacheID",
+          Map(WarehouseIdentification.formId -> WarehouseIdentificationSpec.correctWarehouseIdentificationJSON)
+        )
+      val warehouse = WarehouseBuilder.build(cacheMap)
+      warehouse.getID.getValue should be("1234567GB")
+      warehouse.getTypeCode.getValue should be("R")
+    }
+  }
+}

--- a/test/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/AdditionalDocumentsBuilderSpec.scala
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class AdditionalDocumentsBuilderSpec extends WordSpec with Matchers with GovernmentAgencyGoodsItemMocks {
+
+  "AdditionalDocumentsBuilder" should {
+    "map correctly when values are present" in {
+        implicit val cacheMap: CacheMap = mock[CacheMap]
+        setUpAdditionalDocuments()
+
+        val mappedDocuments = AdditionalDocumentsBuilder.build().get
+        mappedDocuments.isEmpty shouldBe false
+      val firstMappedDocument = mappedDocuments.head
+
+        firstMappedDocument.getCategoryCode.getValue shouldBe documentAndAdditionalDocumentTypeCode.substring(0,1)
+        firstMappedDocument.getTypeCode.getValue shouldBe documentAndAdditionalDocumentTypeCode.substring(1)
+        firstMappedDocument.getID.getValue shouldBe documentIdentifier + documentPart
+        firstMappedDocument.getLPCOExemptionCode.getValue shouldBe documentStatus
+        firstMappedDocument.getName.getValue shouldBe documentStatus + documentStatusReason
+        firstMappedDocument.getSubmitter.getName.getValue shouldBe issusingAuthorityName
+
+        val writeoff = firstMappedDocument.getWriteOff
+        writeoff.getAmountAmount shouldBe null
+        val writeOffQuantity = writeoff.getQuantityQuantity
+        writeOffQuantity.getUnitCode shouldBe measurementUnit
+        writeOffQuantity.getValue shouldBe documentQuantity.bigDecimal
+    }
+  }
+}

--- a/test/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/AdditionalInformationBuilderSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+
+import forms.declaration.AdditionalInformation
+import models.declaration.AdditionalInformationData
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class AdditionalInformationBuilderSpec extends WordSpec with Matchers with MockitoSugar{
+
+  "AdditionalInformationBuilder" should {
+     "map correctly when values are present" in {
+
+       val statementCode = "code"
+       val descriptionValue = "description"
+       val additionalInformation = AdditionalInformation(statementCode, descriptionValue)
+       val additionalInformationData = AdditionalInformationData(Seq(additionalInformation))
+
+
+       implicit val cacheMap: CacheMap = mock[CacheMap]
+       when( cacheMap
+         .getEntry[AdditionalInformationData](AdditionalInformationData.formId))
+           .thenReturn(Some(additionalInformationData))
+
+       val mappedAdditionalInformation = AdditionalInformationBuilder.build().get
+         mappedAdditionalInformation.isEmpty shouldBe false
+         mappedAdditionalInformation.head.getStatementCode.getValue shouldBe statementCode
+         mappedAdditionalInformation.head.getStatementDescription.getValue shouldBe descriptionValue
+     }
+
+    "map correctly when values are not Present" in {
+
+      val additionalInformationData = AdditionalInformationData(Seq())
+
+
+      implicit val cacheMap: CacheMap = mock[CacheMap]
+      when( cacheMap
+        .getEntry[AdditionalInformationData](AdditionalInformationData.formId))
+        .thenReturn(Some(additionalInformationData))
+
+      val mappedAdditionalInformation = AdditionalInformationBuilder.build().get
+      mappedAdditionalInformation.isEmpty shouldBe true
+
+    }
+   }
+
+}

--- a/test/services/mapping/governmentagencygoodsitem/CommodityBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/CommodityBuilderSpec.scala
@@ -1,0 +1,128 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration.{CommodityMeasure, ItemType}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import org.scalatest.{Matchers, WordSpec}
+import services.ExportsItemsCacheIds
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class CommodityBuilderSpec extends WordSpec with Matchers with MockitoSugar {
+
+  "CommodityBuilder" should {
+
+    "map commodity item successfully when dangerous goods present" in {
+
+      implicit val cacheMap: CacheMap = mock[CacheMap]
+      val descriptionOfGoods = "descriptionOfGoods"
+      val unDangerousGoodsCode = "unDangerousGoodsCode"
+      val netMassString = "15.00"
+      val grossMassString = "25.00"
+      val tariffQuantity = "31"
+
+      val itemType = Some(
+        ItemType(
+          "combinedNomenclatureCode",
+          Seq("taricAdditionalCodes"),
+          Seq("nationalAdditionalCodes"),
+          descriptionOfGoods,
+          Some("cusCode"),
+          Some(unDangerousGoodsCode),
+          "statisticalValue"
+        )
+      )
+
+      testBuilder(
+        descriptionOfGoods,
+        Some(unDangerousGoodsCode),
+        netMassString,
+        grossMassString,
+        tariffQuantity,
+        itemType
+      )
+
+    }
+  }
+
+  "map commodity item successfully when dangerous goods not present" in {
+
+    implicit val cacheMap: CacheMap = mock[CacheMap]
+    val descriptionOfGoods = "descriptionOfGoods"
+    val unDangerousGoodsCode = "unDangerousGoodsCode"
+    val netMassString = "15.00"
+    val grossMassString = "25.00"
+    val tariffQuantity = "31"
+
+    val itemType = Some(
+      ItemType(
+        "combinedNomenclatureCode",
+        Seq("taricAdditionalCodes"),
+        Seq("nationalAdditionalCodes"),
+        descriptionOfGoods,
+        Some("cusCode"),
+        None,
+        "statisticalValue"
+      )
+    )
+
+    testBuilder(
+      descriptionOfGoods,
+      None,
+      netMassString,
+      grossMassString,
+      tariffQuantity,
+      itemType
+    )
+
+  }
+
+  def testBuilder(
+    descriptionOfGoods: String,
+    unDangerousGoodsCode: Option[String],
+    netMassString: String,
+    grossMassString: String,
+    tariffQuantity: String,
+    itemType: Some[ItemType]
+  )(implicit  cacheMap: CacheMap) = {
+    val commodityMeasure = CommodityMeasure(Some(tariffQuantity), netMass = netMassString, grossMass = grossMassString)
+    when(
+      cacheMap
+        .getEntry[ItemType](ItemType.id)
+    ).thenReturn(itemType)
+
+    when(cacheMap.getEntry[CommodityMeasure](CommodityMeasure.commodityFormId)).thenReturn(Some(commodityMeasure))
+
+    val mappedCommodity = CommodityBuilder.build.get
+    mappedCommodity.getDescription.getValue shouldBe descriptionOfGoods
+    unDangerousGoodsCode.fold(mappedCommodity.getDangerousGoods.isEmpty shouldBe true){
+      code => mappedCommodity.getDangerousGoods.get(0).getUNDGID.getValue shouldBe code
+    }
+
+    val goodsMeasure = mappedCommodity.getGoodsMeasure
+
+    goodsMeasure.getNetNetWeightMeasure.getValue shouldBe BigDecimal(netMassString).bigDecimal
+    goodsMeasure.getNetNetWeightMeasure.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+
+    goodsMeasure.getGrossMassMeasure.getValue shouldBe BigDecimal(grossMassString).bigDecimal
+    goodsMeasure.getGrossMassMeasure.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+
+    goodsMeasure.getTariffQuantity.getValue shouldBe BigDecimal(tariffQuantity).bigDecimal
+    goodsMeasure.getTariffQuantity.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+  }
+
+}

--- a/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -1,0 +1,144 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+
+import java.util
+
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Reads
+import services.ExportsItemsCacheIds
+import uk.gov.hmrc.http.cache.client.CacheMap
+import uk.gov.hmrc.wco.dec.GovernmentAgencyGoodsItem
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.{GovernmentAgencyGoodsItem => WCOGovernmentAgencyGoodsItem}
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem._
+class GovernmentAgencyGoodsItemBuilderSpec extends WordSpec with Matchers with GovernmentAgencyGoodsItemMocks with GovernmentAgencyGoodsItemData {
+
+  trait SetUp {
+    implicit val cacheMap: CacheMap = mock[CacheMap]
+
+    //Set Up Additional Information
+    setUpAdditionalInformation
+    //setUp Additional Documents
+    setUpAdditionalDocuments()
+    //Set up ProcedureCodes
+    setUpProcedureCodes
+    //Set up Commodity Measure
+    setUpCommodityMeasure
+    //Set up Item Type
+    setUpItemType
+    //Set up PackageInformation
+    setUpPackageInformation
+
+    //setUp GovernmentAgencyGoodsItem
+    val governmentAgencyGoodsItem = GovernmentAgencyGoodsItem(sequenceNumeric = 1)
+
+    when(
+        cacheMap
+      .getEntry[Seq[GovernmentAgencyGoodsItem]](eqTo(ExportsItemsCacheIds.itemsId))(
+          any[Reads[Seq[GovernmentAgencyGoodsItem]]]
+      )
+    ).thenReturn(Some(Seq(governmentAgencyGoodsItem)))
+
+
+  }
+
+  "GovernmentAgencyGoodsItemBuilder" should {
+    "map to WCO model correctly " in new SetUp() {
+
+      val mappedGoodsItemList: List[WCOGovernmentAgencyGoodsItem] = GovernmentAgencyGoodsItemBuilder.build
+      mappedGoodsItemList.isEmpty shouldBe false
+
+      val mappedGoodsItem: WCOGovernmentAgencyGoodsItem = mappedGoodsItemList.head
+
+      val additionalDocuments: util.List[AdditionalDocument] = mappedGoodsItem.getAdditionalDocument
+      additionalDocuments.isEmpty shouldBe false
+      val firstMappedDocument: AdditionalDocument = additionalDocuments.get(0)
+
+
+      val additionalInformations: util.List[AdditionalInformation] = mappedGoodsItem.getAdditionalInformation
+      additionalInformations.isEmpty shouldBe false
+      val additionalInformation: AdditionalInformation = additionalInformations.get(0)
+
+      val commodity: Commodity = mappedGoodsItem.getCommodity
+
+      val packagingList: util.List[Packaging] = mappedGoodsItem.getPackaging
+      packagingList.isEmpty shouldBe false
+      val firstPackaging: Packaging = packagingList.get(0)
+
+      val procedurelist: util.List[GovernmentProcedure] = mappedGoodsItem.getGovernmentProcedure
+      val firstProcedure: GovernmentProcedure = procedurelist.get(0)
+
+      validateAdditionalDocuments(firstMappedDocument)
+      validateAdditionalInformation(additionalInformation)
+      validateCommodity(commodity)
+      validatePackaging(firstPackaging)
+      validateGovernmentProcedure(firstProcedure)
+    }
+  }
+
+  private def validateGovernmentProcedure(mappedProcedure: GovernmentProcedure) = {
+    mappedProcedure.getCurrentCode.getValue shouldBe cachedCode.substring(0,2)
+    mappedProcedure.getPreviousCode.getValue shouldBe cachedCode.substring(2,4)
+  }
+
+
+  private def validatePackaging(packaging: Packaging) = {
+    packaging.getQuantityQuantity.getValue shouldBe BigDecimal(packageQuantity).bigDecimal
+    packaging.getMarksNumbersID.getValue shouldBe shippingMarksValue
+    packaging.getTypeCode.getValue shouldBe packageTypeValue
+  }
+
+  private def validateCommodity(mappedCommodity: WCOGovernmentAgencyGoodsItem.Commodity) = {
+    mappedCommodity.getDescription.getValue shouldBe descriptionOfGoods
+    mappedCommodity.getDangerousGoods.get(0).getUNDGID.getValue shouldBe unDangerousGoodsCode
+
+    val goodsMeasure = mappedCommodity.getGoodsMeasure
+
+    goodsMeasure.getNetNetWeightMeasure.getValue shouldBe BigDecimal(netMassString).bigDecimal
+    goodsMeasure.getNetNetWeightMeasure.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+
+    goodsMeasure.getGrossMassMeasure.getValue shouldBe BigDecimal(grossMassString).bigDecimal
+    goodsMeasure.getGrossMassMeasure.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+
+    goodsMeasure.getTariffQuantity.getValue shouldBe BigDecimal(tariffQuantity).bigDecimal
+    goodsMeasure.getTariffQuantity.getUnitCode shouldBe ExportsItemsCacheIds.defaultMeasureCode
+  }
+  private def validateAdditionalInformation(additionalInfomation: WCOGovernmentAgencyGoodsItem.AdditionalInformation) = {
+    additionalInfomation.getStatementCode.getValue shouldBe statementCode
+    additionalInfomation.getStatementDescription.getValue shouldBe descriptionValue
+  }
+
+
+private def validateAdditionalDocuments(
+    firstMappedDocument: WCOGovernmentAgencyGoodsItem.AdditionalDocument
+  ) = {
+    firstMappedDocument.getCategoryCode.getValue shouldBe documentAndAdditionalDocumentTypeCode.substring(0, 1)
+    firstMappedDocument.getTypeCode.getValue shouldBe documentAndAdditionalDocumentTypeCode.substring(1)
+    firstMappedDocument.getID.getValue shouldBe documentIdentifier + documentPart
+    firstMappedDocument.getLPCOExemptionCode.getValue shouldBe documentStatus
+    firstMappedDocument.getName.getValue shouldBe documentStatus + documentStatusReason
+    firstMappedDocument.getSubmitter.getName.getValue shouldBe issusingAuthorityName
+
+    val writeoff = firstMappedDocument.getWriteOff
+    writeoff.getAmountAmount shouldBe null
+    val writeOffQuantity = writeoff.getQuantityQuantity
+    writeOffQuantity.getUnitCode shouldBe measurementUnit
+    writeOffQuantity.getValue shouldBe documentQuantity.bigDecimal
+  }
+}

--- a/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
+++ b/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemData.scala
@@ -1,0 +1,98 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.common.Date
+import forms.declaration._
+import models.declaration.{AdditionalInformationData, DocumentsProducedData, ProcedureCodesData}
+
+trait GovernmentAgencyGoodsItemData {
+
+  //Document Produced Data
+  val documentQuantity = BigDecimal(10)
+  val dateOfValidity = Date(Some(25), Some(4), Some(2019))
+  val documentAndAdditionalDocumentTypeCode = "1A"
+
+  val documentIdentifier = "SYSUYSU"
+  val documentPart = "12324554"
+  val documentStatus = "PENDING"
+  val documentStatusReason = "Reason"
+  val issusingAuthorityName = "issuingAuthorityName"
+
+  val measurementUnit = "KGM"
+
+  val documentsProduced: Seq[DocumentsProduced] = Seq(
+    DocumentsProduced(
+      Some(documentAndAdditionalDocumentTypeCode),
+      Some(documentIdentifier),
+      Some(documentPart),
+      Some(documentStatus),
+      Some(documentStatus + documentStatusReason),
+      Some(issusingAuthorityName),
+      Some(dateOfValidity),
+      Some(measurementUnit),
+      Some(documentQuantity)
+    )
+  )
+
+  val documentsProducedData = DocumentsProducedData(documentsProduced)
+
+
+  //Package Information Data
+  val shippingMarksValue = "shippingMarks"
+  val packageTypeValue = "packageType"
+  val packageQuantity = 12
+  val numberOfPackages = Some(packageQuantity)
+  val shippingMarksString = Some(shippingMarksValue)
+
+  val packageInformation = new PackageInformation(Some(packageTypeValue), numberOfPackages, shippingMarksString)
+
+  //Item Type Data
+  val descriptionOfGoods = "descriptionOfGoods"
+  val unDangerousGoodsCode = "unDangerousGoodsCode"
+  val itemType = Some(
+    ItemType(
+      "combinedNomenclatureCode",
+      Seq("taricAdditionalCodes"),
+      Seq("nationalAdditionalCodes"),
+      descriptionOfGoods,
+      Some("cusCode"),
+      Some(unDangerousGoodsCode),
+      "10"
+    )
+  )
+
+  //commodity measure data
+  val netMassString = "15.00"
+  val grossMassString = "25.00"
+  val tariffQuantity = "31"
+  val commodityMeasure = CommodityMeasure(Some(tariffQuantity), netMass = netMassString, grossMass = grossMassString)
+
+  //procedureCodes Data
+
+  val previousCode = "1stPrevcode"
+  val previousCodes = Seq(previousCode)
+  val cachedCode = "CUPR"
+  val procedureCodesData = ProcedureCodesData(Some(cachedCode), previousCodes)
+
+
+  //Additional Information data
+  val statementCode = "code"
+  val descriptionValue = "description"
+  val additionalInformation = AdditionalInformation(statementCode, descriptionValue)
+  val additionalInformationData = AdditionalInformationData(Seq(additionalInformation))
+
+}

--- a/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemMocks.scala
+++ b/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemMocks.scala
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+import forms.declaration._
+import models.declaration.{AdditionalInformationData, DocumentsProducedData, ProcedureCodesData}
+import org.mockito.ArgumentMatchers.{any, eq => eqTo}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
+import play.api.libs.json.Reads
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+trait GovernmentAgencyGoodsItemMocks extends MockitoSugar with GovernmentAgencyGoodsItemData{
+
+  def setUpAdditionalDocuments()(implicit cacheMap: CacheMap) {
+    when(cacheMap.getEntry[DocumentsProducedData](eqTo(DocumentsProducedData.formId))(any()))
+      .thenReturn(Some(documentsProducedData))
+  }
+
+  def setUpAdditionalInformation()(implicit cacheMap: CacheMap): Unit = {
+    when(
+      cacheMap
+        .getEntry[AdditionalInformationData](eqTo(AdditionalInformationData.formId))(any())
+    ).thenReturn(Some(additionalInformationData))
+  }
+
+  def setUpPackageInformation()(implicit cacheMap: CacheMap): Unit ={
+    when(
+      cacheMap
+        .getEntry[Seq[PackageInformation]](eqTo(PackageInformation.formId))(any[Reads[Seq[PackageInformation]]])
+    ).thenReturn(Some(Seq(packageInformation)))
+  }
+
+  def setUpItemType()(implicit cacheMap: CacheMap): Unit = {
+    when(cacheMap.getEntry[ItemType](eqTo(ItemType.id))(any[Reads[ItemType]])).thenReturn(itemType)
+  }
+
+  def setUpCommodityMeasure()(implicit cacheMap: CacheMap): Unit = {
+    when(cacheMap.getEntry[CommodityMeasure](eqTo(CommodityMeasure.commodityFormId))(any()))
+      .thenReturn(Some(commodityMeasure))
+  }
+
+  def setUpProcedureCodes()(implicit cacheMap: CacheMap): Unit = {
+    when(
+      cacheMap
+        .getEntry[ProcedureCodesData](eqTo(ProcedureCodesData.formId))(any())
+    ).thenReturn(Some(procedureCodesData))
+  }
+}

--- a/test/services/mapping/governmentagencygoodsitem/PackageBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/PackageBuilderSpec.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class PackageBuilderSpec extends WordSpec with Matchers with GovernmentAgencyGoodsItemMocks {
+
+  "PackageBuilder" should {
+    "map correctly to wco Packaging" in {
+      implicit val cacheMap = mock[CacheMap]
+      setUpPackageInformation()
+
+      val mappedItems = PackageBuilder.build.getOrElse(Seq.empty)
+
+      mappedItems.length should be(1)
+      val wcoPackaging =  mappedItems.head
+      wcoPackaging.getQuantityQuantity.getValue shouldBe BigDecimal(packageQuantity).bigDecimal
+      wcoPackaging.getMarksNumbersID.getValue shouldBe shippingMarksValue
+      wcoPackaging.getTypeCode.getValue shouldBe packageTypeValue
+
+    }
+  }
+
+}

--- a/test/services/mapping/governmentagencygoodsitem/ProcedureCodesBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/ProcedureCodesBuilderSpec.scala
@@ -1,0 +1,43 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.mapping.governmentagencygoodsitem
+
+import org.scalatest.{Matchers, WordSpec}
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem
+
+class ProcedureCodesBuilderSpec extends WordSpec with Matchers with GovernmentAgencyGoodsItemMocks {
+
+  "ProcedureCodesBuilder" should {
+    "build governmentProcedure correctly" in {
+
+      implicit val cacheMap = mock[CacheMap]
+      setUpProcedureCodes()
+
+      val results: Option[Seq[GovernmentAgencyGoodsItem.GovernmentProcedure]] = ProcedureCodesBuilder.build
+
+      results.isDefined shouldBe true
+      val mappedProcedures = results.get
+      mappedProcedures.head.getCurrentCode.getValue shouldBe cachedCode.substring(0,2)
+      mappedProcedures.head.getPreviousCode.getValue shouldBe cachedCode.substring(2,4)
+
+      mappedProcedures.last.getCurrentCode.getValue shouldBe previousCode
+      mappedProcedures.last.getPreviousCode.getValue shouldBe null
+    }
+  }
+
+}


### PR DESCRIPTION
This is the new approach of mapping the user journey data and map it
straight to the WCO-DEC java model.

This allows better serialization and deserialization support than a
Scala bespoke model.

It would also reduce the cost of model changes in the future.

with @mattclark-zerogravit