### PR TITLE
CEDS-1146 Add featureFlag to switch between WCO-DEC Mapping strategies

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -23,6 +23,7 @@ import features.{Feature, FeatureStatus}
 import play.api.Mode.Mode
 import play.api.i18n.Lang
 import play.api.{Configuration, Environment}
+import services.{WcoMetadataJavaMappingStrategy, WcoMetadataMapper, WcoMetadataScalaMappingStrategy}
 import uk.gov.hmrc.play.config.{AppName, ServicesConfig}
 
 @Singleton
@@ -97,6 +98,11 @@ class AppConfig @Inject()(override val runModeConfiguration: Configuration, val 
 
   lazy val defaultFeatureStatus: features.FeatureStatus.Value =
     FeatureStatus.withName(loadConfig(feature2Key(Feature.default)))
+
+  def wcoMetadataMapper(): WcoMetadataMapper =
+    if (useNewMappingStrategy)
+      new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
+    else new WcoMetadataMapper with WcoMetadataScalaMappingStrategy
 
   def featureStatus(feature: Feature): FeatureStatus =
     sys.props

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -84,6 +84,8 @@ class AppConfig @Inject()(override val runModeConfiguration: Configuration, val 
 
   lazy val countriesCsvFilename: String = loadConfig("countryCodesCsvFilename")
 
+  lazy val useNewMappingStrategy = getConfBool("features.use-new-wco-dec-mapping-strategy", false)
+
   lazy val countryCodesJsonFilename: String = loadConfig("countryCodesJsonFilename")
 
   lazy val nrsServiceUrl: String = baseUrl("nrs")

--- a/app/connectors/CustomsDeclareExportsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsConnector.scala
@@ -35,14 +35,14 @@ class CustomsDeclareExportsConnector @Inject()(appConfig: AppConfig, httpClient:
   private[connectors] def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     httpClient.GET(url, Seq())
 
-  def submitExportDeclaration(ducr: String, lrn: Option[String], metadata: MetaData)(
+  def submitExportDeclaration(ducr: String, lrn: Option[String], payload: String)(
     implicit hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[HttpResponse] =
     httpClient
       .POSTString[HttpResponse](
         s"${appConfig.customsDeclareExports}${appConfig.submitDeclaration}",
-        metadata.toXml,
+      payload,
         Seq(
           (HeaderNames.CONTENT_TYPE -> ContentTypes.XML(Codec.utf_8)),
           (HeaderNames.ACCEPT -> ContentTypes.XML(Codec.utf_8)),

--- a/app/connectors/CustomsDeclareExportsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsConnector.scala
@@ -35,7 +35,7 @@ class CustomsDeclareExportsConnector @Inject()(appConfig: AppConfig, httpClient:
   private[connectors] def get(url: String)(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[HttpResponse] =
     httpClient.GET(url, Seq())
 
-  def submitExportDeclaration(ducr: String, lrn: Option[String], payload: String)(
+  def submitExportDeclaration(ducr: Option[String], lrn: Option[String], payload: String)(
     implicit hc: HeaderCarrier,
     ec: ExecutionContext
   ): Future[HttpResponse] =
@@ -46,7 +46,7 @@ class CustomsDeclareExportsConnector @Inject()(appConfig: AppConfig, httpClient:
         Seq(
           (HeaderNames.CONTENT_TYPE -> ContentTypes.XML(Codec.utf_8)),
           (HeaderNames.ACCEPT -> ContentTypes.XML(Codec.utf_8)),
-          ("X-DUCR", ducr),
+          ("X-DUCR", ducr.getOrElse("")),
           ("X-LRN", lrn.getOrElse(""))
         )
       )

--- a/app/controllers/declaration/SummaryPageController.scala
+++ b/app/controllers/declaration/SummaryPageController.scala
@@ -96,9 +96,12 @@ class SummaryPageController @Inject()(
     val metaData = produceMetaData(cacheMap)
 
     val lrn = metaData.declaration.flatMap(_.functionalReferenceId)
+    val ducr = declarationUcr(metaData.declaration).getOrElse("")
+
+    val payload = metaData.toXml
 
     customsDeclareExportsConnector
-      .submitExportDeclaration(declarationUcr(metaData.declaration).getOrElse(""), lrn, metaData)
+      .submitExportDeclaration(ducr, lrn, payload)
       .flatMap {
         case HttpResponse(ACCEPTED, _, _, _) =>
           customsCacheService.remove(cacheId).map { _ =>
@@ -111,5 +114,4 @@ class SummaryPageController @Inject()(
           Future.successful(handleError(s"Error from Customs Declarations API ${error.toString}"))
       }
   }
-
 }

--- a/app/services/WcoMetadataJavaMappingStrategy.scala
+++ b/app/services/WcoMetadataJavaMappingStrategy.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import javax.xml.bind.JAXBElement
+import services.mapping.MetaDataBuilder
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration
+import wco.datamodel.wco.documentmetadata_dms._2.MetaData
+
+trait WcoMetadataJavaMappingStrategy extends WcoMetadataMappingStrategy {
+
+  override def produceMetaData(cacheMap: CacheMap): MetaData =
+    MetaDataBuilder.build(cacheMap)
+
+  override def declarationUcr(metaData: Any): Option[String] =
+    Option(
+      metaData
+        .asInstanceOf[MetaData]
+        .getAny
+        .asInstanceOf[JAXBElement[Declaration]]
+        .getValue
+        .getGoodsShipment
+        .getUCR
+        .getTraderAssignedReferenceID
+        .getValue
+    ).orElse(Some(""))
+
+  override def declarationLrn(metaData: Any): Option[String] =
+    Option(
+      metaData
+        .asInstanceOf[MetaData]
+        .getAny
+        .asInstanceOf[JAXBElement[Declaration]]
+        .getValue
+        .getFunctionalReferenceID
+        .getValue
+    ).orElse(Some(""))
+
+  override def toXml(metaData: Any): String = {
+    import java.io.StringWriter
+
+    import javax.xml.bind.{JAXBContext, Marshaller}
+
+    val jaxbMarshaller = JAXBContext.newInstance(classOf[MetaData]).createMarshaller
+    jaxbMarshaller.setProperty(Marshaller.JAXB_FORMATTED_OUTPUT, true)
+
+    val sw = new StringWriter
+    jaxbMarshaller.marshal(metaData.asInstanceOf[MetaData], sw)
+    sw.toString
+  }
+}

--- a/app/services/WcoMetadataMapper.scala
+++ b/app/services/WcoMetadataMapper.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+class WcoMetadataMapper {
+
+  self: WcoMetadataMappingStrategy =>
+
+  def produceMetaData(cacheMap: CacheMap): Any =
+    produceMetaData(cacheMap)
+
+  def declarationUcr(metaData: Any): Option[String] = declarationUcr(metaData)
+
+  def declarationLrn(metaData: Any): Option[String] = declarationLrn(metaData)
+
+  def toXml(metaData: Any): String = toXml(metaData)
+}

--- a/app/services/WcoMetadataMappingStrategy.scala
+++ b/app/services/WcoMetadataMappingStrategy.scala
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+
+import uk.gov.hmrc.http.cache.client.CacheMap
+
+trait WcoMetadataMappingStrategy {
+
+  def produceMetaData(cacheMap: CacheMap): Any
+
+  def declarationUcr(metaData: Any): Option[String]
+
+  def declarationLrn(metaData: Any): Option[String]
+
+  def toXml(metaData: Any): String
+}

--- a/app/services/mapping/MetaDataBuilder.scala
+++ b/app/services/mapping/MetaDataBuilder.scala
@@ -15,22 +15,20 @@
  */
 
 package services.mapping
+import javax.xml.bind.JAXBElement
+import javax.xml.namespace.QName
 import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues
+import services.mapping.declaration.DeclarationBuilder
+import uk.gov.hmrc.http.cache.client.CacheMap
+import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
 import wco.datamodel.wco.metadata_ds_dms._2._
 
 object MetaDataBuilder {
 
-  def build(): MetaData =
-    buildMetaData()
-
-  private def buildMetaData(): MetaData = {
+  def build(cacheMap: CacheMap): MetaData = {
     val metaData = new MetaData
-    populateMetaDataMandatoryDefaults(metaData)
-    metaData
-  }
 
-  private def populateMetaDataMandatoryDefaults(metaData: MetaData) {
     val agencyAssignedCustomizationCodeType = new MetaDataAgencyAssignedCustomizationCodeType
     agencyAssignedCustomizationCodeType.setValue(SchemaMandatoryValues.agencyAssignedCustomizationVersionCode)
 
@@ -51,6 +49,14 @@ object MetaDataBuilder {
     metaData.setResponsibleCountryCode(metaDataResponsibleCountryCodeType)
     metaData.setWCODataModelVersionCode(metaDataWCODataModelVersionCodeType)
     metaData.setWCOTypeName(metaDataWCOTypeNameTextType)
-  }
 
+    val element: JAXBElement[Declaration] = new JAXBElement[Declaration](
+      new QName("urn:wco:datamodel:WCO:DEC-DMS:2", "Declaration"),
+      classOf[Declaration],
+      DeclarationBuilder.build(cacheMap)
+    )
+    metaData.setAny(element)
+
+    metaData
+  }
 }

--- a/app/services/mapping/declaration/DeclarationBuilder.scala
+++ b/app/services/mapping/declaration/DeclarationBuilder.scala
@@ -16,6 +16,9 @@
 
 package services.mapping.declaration
 
+import java.util.Collections
+
+import org.apache.commons.lang3.StringUtils
 import services.mapping.goodsshipment.GoodsShipmentBuilder
 import uk.gov.hmrc.http.cache.client.CacheMap
 import wco.datamodel.wco.dec_dms._2.Declaration
@@ -41,7 +44,11 @@ object DeclarationBuilder {
     declaration.setSupervisingOffice(SupervisingOfficeBuilder.build)
     declaration.setTotalPackageQuantity(TotalPackageQuantityBuilder.build)
     declaration.setTypeCode(TypeCodeBuilder.build)
-    declaration.getCurrencyExchange.addAll(CurrencyExchangeBuilder.build)
+
+    val currencyExchangeList = CurrencyExchangeBuilder.build
+    if (currencyExchangeList != null && !currencyExchangeList.isEmpty) {
+      declaration.getCurrencyExchange.addAll(currencyExchangeList)
+    }
 
     declaration
   }

--- a/app/test/controllers/TestingUtilitiesController.scala
+++ b/app/test/controllers/TestingUtilitiesController.scala
@@ -56,7 +56,7 @@ class TestingUtilitiesController @Inject()(
   }
 
   private def callConnector(lrn: String, ducr: String, metaData: MetaData)(implicit hc: HeaderCarrier): Future[Result] =
-    connector.submitExportDeclaration(ducr, Some(lrn), metaData.toXml).map { _ =>
+    connector.submitExportDeclaration(Some(ducr), Some(lrn), metaData.toXml).map { _ =>
       Logger.debug("######### Declaration submitted successfully")
       Created("")
     } recover {

--- a/app/test/controllers/TestingUtilitiesController.scala
+++ b/app/test/controllers/TestingUtilitiesController.scala
@@ -56,7 +56,7 @@ class TestingUtilitiesController @Inject()(
   }
 
   private def callConnector(lrn: String, ducr: String, metaData: MetaData)(implicit hc: HeaderCarrier): Future[Result] =
-    connector.submitExportDeclaration(ducr, Some(lrn), metaData).map { _ =>
+    connector.submitExportDeclaration(ducr, Some(lrn), metaData.toXml).map { _ =>
       Logger.debug("######### Declaration submitted successfully")
       Created("")
     } recover {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,6 +91,7 @@ microservice {
 
     features {
       welsh-translation: false
+      use-new-wco-dec-mapping-strategy = enabled
       default: disabled
     }
 
@@ -108,6 +109,7 @@ hmrc-developers-hub.client-id = "customs-declare-exports-frontend"
 countryCodesCsvFilename = "mdg-country-codes.csv"
 countryCodesJsonFilename = "location-autocomplete-canonical-list.json"
 eu-country-codes-filename = "mdg-country-codes-eu.csv"
+
 
 metrics {
   name = ${appName}

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -16,7 +16,7 @@ object AppDependencies {
     "uk.gov.hmrc" %% "bootstrap-play-25" % "4.6.0",
     "uk.gov.hmrc" %% "play-language" % "3.4.0",
     "com.thoughtworks.xstream" % "xstream" % "1.4.10",
-    "uk.gov.hmrc" %% "wco-dec" % "0.29.0",
+    "uk.gov.hmrc" %% "wco-dec" % "0.30.0",
     "ai.x"         %% "play-json-extensions" % "0.9.0"
   )
 

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -46,7 +46,7 @@ import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAs
 import play.api.test.FakeRequest
 import play.filters.csrf.CSRF.Token
 import play.filters.csrf.{CSRFConfig, CSRFConfigProvider, CSRFFilter}
-import services.{CustomsCacheService, ItemsCachingService, NRSService}
+import services._
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.http.SessionKeys
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -72,7 +72,8 @@ trait CustomExportsBaseSpec
       bind[CustomsDeclareExportsConnector].to(mockCustomsDeclareExportsConnector),
       bind[NrsConnector].to(mockNrsConnector),
       bind[NRSService].to(mockNrsService),
-      bind[ItemsCachingService].to(mockItemsCachingService)
+      bind[ItemsCachingService].to(mockItemsCachingService),
+      bind[WcoMetadataMapper].to(new WcoMetadataMapper with WcoMetadataJavaMappingStrategy)
     )
     .build()
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -41,6 +41,7 @@ class AppConfigSpec extends CustomExportsBaseSpec {
         |microservice.services.nrs.apikey=cds-exports
         |microservice.services.features.default=disabled
         |microservice.services.features.welsh-translation=false
+        |microservice.services.features.use-new-wco-dec-mapping-strategy=true
         |microservice.services.auth.port=9988
         |microservice.services.customs-declare-exports.host=localhoste
         |microservice.services.customs-declare-exports.port=9875
@@ -78,6 +79,12 @@ class AppConfigSpec extends CustomExportsBaseSpec {
 
     "have login URL" in {
       validConfigService.loginUrl must be("http://localhost:9949/auth-login-stub/gg-sign-in")
+    }
+
+    "have use-new-wco-dec-mapping-strategy feature flag set as true" in {
+      validConfigService.getConfBool("features.use-new-wco-dec-mapping-strategy", false) must be(
+        true
+      )
     }
 
     // what is continue URL - redirect ?
@@ -149,6 +156,12 @@ class AppConfigSpec extends CustomExportsBaseSpec {
       validConfigService.nrsApiKey must be("cds-exports")
     }
 
+  }
+
+  "when use-new-wco-dec-mapping-strategy feature flag is not defined, default to false" in {
+    emptyConfigService.getConfBool("features.use-new-wco-dec-mapping-strategy", false) must be(
+      false
+    )
   }
 
   "throw an exception when google-analytics.host is missing" in {

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -20,6 +20,7 @@ import base.CustomExportsBaseSpec
 import com.typesafe.config.{Config, ConfigFactory}
 import features.{Feature, FeatureStatus}
 import play.api.{Configuration, Environment}
+import services.{WcoMetadataJavaMappingStrategy, WcoMetadataScalaMappingStrategy}
 
 class AppConfigSpec extends CustomExportsBaseSpec {
 
@@ -81,10 +82,11 @@ class AppConfigSpec extends CustomExportsBaseSpec {
       validConfigService.loginUrl must be("http://localhost:9949/auth-login-stub/gg-sign-in")
     }
 
-    "have use-new-wco-dec-mapping-strategy feature flag set as true" in {
+    "create the WcoMetadataJavaMappingStrategy when use-new-wco-dec-mapping-strategy feature flag set as true" in {
       validConfigService.getConfBool("features.use-new-wco-dec-mapping-strategy", false) must be(
         true
       )
+      validConfigService.wcoMetadataMapper().isInstanceOf[WcoMetadataJavaMappingStrategy] must be(true)
     }
 
     // what is continue URL - redirect ?
@@ -158,10 +160,12 @@ class AppConfigSpec extends CustomExportsBaseSpec {
 
   }
 
-  "when use-new-wco-dec-mapping-strategy feature flag is not defined, default to false" in {
+  "create the WcoMetadataScalaMappingStrategy when use-new-wco-dec-mapping-strategy feature flag is not set" in {
     emptyConfigService.getConfBool("features.use-new-wco-dec-mapping-strategy", false) must be(
       false
     )
+
+    emptyConfigService.wcoMetadataMapper().isInstanceOf[WcoMetadataScalaMappingStrategy] must be(true)
   }
 
   "throw an exception when google-analytics.host is missing" in {

--- a/test/connectors/CustomsDeclareExportsConnectorSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorSpec.scala
@@ -42,7 +42,7 @@ class CustomsDeclareExportsConnectorSpec extends CustomExportsBaseSpec {
       )
 
       val client = new CustomsDeclareExportsConnector(appConfig, http)
-      val response = client.submitExportDeclaration("", None, metadata)(hc, ec)
+      val response = client.submitExportDeclaration("", None, metadata.toXml)(hc, ec)
 
       response.futureValue.status must be(ACCEPTED)
     }

--- a/test/connectors/CustomsDeclareExportsConnectorSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorSpec.scala
@@ -42,7 +42,7 @@ class CustomsDeclareExportsConnectorSpec extends CustomExportsBaseSpec {
       )
 
       val client = new CustomsDeclareExportsConnector(appConfig, http)
-      val response = client.submitExportDeclaration("", None, metadata.toXml)(hc, ec)
+      val response = client.submitExportDeclaration(Some(""), None, metadata.toXml)(hc, ec)
 
       response.futureValue.status must be(ACCEPTED)
     }

--- a/test/controllers/declaration/SummaryPageControllerWithScalaMappingSpec.scala
+++ b/test/controllers/declaration/SummaryPageControllerWithScalaMappingSpec.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declaration
+
+import connectors.{CustomsDeclareExportsConnector, NrsConnector}
+import play.api.Application
+import play.api.inject.bind
+import play.api.inject.guice.GuiceApplicationBuilder
+import services._
+import uk.gov.hmrc.auth.core.AuthConnector
+
+class SummaryPageControllerWithScalaMappingSpec extends SummaryPageControllerSpec {
+
+  override lazy val app: Application = GuiceApplicationBuilder()
+    .overrides(
+      bind[AuthConnector].to(mockAuthConnector),
+      bind[CustomsCacheService].to(mockCustomsCacheService),
+      bind[CustomsDeclareExportsConnector].to(mockCustomsDeclareExportsConnector),
+      bind[NrsConnector].to(mockNrsConnector),
+      bind[NRSService].to(mockNrsService),
+      bind[ItemsCachingService].to(mockItemsCachingService),
+      bind[WcoMetadataMapper].to(new WcoMetadataMapper with WcoMetadataScalaMappingStrategy)
+    )
+    .build()
+}

--- a/test/resources/wco_dec_metadata.xml
+++ b/test/resources/wco_dec_metadata.xml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<MetaData xmlns="urn:wco:datamodel:WCO:DocumentMetaData-DMS:2" xmlns:ns2="urn:wco:datamodel:WCO:Declaration_DS:DMS:2" xmlns:ns3="urn:wco:datamodel:WCO:DEC-DMS:2">
+    <WCODataModelVersionCode>3.6</WCODataModelVersionCode>
+    <WCOTypeName>DEC</WCOTypeName>
+    <ResponsibleCountryCode>GB</ResponsibleCountryCode>
+    <ResponsibleAgencyName>HMRC</ResponsibleAgencyName>
+    <AgencyAssignedCustomizationCode>v2.1</AgencyAssignedCustomizationCode>
+    <ns3:Declaration>
+        <ns3:FunctionCode>9</ns3:FunctionCode>
+        <ns3:FunctionalReferenceID>123ABC</ns3:FunctionalReferenceID>
+        <ns3:TypeCode>EXY</ns3:TypeCode>
+        <ns3:GoodsItemQuantity>123</ns3:GoodsItemQuantity>
+        <ns3:InvoiceAmount currencyID="GBP">1212312.12</ns3:InvoiceAmount>
+        <ns3:TotalPackageQuantity>123</ns3:TotalPackageQuantity>
+        <ns3:Agent>
+            <ns3:Name>Full Name</ns3:Name>
+            <ns3:ID>9GB1234567ABCDEF</ns3:ID>
+            <ns3:Address>
+                <ns3:CityName>Town or City</ns3:CityName>
+                <ns3:CountryCode>PL</ns3:CountryCode>
+                <ns3:Line>Address Line</ns3:Line>
+                <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
+            </ns3:Address>
+        </ns3:Agent>
+        <ns3:BorderTransportMeans>
+            <ns3:ID>1234567878ui</ns3:ID>
+            <ns3:IdentificationTypeCode>40</ns3:IdentificationTypeCode>
+            <ns3:RegistrationNationalityCode>PT</ns3:RegistrationNationalityCode>
+            <ns3:ModeCode>3</ns3:ModeCode>
+        </ns3:BorderTransportMeans>
+        <ns3:CurrencyExchange>
+            <ns3:RateNumeric>1212121.12345</ns3:RateNumeric>
+        </ns3:CurrencyExchange>
+        <ns3:Declarant>
+            <ns3:Name>Full Name</ns3:Name>
+            <ns3:Address>
+                <ns3:CityName>Town or City</ns3:CityName>
+                <ns3:CountryCode>PL</ns3:CountryCode>
+                <ns3:Line>Address Line</ns3:Line>
+                <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
+            </ns3:Address>
+        </ns3:Declarant>
+        <ns3:ExitOffice>
+            <ns3:ID>123qwe12</ns3:ID>
+        </ns3:ExitOffice>
+        <ns3:Exporter>
+            <ns3:Name>Full Name</ns3:Name>
+            <ns3:ID>9GB1234567ABCDEF</ns3:ID>
+            <ns3:Address>
+                <ns3:CityName>Town or City</ns3:CityName>
+                <ns3:CountryCode>PL</ns3:CountryCode>
+                <ns3:Line>Address Line</ns3:Line>
+                <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
+            </ns3:Address>
+        </ns3:Exporter>
+        <ns3:GoodsShipment>
+            <ns3:TransactionNatureCode>11</ns3:TransactionNatureCode>
+            <ns3:AEOMutualRecognitionParty>
+                <ns3:ID>eori1</ns3:ID>
+                <ns3:RoleCode>CS</ns3:RoleCode>
+            </ns3:AEOMutualRecognitionParty>
+            <ns3:Consignee>
+                <ns3:Name>Full Name</ns3:Name>
+                <ns3:ID>9GB1234567ABCDEF</ns3:ID>
+                <ns3:Address>
+                    <ns3:CityName>Town or City</ns3:CityName>
+                    <ns3:CountryCode>PL</ns3:CountryCode>
+                    <ns3:Line>Address Line</ns3:Line>
+                    <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
+                </ns3:Address>
+            </ns3:Consignee>
+            <ns3:Consignment>
+                <ns3:ContainerCode>1</ns3:ContainerCode>
+                <ns3:ArrivalTransportMeans>
+                    <ns3:ModeCode>1</ns3:ModeCode>
+                </ns3:ArrivalTransportMeans>
+                <ns3:DepartureTransportMeans>
+                    <ns3:ID>123112yu78</ns3:ID>
+                    <ns3:IdentificationTypeCode>40</ns3:IdentificationTypeCode>
+                </ns3:DepartureTransportMeans>
+                <ns3:GoodsLocation>
+                    <ns3:Name>Full Name</ns3:Name>
+                    <ns3:ID>9GB1234567ABCDEF</ns3:ID>
+                    <ns3:Address>
+                        <ns3:CityName>Town or City</ns3:CityName>
+                        <ns3:CountryCode>PL</ns3:CountryCode>
+                        <ns3:Line>Address Line</ns3:Line>
+                        <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
+                    </ns3:Address>
+                </ns3:GoodsLocation>
+            </ns3:Consignment>
+            <ns3:Destination>
+                <ns3:CountryCode>PL</ns3:CountryCode>
+                <ns3:RegionID/>
+            </ns3:Destination>
+            <ns3:ExportCountry>
+                <ns3:ID>PL</ns3:ID>
+            </ns3:ExportCountry>
+            <ns3:PreviousDocument>
+                <ns3:CategoryCode>X</ns3:CategoryCode>
+                <ns3:ID>DocumentReference</ns3:ID>
+                <ns3:TypeCode>ABC</ns3:TypeCode>
+                <ns3:LineNumeric>123</ns3:LineNumeric>
+            </ns3:PreviousDocument>
+            <ns3:UCR>
+                <ns3:ID/>
+                <ns3:TraderAssignedReferenceID>8GB123456789012-1234567890QWERTYUIO</ns3:TraderAssignedReferenceID>
+            </ns3:UCR>
+            <ns3:Warehouse>
+                <ns3:ID>1234567GB</ns3:ID>
+                <ns3:TypeCode>R</ns3:TypeCode>
+            </ns3:Warehouse>
+        </ns3:GoodsShipment>
+        <ns3:SupervisingOffice>
+            <ns3:ID>12345678</ns3:ID>
+        </ns3:SupervisingOffice>
+    </ns3:Declaration>
+</MetaData>

--- a/test/services/WcoMetadataJavaMappingStrategySpec.scala
+++ b/test/services/WcoMetadataJavaMappingStrategySpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services
+import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues
+import models.declaration.SupplementaryDeclarationDataSpec
+import org.scalatest.{Matchers, WordSpec}
+
+import scala.io.Source
+
+class WcoMetadataJavaMappingStrategySpec extends WordSpec with Matchers {
+
+  "WcoMetadataJavaMappingSpec" should {
+    "produce metadata" in {
+      val mapper = new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
+      val metaData = mapper.produceMetaData(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+
+      metaData.getWCOTypeName.getValue shouldBe SchemaMandatoryValues.wcoTypeName
+      metaData.getWCODataModelVersionCode.getValue shouldBe SchemaMandatoryValues.wcoDataModelVersionCode
+      metaData.getResponsibleAgencyName.getValue shouldBe SchemaMandatoryValues.responsibleAgencyName
+      metaData.getResponsibleCountryCode.getValue shouldBe SchemaMandatoryValues.responsibleCountryCode
+      metaData.getAgencyAssignedCustomizationCode.getValue shouldBe SchemaMandatoryValues.agencyAssignedCustomizationVersionCode
+      metaData.getAny should not be (null)
+    }
+
+    "retrieve a DUCR based on the produced metadata" in {
+      val mapper = new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
+      val metaData = mapper.produceMetaData(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+
+      mapper.declarationUcr(metaData) should be(Some("8GB123456789012-1234567890QWERTYUIO"))
+    }
+
+    "retrieve a LRN based on the produced metadata" in {
+      val mapper = new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
+      val metaData = mapper.produceMetaData(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+
+      mapper.declarationLrn(metaData) should be(Some("123ABC"))
+    }
+
+    "marshall the metadata correctly" in {
+      val mapper = new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
+      val metaData = mapper.produceMetaData(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+
+      mapper.toXml(metaData) should include(Source.fromURL(getClass.getResource("/wco_dec_metadata.xml")).mkString)
+    }
+  }
+}

--- a/test/services/mapping/MetaDataBuilderSpec.scala
+++ b/test/services/mapping/MetaDataBuilderSpec.scala
@@ -15,21 +15,23 @@
  */
 
 package services.mapping
+import javax.xml.bind.JAXBElement
 import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues
+import models.declaration.SupplementaryDeclarationDataSpec
 import org.scalatest.{Matchers, WordSpec}
+import wco.datamodel.wco.dec_dms._2.Declaration
 
 class MetaDataBuilderSpec extends WordSpec with Matchers {
 
   "MetaDataBuilder" should {
     "build wco MetaData with correct defaultValues" in {
-      val emptyDefaultMetaData = MetaDataBuilder.build
-      emptyDefaultMetaData.getWCOTypeName.getValue shouldBe SchemaMandatoryValues.wcoTypeName
-      emptyDefaultMetaData.getWCODataModelVersionCode.getValue shouldBe SchemaMandatoryValues.wcoDataModelVersionCode
-      emptyDefaultMetaData.getResponsibleAgencyName.getValue shouldBe SchemaMandatoryValues.responsibleAgencyName
-      emptyDefaultMetaData.getResponsibleCountryCode.getValue shouldBe SchemaMandatoryValues.responsibleCountryCode
-      emptyDefaultMetaData.getAgencyAssignedCustomizationCode.getValue shouldBe SchemaMandatoryValues.agencyAssignedCustomizationVersionCode
-
+      val metaData = MetaDataBuilder.build(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
+      metaData.getWCOTypeName.getValue shouldBe SchemaMandatoryValues.wcoTypeName
+      metaData.getWCODataModelVersionCode.getValue shouldBe SchemaMandatoryValues.wcoDataModelVersionCode
+      metaData.getResponsibleAgencyName.getValue shouldBe SchemaMandatoryValues.responsibleAgencyName
+      metaData.getResponsibleCountryCode.getValue shouldBe SchemaMandatoryValues.responsibleCountryCode
+      metaData.getAgencyAssignedCustomizationCode.getValue shouldBe SchemaMandatoryValues.agencyAssignedCustomizationVersionCode
+      metaData.getAny.asInstanceOf[JAXBElement[Declaration]].getValue should not be (null)
     }
   }
-
 }

--- a/test/services/mapping/XmlMarshallingSpec.scala
+++ b/test/services/mapping/XmlMarshallingSpec.scala
@@ -15,25 +15,19 @@
  */
 
 package services.mapping
+import models.declaration.SupplementaryDeclarationDataSpec
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
-import wco.datamodel.wco.dec_dms._2.Declaration
 import wco.datamodel.wco.documentmetadata_dms._2.MetaData
+
+import scala.io.Source
 
 class XmlMarshallingSpec extends WordSpec with Matchers with MockitoSugar {
 
-  val expectedPayload = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n" +
-    "<MetaData xmlns=\"urn:wco:datamodel:WCO:DocumentMetaData-DMS:2\">\n" +
-    "    <WCODataModelVersionCode>3.6</WCODataModelVersionCode>\n" +
-    "    <WCOTypeName>DEC</WCOTypeName>\n" +
-    "    <ResponsibleCountryCode>GB</ResponsibleCountryCode>\n" +
-    "    <ResponsibleAgencyName>HMRC</ResponsibleAgencyName>\n" +
-    "    <AgencyAssignedCustomizationCode>v2.1</AgencyAssignedCustomizationCode>\n" +
-    "</MetaData>\n"
-
   "XmlMarshalling" should {
     "generate correct xml payload for empty Metadata with defaults when marshalled" in {
-      val metaData = MetaDataBuilder.build()
+
+      val metaData = MetaDataBuilder.build(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
 
       import java.io.StringWriter
 
@@ -50,7 +44,7 @@ class XmlMarshallingSpec extends WordSpec with Matchers with MockitoSugar {
         jaxbMarshaller.marshal(metaData, sw)
         //Verify XML Content
         val xmlContent = sw.toString
-        xmlContent should be(expectedPayload)
+        xmlContent should include(Source.fromURL(getClass.getResource("/wco_dec_metadata.xml")).mkString)
       } catch {
         case e: JAXBException =>
           e.printStackTrace()


### PR DESCRIPTION
* **Add featureFlag to switch between WCO-DEC Mapping strategies**

* **Refactor `submitExportDeclaration` signature**
This is to ensure ease the creation of the WCO-DEC payload a avoid
leaking the logic on how to get the XML String payload into the
`CustomsDeclareExportsConnector.submitExportDeclaration` function.

* **Update wco-dec version to allow serialisation of WCO-DEC Declaration**

* **Map WCO-DEC Metadata based on a Mapping Strategy**
. There is never an elegant way to maintain backwards compatibility in
code, so this is the best attempt at it:
 Create a Java and Scala WCO-DEC Mapping classes
. Classes renamed to represent which model (Scala or Java) they are
mapping too. This is better than using "Old" and "New" naming
conventions.
. Having two mappers, for a Scala(old) and Java(new) models, allows us
to make use of the Strategy design pattern when time comes to marshall
the WCO-DEC declaration.
. Again the reason why going with a WCO-DEC Java model is due to ease
of serialization/deserialization.