### PR TITLE
CEDS-1146 Fix Empty values on new mapping strategy

### DIFF
--- a/app/forms/common/Address.scala
+++ b/app/forms/common/Address.scala
@@ -28,7 +28,10 @@ case class Address(
   townOrCity: String, // alphanumeric length 1 - 35
   postCode: String, // alphanumeric length 1 - 9
   country: String // full country name, convert to 2 upper case alphabetic characters for backend
-)
+) {
+  def isDefined(): Boolean =
+    fullName.nonEmpty || addressLine.nonEmpty || townOrCity.nonEmpty || postCode.nonEmpty || country.nonEmpty
+}
 
 object Address {
   implicit val format = Json.format[Address]

--- a/app/services/mapping/goodsshipment/ConsignmentBuilder.scala
+++ b/app/services/mapping/goodsshipment/ConsignmentBuilder.scala
@@ -28,89 +28,117 @@ import wco.datamodel.wco.declaration_ds.dms._2._
 
 object ConsignmentBuilder {
 
-  def build(implicit cacheMap: CacheMap): GoodsShipment.Consignment =
-    cacheMap
-      .getEntry[CarrierDetails](CarrierDetails.id)
-      .map(carrierDetails => createConsignmentAddress(carrierDetails.details))
-      .orNull
-
-  private def createConsignmentAddress(
-    details: EntityDetails
-  )(implicit cacheMap: CacheMap): GoodsShipment.Consignment = {
-    val id = new GoodsLocationIdentificationIDType()
-    id.setValue(details.eori.orNull)
-
-    val name = new GoodsLocationNameTextType()
-
-    val goodsAddress = new Consignment.GoodsLocation.Address()
-    details.address.map(address => {
-      name.setValue(address.fullName)
-
-      val line = new AddressLineTextType()
-      line.setValue(address.addressLine)
-
-      val city = new AddressCityNameTextType
-      city.setValue(address.townOrCity)
-
-      val postcode = new AddressPostcodeIDType()
-      postcode.setValue(address.postCode)
-
-      val countryCode = new AddressCountryCodeType
-      countryCode.setValue(
-        allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
-      )
-
-      goodsAddress.setLine(line)
-      goodsAddress.setCityName(city)
-      goodsAddress.setCountryCode(countryCode)
-      goodsAddress.setPostcodeID(postcode)
-    })
-
-    val goodsLocation = new GoodsShipment.Consignment.GoodsLocation()
-    goodsLocation.setID(id)
-    goodsLocation.setName(name)
-    goodsLocation.setAddress(goodsAddress)
-
+  def build(implicit cacheMap: CacheMap): GoodsShipment.Consignment = {
     val consignment = new GoodsShipment.Consignment()
-    consignment.setGoodsLocation(goodsLocation)
+
+    consignment.setGoodsLocation(buildGoodsLocation(cacheMap))
     consignment.setContainerCode(buildContainerCode)
     consignment.setArrivalTransportMeans(buildArrivalTransportMeans)
     consignment.setDepartureTransportMeans(buildDepartureTransportMeans())
     consignment
   }
 
+  private def buildGoodsLocation(cacheMap: CacheMap): Consignment.GoodsLocation =
+    cacheMap
+      .getEntry[CarrierDetails](CarrierDetails.id)
+      .filter(
+        carrierDetails =>
+          carrierDetails.details.eori.getOrElse("").nonEmpty ||
+            (carrierDetails.details.address.isDefined && carrierDetails.details.address.get.isDefined())
+      )
+      .map(carrierDetails => buildEoriOrAddress(carrierDetails.details))
+      .orNull
+
+  private def buildEoriOrAddress(details: EntityDetails) = {
+    val goodsLocation = new Consignment.GoodsLocation()
+    if (details.eori.getOrElse("").nonEmpty) {
+      val id = new GoodsLocationIdentificationIDType()
+      id.setValue(details.eori.orNull)
+      goodsLocation.setID(id)
+    } else {
+      val goodsAddress = new Consignment.GoodsLocation.Address()
+      details.address.map(address => {
+
+        if (address.fullName.nonEmpty) {
+          val name = new GoodsLocationNameTextType()
+          name.setValue(address.fullName)
+          goodsLocation.setName(name)
+        }
+
+        if (address.addressLine.nonEmpty) {
+          val line = new AddressLineTextType()
+          line.setValue(address.addressLine)
+          goodsAddress.setLine(line)
+        }
+
+        if (address.townOrCity.nonEmpty) {
+          val city = new AddressCityNameTextType
+          city.setValue(address.townOrCity)
+          goodsAddress.setCityName(city)
+        }
+
+        if (address.postCode.nonEmpty) {
+          val postcode = new AddressPostcodeIDType()
+          postcode.setValue(address.postCode)
+          goodsAddress.setPostcodeID(postcode)
+        }
+
+        if (address.country.nonEmpty) {
+          val countryCode = new AddressCountryCodeType
+          countryCode.setValue(
+            allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
+          )
+          goodsAddress.setCountryCode(countryCode)
+        }
+      })
+      goodsLocation.setAddress(goodsAddress)
+    }
+    goodsLocation
+  }
+
   private def buildDepartureTransportMeans()(implicit cacheMap: CacheMap): Consignment.DepartureTransportMeans =
     cacheMap
       .getEntry[TransportInformation](TransportInformation.id)
+      .filter(isTransportInformationDefined)
       .map(createDepartureTransportMeans)
       .orNull
 
+  private def isTransportInformationDefined(transportInformation: TransportInformation): Boolean =
+    transportInformation.meansOfTransportOnDepartureIDNumber.getOrElse("").nonEmpty ||
+      transportInformation.inlandModeOfTransportCode.getOrElse("").nonEmpty ||
+      transportInformation.meansOfTransportCrossingTheBorderType.nonEmpty
+
   private def createDepartureTransportMeans(data: TransportInformation): Consignment.DepartureTransportMeans = {
-    val id = new DepartureTransportMeansIdentificationIDType()
-    id.setValue(data.meansOfTransportOnDepartureIDNumber.getOrElse(""))
-
-    val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
-    identificationTypeCode.setValue(data.meansOfTransportCrossingTheBorderType)
-
     val departureTransportMeans = new DepartureTransportMeans()
-    departureTransportMeans.setID(id)
-    departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
+
+    val idValue = data.meansOfTransportOnDepartureIDNumber.getOrElse("")
+    if (idValue.nonEmpty) {
+      val id = new DepartureTransportMeansIdentificationIDType()
+      id.setValue(idValue)
+      departureTransportMeans.setID(id)
+    }
+
+    if (data.meansOfTransportCrossingTheBorderType.nonEmpty) {
+      val identificationTypeCode = new DepartureTransportMeansIdentificationTypeCodeType()
+      identificationTypeCode.setValue(data.meansOfTransportCrossingTheBorderType)
+      departureTransportMeans.setIdentificationTypeCode(identificationTypeCode)
+    }
+
     departureTransportMeans
   }
 
-  private def buildArrivalTransportMeans()(implicit cacheMap: CacheMap): Consignment.ArrivalTransportMeans = {
-    val modeCodeType = new ArrivalTransportMeansModeCodeType()
-    modeCodeType.setValue(
-      cacheMap
-        .getEntry[TransportInformation](TransportInformation.id)
-        .map(transportInformation => transportInformation.inlandModeOfTransportCode.getOrElse(""))
-        .getOrElse("")
-    )
-
-    val arrivalTransportMeans = new ArrivalTransportMeans()
-    arrivalTransportMeans.setModeCode(modeCodeType)
-    arrivalTransportMeans
-  }
+  private def buildArrivalTransportMeans()(implicit cacheMap: CacheMap): Consignment.ArrivalTransportMeans =
+    cacheMap
+      .getEntry[TransportInformation](TransportInformation.id)
+      .filter(_.inlandModeOfTransportCode.getOrElse("").nonEmpty)
+      .map(transportInformation => {
+        val arrivalTransportMeans = new ArrivalTransportMeans()
+        val modeCodeType = new ArrivalTransportMeansModeCodeType()
+        modeCodeType.setValue(transportInformation.inlandModeOfTransportCode.get)
+        arrivalTransportMeans.setModeCode(modeCodeType)
+        arrivalTransportMeans
+      })
+      .orNull
 
   private def buildContainerCode()(implicit cacheMap: CacheMap): ConsignmentContainerCodeType = {
     val codeType = new ConsignmentContainerCodeType()
@@ -122,4 +150,15 @@ object ConsignmentBuilder {
     )
     codeType
   }
+
+  private def isDefined(carrierDetails: CarrierDetails, cacheMap: CacheMap): Boolean =
+    carrierDetails.details.eori.getOrElse("").nonEmpty ||
+      (carrierDetails.details.address.isDefined && carrierDetails.details.address.get.isDefined()) ||
+      (cacheMap
+        .getEntry[TransportInformation](TransportInformation.id)
+        .isDefined && isTransportInformationDefined(
+        cacheMap
+          .getEntry[TransportInformation](TransportInformation.id)
+          .get
+      ))
 }

--- a/app/services/mapping/goodsshipment/DestinationBuilder.scala
+++ b/app/services/mapping/goodsshipment/DestinationBuilder.scala
@@ -20,15 +20,18 @@ import services.Countries.allCountries
 import uk.gov.hmrc.http.cache.client.CacheMap
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment.Destination
-import wco.datamodel.wco.declaration_ds.dms._2.{DestinationCountryCodeType, DestinationRegionIDType}
+import wco.datamodel.wco.declaration_ds.dms._2.DestinationCountryCodeType
 
 object DestinationBuilder {
 
   def build(implicit cacheMap: CacheMap): GoodsShipment.Destination =
     cacheMap
       .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
+      .filter(isDefined)
       .map(createExportCountry)
       .orNull
+
+  private def isDefined(country: DestinationCountriesSupplementary): Boolean = country.countryOfDestination.nonEmpty
 
   private def createExportCountry(data: DestinationCountriesSupplementary): GoodsShipment.Destination = {
 

--- a/app/services/mapping/goodsshipment/ExportCountryBuilder.scala
+++ b/app/services/mapping/goodsshipment/ExportCountryBuilder.scala
@@ -27,8 +27,11 @@ object ExportCountryBuilder {
   def build(implicit cacheMap: CacheMap): GoodsShipment.ExportCountry =
     cacheMap
       .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
+      .filter(isDefined)
       .map(createExportCountry)
       .orNull
+
+  private def isDefined(country: DestinationCountriesSupplementary): Boolean = country.countryOfDispatch.nonEmpty
 
   private def createExportCountry(data: DestinationCountriesSupplementary): GoodsShipment.ExportCountry = {
 

--- a/app/services/mapping/goodsshipment/TransactionNatureCodeBuilder.scala
+++ b/app/services/mapping/goodsshipment/TransactionNatureCodeBuilder.scala
@@ -25,8 +25,13 @@ object GoodsShipmentTransactionTypeBuilder {
   def build(implicit cacheMap: CacheMap): GoodsShipmentTransactionNatureCodeType =
     cacheMap
       .getEntry[TransactionType](TransactionType.formId)
+      .filter(transactionType => isDefined(transactionType))
       .map(createTransactionNatureCode)
       .orNull
+
+  private def isDefined(transactionType: TransactionType): Boolean =
+    transactionType.documentTypeCode.nonEmpty &&
+      transactionType.identifier.getOrElse("").nonEmpty
 
   private def createTransactionNatureCode(data: TransactionType): GoodsShipmentTransactionNatureCodeType = {
 

--- a/app/services/mapping/goodsshipment/UCRBuilder.scala
+++ b/app/services/mapping/goodsshipment/UCRBuilder.scala
@@ -26,22 +26,19 @@ object UCRBuilder {
   def build(implicit cacheMap: CacheMap): UCR =
     cacheMap
       .getEntry[ConsignmentReferences](ConsignmentReferences.id)
+      .filter(isDefined)
       .map(createUCR)
       .orNull
 
+  private def isDefined(reference: ConsignmentReferences): Boolean = reference.ducr.getOrElse(Ducr("")).ducr.nonEmpty
+
   private def createUCR(data: ConsignmentReferences): UCR = {
 
-    val ducr = data.ducr.getOrElse(Ducr("")).ducr
-    if (!ducr.isEmpty) {
+    val traderAssignedReferenceID = new UCRTraderAssignedReferenceIDType()
+    traderAssignedReferenceID.setValue(data.ducr.getOrElse(Ducr("")).ducr)
 
-      val traderAssignedReferenceID = new UCRTraderAssignedReferenceIDType()
-      traderAssignedReferenceID.setValue(ducr)
-
-      val warehouse = new UCR()
-      warehouse.setTraderAssignedReferenceID(traderAssignedReferenceID)
-      return warehouse
-    }
-    return null
+    val warehouse = new UCR()
+    warehouse.setTraderAssignedReferenceID(traderAssignedReferenceID)
+    warehouse
   }
-
 }

--- a/app/services/mapping/goodsshipment/WarehouseBuilder.scala
+++ b/app/services/mapping/goodsshipment/WarehouseBuilder.scala
@@ -25,20 +25,24 @@ object WarehouseBuilder {
   def build(implicit cacheMap: CacheMap): Warehouse =
     cacheMap
       .getEntry[WarehouseIdentification](WarehouseIdentification.formId)
+      .filter(isDefined)
       .map(createWarehouse)
       .orNull
 
+  private def isDefined(warehouse: WarehouseIdentification): Boolean =
+    warehouse.identificationNumber.getOrElse("").nonEmpty
+
   private def createWarehouse(data: WarehouseIdentification): Warehouse = {
+    val warehouse = new Warehouse()
 
     val id = new WarehouseIdentificationIDType()
     id.setValue(data.identificationNumber.map(_.drop(1).toString).getOrElse(""))
+    warehouse.setID(id)
 
     val typeCode = new WarehouseTypeCodeType()
     typeCode.setValue(data.identificationNumber.flatMap(_.headOption).fold("")(_.toString))
-
-    val warehouse = new Warehouse()
-    warehouse.setID(id)
     warehouse.setTypeCode(typeCode)
+
     warehouse
   }
 }

--- a/test/forms/declaration/DocumentSpec.scala
+++ b/test/forms/declaration/DocumentSpec.scala
@@ -105,8 +105,6 @@ object DocumentSpec {
     )
   )
 
-  val correctPreviousDocumentsJSONList = JsObject(Map("documents" -> JsArray(Seq(correctPreviousDocumentsJSON))))
-
   val emptyPreviousDocumentsJSON: JsValue = JsObject(
     Map(
       "documentCategory" -> JsString(""),
@@ -131,5 +129,8 @@ object DocumentSpec {
       "goodsItemIdentifier" -> JsString("Incorrect identifier")
     )
   )
+
+  val correctPreviousDocumentsJSONList = JsObject(Map("documents" -> JsArray(Seq(correctPreviousDocumentsJSON))))
+  val emptyPreviousDocumentsJSONList = JsObject(Map("documents" -> JsArray(Seq(emptyPreviousDocumentsJSON))))
 
 }

--- a/test/forms/declaration/EntityDetailsSpec.scala
+++ b/test/forms/declaration/EntityDetailsSpec.scala
@@ -237,7 +237,7 @@ object EntityDetailsSpec {
     Map("eori" -> JsString("9GB1234567ABCDEF"), "address" -> AddressSpec.addressWithEmptyFullnameJSON)
   )
   val correctEntityDetailsEORIOnlyJSON: JsValue = JsObject(
-    Map("eori" -> JsString("9GB1234567ABCDEF"), "address" -> JsString(""))
+    Map("eori" -> JsString("9GB1234567ABCDEF"), "address" -> AddressSpec.emptyAddressJSON)
   )
   val correctEntityDetailsAddressOnlyJSON: JsValue = JsObject(
     Map("eori" -> JsString(""), "address" -> AddressSpec.correctAddressJSON)
@@ -248,7 +248,7 @@ object EntityDetailsSpec {
       "address" -> AddressSpec.incorrectAddressJSON
     )
   )
-  val emptyEntityDetailsJSON: JsValue = JsObject(Map("eori" -> JsString(""), "address" -> JsString("")))
+  val emptyEntityDetailsJSON: JsValue = JsObject(Map("eori" -> JsString(""), "address" -> AddressSpec.emptyAddressJSON))
 
   def buildEntityInputMap(entityDetails: EntityDetails): Map[String, String] = buildEntityInputMap(
     eori = entityDetails.eori.getOrElse(""),

--- a/test/forms/declaration/TransportInformationSpec.scala
+++ b/test/forms/declaration/TransportInformationSpec.scala
@@ -36,4 +36,17 @@ object TransportInformationSpec {
         "container" -> JsBoolean(true)
       )
     )
+  val emptyTransportInformationJSON: JsValue =
+    JsObject(
+      Map(
+        "inlandModeOfTransportCode" -> JsString(""),
+        "borderModeOfTransportCode" -> JsString(""),
+        "meansOfTransportOnDepartureType" -> JsString(""),
+        "meansOfTransportOnDepartureIDNumber" -> JsString(""),
+        "meansOfTransportCrossingTheBorderType" -> JsString(""),
+        "meansOfTransportCrossingTheBorderIDNumber" -> JsString(""),
+        "meansOfTransportCrossingTheBorderNationality" -> JsString(""),
+        "container" -> JsBoolean(false)
+      )
+    )
 }

--- a/test/resources/wco_dec_metadata.xml
+++ b/test/resources/wco_dec_metadata.xml
@@ -60,14 +60,7 @@
                 <ns3:RoleCode>CS</ns3:RoleCode>
             </ns3:AEOMutualRecognitionParty>
             <ns3:Consignee>
-                <ns3:Name>Full Name</ns3:Name>
                 <ns3:ID>9GB1234567ABCDEF</ns3:ID>
-                <ns3:Address>
-                    <ns3:CityName>Town or City</ns3:CityName>
-                    <ns3:CountryCode>PL</ns3:CountryCode>
-                    <ns3:Line>Address Line</ns3:Line>
-                    <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
-                </ns3:Address>
             </ns3:Consignee>
             <ns3:Consignment>
                 <ns3:ContainerCode>1</ns3:ContainerCode>
@@ -79,14 +72,7 @@
                     <ns3:IdentificationTypeCode>40</ns3:IdentificationTypeCode>
                 </ns3:DepartureTransportMeans>
                 <ns3:GoodsLocation>
-                    <ns3:Name>Full Name</ns3:Name>
                     <ns3:ID>9GB1234567ABCDEF</ns3:ID>
-                    <ns3:Address>
-                        <ns3:CityName>Town or City</ns3:CityName>
-                        <ns3:CountryCode>PL</ns3:CountryCode>
-                        <ns3:Line>Address Line</ns3:Line>
-                        <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
-                    </ns3:Address>
                 </ns3:GoodsLocation>
             </ns3:Consignment>
             <ns3:Destination>

--- a/test/services/mapping/declaration/DeclarationBuilderSpec.scala
+++ b/test/services/mapping/declaration/DeclarationBuilderSpec.scala
@@ -84,22 +84,12 @@ class DeclarationBuilderSpec extends WordSpec with Matchers {
     declaration.getGoodsShipment.getTransactionNatureCode.getValue should be("11")
 
     declaration.getGoodsShipment.getConsignee.getID.getValue should be("9GB1234567ABCDEF")
-    declaration.getGoodsShipment.getConsignee.getName.getValue should be("Full Name")
-    declaration.getGoodsShipment.getConsignee.getAddress.getLine.getValue should be("Address Line")
-    declaration.getGoodsShipment.getConsignee.getAddress.getCityName.getValue should be("Town or City")
-    declaration.getGoodsShipment.getConsignee.getAddress.getCountryCode.getValue should be("PL")
-    declaration.getGoodsShipment.getConsignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+    declaration.getGoodsShipment.getConsignee.getName should be(null)
+    declaration.getGoodsShipment.getConsignee.getAddress should be(null)
 
     declaration.getGoodsShipment.getConsignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
-    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getName.getValue should be("Full Name")
-    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
-    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getAddress.getCityName.getValue should be(
-      "Town or City"
-    )
-    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
-    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be(
-      "AB12 34CD"
-    )
+    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getName should be(null)
+    declaration.getGoodsShipment.getConsignment.getGoodsLocation.getAddress should be(null)
 
     declaration.getGoodsShipment.getDestination.getCountryCode.getValue should be("PL")
 

--- a/test/services/mapping/goodsshipment/AEOMutualRecognitionPartiesBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/AEOMutualRecognitionPartiesBuilderSpec.scala
@@ -20,30 +20,71 @@ import models.declaration.{DeclarationAdditionalActorsData, DeclarationAdditiona
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class AEOMutualRecognitionPartiesBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
   "AEOMutualRecognitionPartiesBuilder " should {
-    "correctly map to a WCO-DEC GoodsShipment.AEOMutualRecognitionParties instance" in {
-      implicit val cacheMap: CacheMap =
-        CacheMap(
-          "CacheID",
-          Map(DeclarationAdditionalActors.formId -> DeclarationAdditionalActorsDataSpec.correctAdditionalActorsDataJSON)
-        )
-      val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
-      actors.size should be(1)
-      actors.get(0).getID.getValue should be("eori1")
-      actors.get(0).getRoleCode.getValue should be("CS")
-    }
+    "correctly map to a WCO-DEC GoodsShipment.AEOMutualRecognitionParties instance" when {
+      "all data has been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              DeclarationAdditionalActors.formId -> DeclarationAdditionalActorsDataSpec.correctAdditionalActorsDataJSON
+            )
+          )
+        val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
+        actors.size should be(1)
+        actors.get(0).getID.getValue should be("eori1")
+        actors.get(0).getRoleCode.getValue should be("CS")
+      }
 
-    "handle empty documents when mapping to WCO-DEC GoodsShipment.AEOMutualRecognitionParties" in {
-      implicit val cacheMap: CacheMap = mock[CacheMap]
-      when(cacheMap.getEntry[DeclarationAdditionalActorsData](DeclarationAdditionalActors.formId))
-        .thenReturn(None)
+      "'eori' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(DeclarationAdditionalActors.formId -> setupCacheData(eori = "")))
+        val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
+        actors.size should be(1)
+        actors.get(0).getID should be(null)
+        actors.get(0).getRoleCode.getValue should be("CS")
+      }
 
-      val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
-      actors.isEmpty shouldBe true
+      "'partyType' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(DeclarationAdditionalActors.formId -> setupCacheData(partyType = "")))
+        val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
+        actors.size should be(1)
+        actors.get(0).getID.getValue should be("eori1")
+        actors.get(0).getRoleCode should be(null)
+      }
+
+      "handle no documents when mapping to WCO-DEC GoodsShipment.AEOMutualRecognitionParties" in {
+        implicit val cacheMap: CacheMap = mock[CacheMap]
+        when(cacheMap.getEntry[DeclarationAdditionalActorsData](DeclarationAdditionalActors.formId))
+          .thenReturn(None)
+
+        val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
+        actors.isEmpty shouldBe true
+      }
+
+      "handle empty documents when mapping to WCO-DEC GoodsShipment.AEOMutualRecognitionParties" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(DeclarationAdditionalActors.formId -> DeclarationAdditionalActorsDataSpec.emptyAdditionalActorsDataJSON)
+          )
+        val actors = AEOMutualRecognitionPartiesBuilder.build(cacheMap)
+        actors.isEmpty shouldBe true
+      }
     }
   }
+
+  private def setupCacheData(eori: String = "eori1", partyType: String = "CS") = {
+    val objectJson: JsValue = JsObject(Map("eori" -> JsString(eori), "partyType" -> JsString(partyType)))
+
+    val objectsJSONList = JsObject(Map("actors" -> JsArray(Seq(objectJson))))
+    objectsJSONList
+  }
+
 }

--- a/test/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ConsigneeBuilderSpec.scala
@@ -18,17 +18,27 @@ package services.mapping.goodsshipment
 
 import forms.declaration.{ConsigneeDetails, ConsigneeDetailsSpec}
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsObject, JsString, JsValue}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class ConsigneeBuilderSpec extends WordSpec with Matchers {
 
   "ConsigneeBuilder" should {
     "correctly map to the WCO-DEC GoodsShipment.Consignee instance" when {
-      "all data is supplied " in {
+      "only eori is supplied " in {
         implicit val cacheMap: CacheMap =
-          CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.correctConsigneeDetailsJSON))
+          CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.correctConsigneeDetailsEORIOnlyJSON))
         val consignee = ConsigneeBuilder.build(cacheMap)
         consignee.getID.getValue should be("9GB1234567ABCDEF")
+        consignee.getName should be(null)
+        consignee.getAddress should be(null)
+      }
+
+      "only address is supplied " in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.correctConsigneeDetailsAddressOnlyJSON))
+        val consignee = ConsigneeBuilder.build(cacheMap)
+        consignee.getID should be(null)
         consignee.getName.getValue should be("Full Name")
         consignee.getAddress.getLine.getValue should be("Address Line")
         consignee.getAddress.getCityName.getValue should be("Town or City")
@@ -36,17 +46,50 @@ class ConsigneeBuilderSpec extends WordSpec with Matchers {
         consignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
       }
 
-      "fullname is not supplied" in {
+      "empty data is supplied " in {
         implicit val cacheMap: CacheMap =
-          CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.entityDetailsWithEmptyFullNameJSON))
+          CacheMap("CacheID", Map(ConsigneeDetails.id -> ConsigneeDetailsSpec.emptyConsigneeDetailsJSON))
+        ConsigneeBuilder.build(cacheMap) should be(null)
+      }
+
+      "'address.fullname' is not supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(ConsigneeDetails.id -> setupCacheData(eori = "", fullName = "")))
         val consignee = ConsigneeBuilder.build(cacheMap)
-        consignee.getID.getValue should be("9GB1234567ABCDEF")
+        consignee.getID should be(null)
         consignee.getName should be(null)
         consignee.getAddress.getLine.getValue should be("Address Line")
         consignee.getAddress.getCityName.getValue should be("Town or City")
-        consignee.getAddress.getCountryCode.getValue should be("PL")
+        consignee.getAddress.getCountryCode.getValue should be("PT")
         consignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
       }
     }
+  }
+
+  private def setupCacheData(
+    eori: String = "9GB1234567ABCDEF",
+    fullName: String = "fullname",
+    addressLine: String = "Address Line",
+    townOrCity: String = "Town or City",
+    postCode: String = "AB12 34CD",
+    country: String = "Portugal"
+  ) = {
+    val objectJson: JsValue = JsObject(
+      Map(
+        "eori" -> JsString(eori),
+        "address" -> JsObject(
+          Map(
+            "fullName" -> JsString(fullName),
+            "addressLine" -> JsString(addressLine),
+            "townOrCity" -> JsString(townOrCity),
+            "postCode" -> JsString(postCode),
+            "country" -> JsString(country)
+          )
+        )
+      )
+    )
+
+    val objectsJSONList = JsObject(Map("details" -> objectJson))
+    objectsJSONList
   }
 }

--- a/test/services/mapping/goodsshipment/ConsignmentBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ConsignmentBuilderSpec.scala
@@ -23,30 +23,93 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 class ConsignmentBuilderSpec extends WordSpec with Matchers {
 
   "ConsignmentBuilder" should {
-    "correctly map to the WCO-DEC GoodsShipment.Consignment instance" in {
-      implicit val cacheMap: CacheMap =
-        CacheMap(
-          "CacheID",
-          Map(
-            CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsJSON,
-            TransportInformation.id -> TransportInformationSpec.correctTransportInformationJSON
+    "correctly map to the WCO-DEC GoodsShipment.Consignment instance" when {
+      "all data has been supplied with eori only" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsEORIOnlyJSON,
+              TransportInformation.id -> TransportInformationSpec.correctTransportInformationJSON
+            )
           )
-        )
-      val consignment = ConsignmentBuilder.build(cacheMap)
-      consignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
-      consignment.getGoodsLocation.getName.getValue should be("Full Name")
+        val consignment = ConsignmentBuilder.build(cacheMap)
+        consignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
 
-      consignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
-      consignment.getGoodsLocation.getAddress.getCityName.getValue should be("Town or City")
-      consignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
-      consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
-      consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+        consignment.getGoodsLocation.getName should be(null)
+        consignment.getGoodsLocation.getAddress should be(null)
 
-      consignment.getContainerCode.getValue should be("1")
+        consignment.getContainerCode.getValue should be("1")
 
-      consignment.getArrivalTransportMeans.getModeCode.getValue should be("1")
-      consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
-      consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+        consignment.getArrivalTransportMeans.getModeCode.getValue should be("1")
+        consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
+        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+      }
+      "all data has been supplied with address only" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsAddressOnlyJSON,
+              TransportInformation.id -> TransportInformationSpec.correctTransportInformationJSON
+            )
+          )
+        val consignment = ConsignmentBuilder.build(cacheMap)
+        consignment.getGoodsLocation.getID should be(null)
+        consignment.getGoodsLocation.getName.getValue should be("Full Name")
+
+        consignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
+        consignment.getGoodsLocation.getAddress.getCityName.getValue should be("Town or City")
+        consignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
+        consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+        consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+
+        consignment.getContainerCode.getValue should be("1")
+
+        consignment.getArrivalTransportMeans.getModeCode.getValue should be("1")
+        consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
+        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+      }
+
+      "no carrier data has been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              CarrierDetails.id -> CarrierDetailsSpec.emptyCarrierDetailsJSON,
+              TransportInformation.id -> TransportInformationSpec.correctTransportInformationJSON
+            )
+          )
+        val consignment = ConsignmentBuilder.build(cacheMap)
+        consignment.getGoodsLocation should be(null)
+
+        consignment.getContainerCode.getValue should be("1")
+
+        consignment.getArrivalTransportMeans.getModeCode.getValue should be("1")
+        consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
+        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+      }
+
+      "no transport information data has been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsEORIOnlyJSON,
+              TransportInformation.id -> TransportInformationSpec.emptyTransportInformationJSON
+            )
+          )
+        val consignment = ConsignmentBuilder.build(cacheMap)
+        consignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
+
+        consignment.getGoodsLocation.getName should be(null)
+        consignment.getGoodsLocation.getAddress should be(null)
+
+        consignment.getContainerCode.getValue should be("0")
+
+        consignment.getArrivalTransportMeans should be(null)
+        consignment.getDepartureTransportMeans should be(null)
+      }
     }
   }
 }

--- a/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
@@ -19,22 +19,33 @@ package services.mapping.goodsshipment
 import forms.declaration.DestinationCountriesSupplementarySpec
 import forms.declaration.destinationCountries.DestinationCountries
 import org.scalatest.{Matchers, WordSpec}
-
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class DestinationBuilderSpec extends WordSpec with Matchers {
 
   "DestinationBuilder" should {
-    "correctly map to the WCO-DEC GoodsShipment.Destination instance" in {
-      implicit val cacheMap: CacheMap =
-        CacheMap(
-          "CacheID",
-          Map(
-            DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+    "correctly map to the WCO-DEC GoodsShipment.Destination instance" when {
+      "countryOfDestination has been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+            )
           )
-        )
-      val destination = DestinationBuilder.build(cacheMap)
-      destination.getCountryCode.getValue should be("PL")
+        val destination = DestinationBuilder.build(cacheMap)
+        destination.getCountryCode.getValue should be("PL")
+      }
+      "countryOfDestination has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.emptyDestinationCountriesSupplementaryJSON
+            )
+          )
+        DestinationBuilder.build(cacheMap) should be(null)
+      }
     }
   }
 }

--- a/test/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/ExportCountryBuilderSpec.scala
@@ -24,16 +24,28 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 class ExportCountryBuilderSpec extends WordSpec with Matchers {
 
   "ExportCountryBuilder" should {
-    "correctly map to the WCO-DEC GoodsShipment.ExportCountries instance" in {
-      implicit val cacheMap: CacheMap =
-        CacheMap(
-          "CacheID",
-          Map(
-            DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+    "correctly map to the WCO-DEC GoodsShipment.ExportCountries instance" when {
+      "countryOfDispatch has been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+            )
           )
-        )
-      val obj = ExportCountryBuilder.build(cacheMap)
-      obj.getID.getValue should be("PL")
+        val obj = ExportCountryBuilder.build(cacheMap)
+        obj.getID.getValue should be("PL")
+      }
+      "countryOfDispatch has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.emptyDestinationCountriesSupplementaryJSON
+            )
+          )
+        ExportCountryBuilder.build(cacheMap) should be(null)
+      }
     }
   }
 }

--- a/test/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/GoodsShipmentBuilderSpec.scala
@@ -27,18 +27,12 @@ class GoodsShipmentBuilderSpec extends WordSpec with Matchers {
       goodsShipment.getTransactionNatureCode.getValue should be("11")
 
       goodsShipment.getConsignee.getID.getValue should be("9GB1234567ABCDEF")
-      goodsShipment.getConsignee.getName.getValue should be("Full Name")
-      goodsShipment.getConsignee.getAddress.getLine.getValue should be("Address Line")
-      goodsShipment.getConsignee.getAddress.getCityName.getValue should be("Town or City")
-      goodsShipment.getConsignee.getAddress.getCountryCode.getValue should be("PL")
-      goodsShipment.getConsignee.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+      goodsShipment.getConsignee.getName should be(null)
+      goodsShipment.getConsignee.getAddress should be(null)
 
       goodsShipment.getConsignment.getGoodsLocation.getID.getValue should be("9GB1234567ABCDEF")
-      goodsShipment.getConsignment.getGoodsLocation.getName.getValue should be("Full Name")
-      goodsShipment.getConsignment.getGoodsLocation.getAddress.getLine.getValue should be("Address Line")
-      goodsShipment.getConsignment.getGoodsLocation.getAddress.getCityName.getValue should be("Town or City")
-      goodsShipment.getConsignment.getGoodsLocation.getAddress.getCountryCode.getValue should be("PL")
-      goodsShipment.getConsignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+      goodsShipment.getConsignment.getGoodsLocation.getName should be(null)
+      goodsShipment.getConsignment.getGoodsLocation.getAddress should be(null)
 
       goodsShipment.getDestination.getCountryCode.getValue should be("PL")
 

--- a/test/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/PreviousDocumentsBuilderSpec.scala
@@ -20,6 +20,7 @@ import forms.declaration.{Document, DocumentSpec, PreviousDocumentsData}
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class PreviousDocumentsBuilderSpec extends WordSpec with Matchers with MockitoSugar {
@@ -36,13 +37,85 @@ class PreviousDocumentsBuilderSpec extends WordSpec with Matchers with MockitoSu
       previousDoc.get(0).getTypeCode.getValue should be("ABC")
     }
 
-    "handle empty documents when mapping to WCO-DEC GoodsShipment.PreviousDocuments" in {
+    "handle no documents when mapping to WCO-DEC GoodsShipment.PreviousDocuments" in {
       implicit val cacheMap: CacheMap = mock[CacheMap]
       when(cacheMap.getEntry[PreviousDocumentsData](Document.formId))
         .thenReturn(None)
 
-      val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
-      previousDoc.isEmpty shouldBe true
+      PreviousDocumentsBuilder.build(cacheMap).isEmpty shouldBe true
     }
+
+    "handle empty documents when mapping to WCO-DEC GoodsShipment.PreviousDocuments" in {
+      implicit val cacheMap: CacheMap =
+        CacheMap("CacheID", Map(Document.formId -> DocumentSpec.emptyPreviousDocumentsJSONList))
+
+      PreviousDocumentsBuilder.build(cacheMap).isEmpty shouldBe true
+    }
+
+    "handle documents mapping to WCO-DEC GoodsShipment.PreviousDocuments" when {
+      "'lineNumeric' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(Document.formId -> setupCacheData(goodsItemIdentifier = "")))
+
+        val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+        previousDoc.size should be(1)
+        previousDoc.get(0).getID.getValue should be("DocumentReference")
+        previousDoc.get(0).getCategoryCode.getValue should be("X")
+        previousDoc.get(0).getTypeCode.getValue should be("ABC")
+        previousDoc.get(0).getLineNumeric should be(null)
+      }
+      "'documentType' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(Document.formId -> setupCacheData(documentType = "")))
+
+        val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+        previousDoc.size should be(1)
+        previousDoc.get(0).getID.getValue should be("DocumentReference")
+        previousDoc.get(0).getCategoryCode.getValue should be("X")
+        previousDoc.get(0).getTypeCode should be(null)
+        previousDoc.get(0).getLineNumeric.doubleValue() should be(10.0)
+      }
+      "'documentReference' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(Document.formId -> setupCacheData(documentReference = "")))
+
+        val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+        previousDoc.size should be(1)
+        previousDoc.get(0).getID should be(null)
+        previousDoc.get(0).getCategoryCode.getValue should be("X")
+        previousDoc.get(0).getTypeCode.getValue should be("ABC")
+        previousDoc.get(0).getLineNumeric.doubleValue() should be(10.0)
+      }
+      "'documentCategory' has not been supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap("CacheID", Map(Document.formId -> setupCacheData(documentCategory = "")))
+
+        val previousDoc = PreviousDocumentsBuilder.build(cacheMap)
+        previousDoc.size should be(1)
+        previousDoc.get(0).getID.getValue should be("DocumentReference")
+        previousDoc.get(0).getCategoryCode should be(null)
+        previousDoc.get(0).getTypeCode.getValue should be("ABC")
+        previousDoc.get(0).getLineNumeric.doubleValue() should be(10.0)
+      }
+    }
+  }
+
+  private def setupCacheData(
+    documentCategory: String = "X",
+    documentType: String = "ABC",
+    documentReference: String = "DocumentReference",
+    goodsItemIdentifier: String = "10.0"
+  ) = {
+    val previousDocumentsJSON: JsValue = JsObject(
+      Map(
+        "documentCategory" -> JsString(documentCategory),
+        "documentType" -> JsString(documentType),
+        "documentReference" -> JsString(documentReference),
+        "goodsItemIdentifier" -> JsString(goodsItemIdentifier)
+      )
+    )
+
+    val previousDocumentsJSONList = JsObject(Map("documents" -> JsArray(Seq(previousDocumentsJSON))))
+    previousDocumentsJSONList
   }
 }

--- a/test/services/mapping/goodsshipment/TransactionTypeBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/TransactionTypeBuilderSpec.scala
@@ -23,11 +23,18 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 class TransactionTypeBuilderSpec extends WordSpec with Matchers {
 
   "TransactionTypeBuilder" should {
-    "correctly map to the WCO-DEC GoodsShipment.TransactionNatureCodeType instance" in {
-      implicit val cacheMap =
-        CacheMap("CacheID", Map(TransactionType.formId -> TransactionTypeSpec.correctTransactionTypeJSON))
-      val transactionNatureCodeType = GoodsShipmentTransactionTypeBuilder.build(cacheMap)
-      transactionNatureCodeType.getValue should be("11")
+    "correctly map to the WCO-DEC GoodsShipment.TransactionNatureCodeType instance" when {
+      "'identifier' has been supplied" in {
+        implicit val cacheMap =
+          CacheMap("CacheID", Map(TransactionType.formId -> TransactionTypeSpec.correctTransactionTypeJSON))
+        val transactionNatureCodeType = GoodsShipmentTransactionTypeBuilder.build(cacheMap)
+        transactionNatureCodeType.getValue should be("11")
+      }
+      "'identifier' has not been supplied" in {
+        implicit val cacheMap =
+          CacheMap("CacheID", Map(TransactionType.formId -> TransactionTypeSpec.emptyTransactionTypeJSON))
+        GoodsShipmentTransactionTypeBuilder.build(cacheMap) should be(null)
+      }
     }
   }
 }

--- a/test/services/mapping/goodsshipment/UCRBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/UCRBuilderSpec.scala
@@ -17,10 +17,12 @@
 package services.mapping.goodsshipment
 
 import forms.declaration.{ConsignmentReferences, ConsignmentReferencesSpec}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-class UCRBuilderSpec extends WordSpec with Matchers {
+class UCRBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
   "UCRBuilder" should {
     "correctly map to the WCO-DEC GoodsShipment.UCR instance" when {
@@ -39,9 +41,16 @@ class UCRBuilderSpec extends WordSpec with Matchers {
       "ducr not supplied" in {
         implicit val cacheMap =
           CacheMap("CacheID", Map(ConsignmentReferences.id -> ConsignmentReferencesSpec.emptyConsignmentReferencesJSON))
-        val ucrObject = UCRBuilder.build(cacheMap)
-        ucrObject should be(null)
+        UCRBuilder.build(cacheMap) should be(null)
       }
+
+      "Nothing is supplied" in {
+        implicit val cacheMap: CacheMap = mock[CacheMap]
+        when(cacheMap.getEntry[ConsignmentReferences](ConsignmentReferences.id))
+          .thenReturn(None)
+        UCRBuilder.build(cacheMap) should be(null)
+      }
+
     }
   }
 }

--- a/test/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/WarehouseBuilderSpec.scala
@@ -17,21 +17,42 @@
 package services.mapping.goodsshipment
 
 import forms.declaration.{WarehouseIdentification, WarehouseIdentificationSpec}
+import org.mockito.Mockito.when
+import org.scalatest.mockito.MockitoSugar
 import org.scalatest.{Matchers, WordSpec}
 import uk.gov.hmrc.http.cache.client.CacheMap
 
-class WarehouseBuilderSpec extends WordSpec with Matchers {
+class WarehouseBuilderSpec extends WordSpec with Matchers with MockitoSugar {
 
   "WarehouseBuilder" should {
-    "correctly map to the WCO-DEC Warehouse instance" in {
-      implicit val cacheMap =
-        CacheMap(
-          "CacheID",
-          Map(WarehouseIdentification.formId -> WarehouseIdentificationSpec.correctWarehouseIdentificationJSON)
-        )
-      val warehouse = WarehouseBuilder.build(cacheMap)
-      warehouse.getID.getValue should be("1234567GB")
-      warehouse.getTypeCode.getValue should be("R")
+    "correctly map to the WCO-DEC Warehouse instance" when {
+      "identificationNumber is supplied" in {
+        implicit val cacheMap =
+          CacheMap(
+            "CacheID",
+            Map(WarehouseIdentification.formId -> WarehouseIdentificationSpec.correctWarehouseIdentificationJSON)
+          )
+        val warehouse = WarehouseBuilder.build(cacheMap)
+        warehouse.getID.getValue should be("1234567GB")
+        warehouse.getTypeCode.getValue should be("R")
+      }
+
+      "identificationNumber is not supplied" in {
+        implicit val cacheMap =
+          CacheMap(
+            "CacheID",
+            Map(WarehouseIdentification.formId -> WarehouseIdentificationSpec.emptyWarehouseIdentificationJSON)
+          )
+        WarehouseBuilder.build(cacheMap) should be(null)
+      }
+
+      "Nothing is supplied" in {
+        implicit val cacheMap: CacheMap = mock[CacheMap]
+        when(cacheMap.getEntry[WarehouseIdentification](WarehouseIdentification.formId))
+          .thenReturn(None)
+        WarehouseBuilder.build(cacheMap) should be(null)
+      }
+
     }
   }
 }


### PR DESCRIPTION
If empty fields/strings reach the mapping strategy we should not
instantiate new instances as it will cause the WCO-DEC schema to fail