### PR TITLE
CEDS-1146 Stop injecting the WcoMetadataMapper

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -23,7 +23,7 @@ import features.{Feature, FeatureStatus}
 import play.api.Mode.Mode
 import play.api.i18n.Lang
 import play.api.{Configuration, Environment}
-import services.{WcoMetadataJavaMappingStrategy, WcoMetadataMapper, WcoMetadataScalaMappingStrategy}
+import services.{WcoMetadataJavaMappingStrategy, WcoMetadataMapper, WcoMetadataMappingStrategy, WcoMetadataScalaMappingStrategy}
 import uk.gov.hmrc.play.config.{AppName, ServicesConfig}
 
 @Singleton
@@ -99,7 +99,7 @@ class AppConfig @Inject()(override val runModeConfiguration: Configuration, val 
   lazy val defaultFeatureStatus: features.FeatureStatus.Value =
     FeatureStatus.withName(loadConfig(feature2Key(Feature.default)))
 
-  def wcoMetadataMapper(): WcoMetadataMapper =
+  def wcoMetadataMapper(): WcoMetadataMapper with WcoMetadataMappingStrategy =
     if (useNewMappingStrategy)
       new WcoMetadataMapper with WcoMetadataJavaMappingStrategy
     else new WcoMetadataMapper with WcoMetadataScalaMappingStrategy

--- a/app/controllers/declaration/SummaryPageController.scala
+++ b/app/controllers/declaration/SummaryPageController.scala
@@ -30,7 +30,7 @@ import models.requests.JourneyRequest
 import play.api.Logger
 import play.api.i18n.{I18nSupport, MessagesApi}
 import play.api.mvc._
-import services.{CustomsCacheService, NRSService, WcoMetadataMapper}
+import services._
 import uk.gov.hmrc.http.cache.client.CacheMap
 import uk.gov.hmrc.http.{HeaderCarrier, HttpResponse}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
@@ -47,8 +47,7 @@ class SummaryPageController @Inject()(
   customsCacheService: CustomsCacheService,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   exportsMetrics: ExportsMetrics,
-  nrsService: NRSService,
-  wcoMetadataMapper: WcoMetadataMapper
+  nrsService: NRSService
 )(implicit ec: ExecutionContext)
     extends FrontendController with I18nSupport {
 
@@ -79,11 +78,12 @@ class SummaryPageController @Inject()(
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
     val timerContext = exportsMetrics.startTimer(submissionMetric)
 
-    val metaData = wcoMetadataMapper.getMetaData(cacheMap)
+    val mapper = appConfig.wcoMetadataMapper
+    val metaData = mapper.getMetaData(cacheMap)
 
-    val lrn = wcoMetadataMapper.getDeclarationLrn(metaData)
-    val ducr = wcoMetadataMapper.getDeclarationLrn(metaData)
-    val payload = wcoMetadataMapper.serialise(metaData)
+    val lrn = mapper.getDeclarationLrn(metaData)
+    val ducr = mapper.getDeclarationLrn(metaData)
+    val payload = mapper.serialise(metaData)
 
     customsDeclareExportsConnector
       .submitExportDeclaration(ducr, lrn, payload)

--- a/app/services/WcoMetadataMapper.scala
+++ b/app/services/WcoMetadataMapper.scala
@@ -23,11 +23,11 @@ class WcoMetadataMapper {
   self: WcoMetadataMappingStrategy =>
 
   def getMetaData(cacheMap: CacheMap): Any =
-    produceMetaData(cacheMap)
+    self.produceMetaData(cacheMap)
 
-  def getDeclarationUcr(metaData: Any): Option[String] = declarationUcr(metaData)
+  def getDeclarationUcr(metaData: Any): Option[String] = self.declarationUcr(metaData)
 
-  def getDeclarationLrn(metaData: Any): Option[String] = declarationLrn(metaData)
+  def getDeclarationLrn(metaData: Any): Option[String] = self.declarationLrn(metaData)
 
-  def serialise(metaData: Any): String = toXml(metaData)
+  def serialise(metaData: Any): String = self.toXml(metaData)
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -91,7 +91,7 @@ microservice {
 
     features {
       welsh-translation: false
-      use-new-wco-dec-mapping-strategy = enabled
+      use-new-wco-dec-mapping-strategy = false
       default: disabled
     }
 

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -72,8 +72,7 @@ trait CustomExportsBaseSpec
       bind[CustomsDeclareExportsConnector].to(mockCustomsDeclareExportsConnector),
       bind[NrsConnector].to(mockNrsConnector),
       bind[NRSService].to(mockNrsService),
-      bind[ItemsCachingService].to(mockItemsCachingService),
-      bind[WcoMetadataMapper].to(new WcoMetadataMapper with WcoMetadataJavaMappingStrategy)
+      bind[ItemsCachingService].to(mockItemsCachingService)
     )
     .build()
 


### PR DESCRIPTION
This was causing a ClassCastException only picked up when the
application was started, meaning the unit tests failed to pick this
problem.

Instead of using Dependency Injection on the controller we will instead
use the AppConfig to return an instance of the Mapping Strategy (each
one based on the Scala or Java model)