### PR TITLE
CEDS-1146 Fix null pointer exception if ItemType is None

### DIFF
--- a/app/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
+++ b/app/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilder.scala
@@ -48,7 +48,7 @@ object GovernmentAgencyGoodsItemBuilder {
 
     val statisticalValueAmountType = new GovernmentAgencyGoodsItemStatisticalValueAmountType
     statisticalValueAmountType.setCurrencyID(maybeStatisticalValueAmount.flatMap(_.currencyId).orNull)
-    statisticalValueAmountType.setValue(maybeStatisticalValueAmount.flatMap(_.value).orNull.bigDecimal)
+    statisticalValueAmountType.setValue(maybeStatisticalValueAmount.flatMap(_.value.map(_.bigDecimal)).orNull)
 
     wcoGovernmentAgencyGoodsItem.setSequenceNumeric(BigDecimal(governmentAgencyGoodsItem.sequenceNumeric).bigDecimal)
 

--- a/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
+++ b/test/services/mapping/governmentagencygoodsitem/GovernmentAgencyGoodsItemBuilderSpec.scala
@@ -18,6 +18,7 @@ package services.mapping.governmentagencygoodsitem
 
 import java.util
 
+import forms.declaration.ItemType
 import models.declaration.governmentagencygoodsitem.GovernmentAgencyGoodsItem
 import org.mockito.ArgumentMatchers.{any, eq => eqTo}
 import org.mockito.Mockito.when
@@ -26,9 +27,7 @@ import play.api.libs.json.Reads
 import services.ExportsItemsCacheIds
 import uk.gov.hmrc.http.cache.client.CacheMap
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.GovernmentAgencyGoodsItem._
-import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.{
-  GovernmentAgencyGoodsItem => WCOGovernmentAgencyGoodsItem
-}
+import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.{GovernmentAgencyGoodsItem => WCOGovernmentAgencyGoodsItem}
 class GovernmentAgencyGoodsItemBuilderSpec
     extends WordSpec with Matchers with GovernmentAgencyGoodsItemMocks with GovernmentAgencyGoodsItemData {
 
@@ -90,6 +89,14 @@ class GovernmentAgencyGoodsItemBuilderSpec
       validateCommodity(commodity)
       validatePackaging(firstPackaging)
       validateGovernmentProcedure(firstProcedure)
+
+    }
+
+    "map correctly if ItemType is None " in new SetUp() {
+
+      when(cacheMap.getEntry[ItemType](eqTo(ItemType.id))(any[Reads[ItemType]])).thenReturn(None)
+      val mappedGoodsItemList: List[WCOGovernmentAgencyGoodsItem] = GovernmentAgencyGoodsItemBuilder.build
+      mappedGoodsItemList.isEmpty shouldBe false
     }
   }
 


### PR DESCRIPTION
Invoking `bigDecimal` after `orNull`, if ItemType is None will cause a
NullPointerException.

I have added a unit test to replicate the issue.