### PR TITLE
CEDS-1143 Check the form validation and align the mapping

### DIFF
--- a/app/services/WcoMetadataJavaMappingStrategy.scala
+++ b/app/services/WcoMetadataJavaMappingStrategy.scala
@@ -27,8 +27,8 @@ trait WcoMetadataJavaMappingStrategy extends WcoMetadataMappingStrategy {
   override def produceMetaData(cacheMap: CacheMap): MetaData =
     MetaDataBuilder.build(cacheMap)
 
-  override def declarationUcr(metaData: Any): Option[String] =
-    Option(
+  override def declarationUcr(metaData: Any): Option[String] = {
+    val ucr = Option(
       metaData
         .asInstanceOf[MetaData]
         .getAny
@@ -36,9 +36,12 @@ trait WcoMetadataJavaMappingStrategy extends WcoMetadataMappingStrategy {
         .getValue
         .getGoodsShipment
         .getUCR
-        .getTraderAssignedReferenceID
-        .getValue
-    ).orElse(Some(""))
+    )
+
+    ucr
+      .map(_.getTraderAssignedReferenceID.getValue)
+      .orElse(Some(""))
+  }
 
   override def declarationLrn(metaData: Any): Option[String] =
     Option(

--- a/app/services/mapping/declaration/AgentBuilder.scala
+++ b/app/services/mapping/declaration/AgentBuilder.scala
@@ -28,47 +28,51 @@ object AgentBuilder {
   def build(implicit cacheMap: CacheMap): Declaration.Agent =
     cacheMap
       .getEntry[RepresentativeDetails](RepresentativeDetails.formId)
-      .map(data => createAgent(data.details.orNull))
+      .filter(isDefined)
+      .map(data => createAgent(data.details.get))
       .orNull
+
+  private def isDefined(representativeDetails: RepresentativeDetails): Boolean =
+    representativeDetails.details.isDefined && (representativeDetails.details.get.eori.isDefined || representativeDetails.details.get.address.isDefined)
 
   private def createAgent(details: EntityDetails): Declaration.Agent = {
     val agent = new Declaration.Agent()
 
-    val agentId = new AgentIdentificationIDType()
-    agentId.setValue(details.eori.orNull)
-    agent.setID(agentId)
+    if (details.eori.isDefined) {
+      val agentId = new AgentIdentificationIDType()
+      agentId.setValue(details.eori.get)
+      agent.setID(agentId)
+    } else {
 
-    val agentAddress = new Agent.Address()
+      val agentAddress = new Agent.Address()
 
-    details.address.map(address => {
+      details.address.map(address => {
 
-      if (!Option(address.fullName).getOrElse("").isEmpty) {
         val agentName = new AgentNameTextType()
         agentName.setValue(address.fullName)
+
+        val line = new AddressLineTextType()
+        line.setValue(address.addressLine)
+
+        val city = new AddressCityNameTextType
+        city.setValue(address.townOrCity)
+
+        val postcode = new AddressPostcodeIDType()
+        postcode.setValue(address.postCode)
+
+        val countryCode = new AddressCountryCodeType
+        countryCode.setValue(
+          allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
+        )
+
         agent.setName(agentName)
-      }
-
-      val line = new AddressLineTextType()
-      line.setValue(address.addressLine)
-
-      val city = new AddressCityNameTextType
-      city.setValue(address.townOrCity)
-
-      val postcode = new AddressPostcodeIDType()
-      postcode.setValue(address.postCode)
-
-      val countryCode = new AddressCountryCodeType
-      countryCode.setValue(
-        allCountries.find(country => address.country.contains(country.countryName)).map(_.countryCode).getOrElse("")
-      )
-
-      agentAddress.setLine(line)
-      agentAddress.setCityName(city)
-      agentAddress.setCountryCode(countryCode)
-      agentAddress.setPostcodeID(postcode)
-    })
-
-    agent.setAddress(agentAddress)
+        agentAddress.setLine(line)
+        agentAddress.setCityName(city)
+        agentAddress.setCountryCode(countryCode)
+        agentAddress.setPostcodeID(postcode)
+      })
+      agent.setAddress(agentAddress)
+    }
     agent
   }
 }

--- a/app/services/mapping/declaration/BorderTransportMeansBuilder.scala
+++ b/app/services/mapping/declaration/BorderTransportMeansBuilder.scala
@@ -32,33 +32,47 @@ object BorderTransportMeansBuilder {
   def build(implicit cacheMap: CacheMap): Declaration.BorderTransportMeans =
     cacheMap
       .getEntry[TransportInformation](TransportInformation.id)
+      .filter(isDefined)
       .map(createBorderTransportMeans)
       .orNull
 
+  private def isDefined(transportInformation: TransportInformation): Boolean =
+    transportInformation.meansOfTransportCrossingTheBorderIDNumber.isDefined ||
+      transportInformation.meansOfTransportCrossingTheBorderType.nonEmpty ||
+      transportInformation.borderModeOfTransportCode.nonEmpty
+
   private def createBorderTransportMeans(data: TransportInformation): Declaration.BorderTransportMeans = {
-
-    val id = new BorderTransportMeansIdentificationIDType()
-    id.setValue(data.meansOfTransportCrossingTheBorderIDNumber.getOrElse(""))
-
-    val modeCode = new BorderTransportMeansModeCodeType()
-    modeCode.setValue(data.borderModeOfTransportCode)
-
-    val identificationTypeCode = new BorderTransportMeansIdentificationTypeCodeType()
-    identificationTypeCode.setValue(data.meansOfTransportCrossingTheBorderType)
-
-    val registrationNationalityCode = new BorderTransportMeansRegistrationNationalityCodeType()
-    registrationNationalityCode.setValue(
-      allCountries
-        .find(country => data.meansOfTransportCrossingTheBorderNationality.contains(country.countryName))
-        .map(_.countryCode)
-        .getOrElse("")
-    )
-
     val transportMeans = new Declaration.BorderTransportMeans()
-    transportMeans.setID(id)
-    transportMeans.setIdentificationTypeCode(identificationTypeCode)
-    transportMeans.setModeCode(modeCode)
-    transportMeans.setRegistrationNationalityCode(registrationNationalityCode)
+
+    if (data.meansOfTransportCrossingTheBorderIDNumber.isDefined) {
+      val id = new BorderTransportMeansIdentificationIDType()
+      id.setValue(data.meansOfTransportCrossingTheBorderIDNumber.getOrElse(""))
+      transportMeans.setID(id)
+    }
+
+    if (data.borderModeOfTransportCode.nonEmpty) {
+      val modeCode = new BorderTransportMeansModeCodeType()
+      modeCode.setValue(data.borderModeOfTransportCode)
+      transportMeans.setModeCode(modeCode)
+    }
+
+    if (data.meansOfTransportCrossingTheBorderType.nonEmpty) {
+      val identificationTypeCode = new BorderTransportMeansIdentificationTypeCodeType()
+      identificationTypeCode.setValue(data.meansOfTransportCrossingTheBorderType)
+      transportMeans.setIdentificationTypeCode(identificationTypeCode)
+    }
+
+    if (data.meansOfTransportCrossingTheBorderNationality.isDefined) {
+      val registrationNationalityCode = new BorderTransportMeansRegistrationNationalityCodeType()
+      registrationNationalityCode.setValue(
+        allCountries
+          .find(country => data.meansOfTransportCrossingTheBorderNationality.contains(country.countryName))
+          .map(_.countryCode)
+          .getOrElse("")
+      )
+      transportMeans.setRegistrationNationalityCode(registrationNationalityCode)
+    }
+
     transportMeans
   }
 }

--- a/test/models/declaration/SupplementaryDeclarationDataSpec.scala
+++ b/test/models/declaration/SupplementaryDeclarationDataSpec.scala
@@ -17,11 +17,9 @@
 package models.declaration
 
 import forms.common.Date
-import forms.{Choice, ChoiceSpec}
 import forms.declaration.ConsigneeDetailsSpec._
 import forms.declaration.ConsignmentReferencesSpec._
 import forms.declaration.DeclarantDetailsSpec._
-import forms.declaration.DeclarationAdditionalActorsSpec.correctAdditionalActorsJSON
 import forms.declaration.DestinationCountriesSupplementarySpec._
 import forms.declaration.DispatchLocation.AllowedDispatchLocations
 import forms.declaration.DispatchLocationSpec._
@@ -44,24 +42,18 @@ import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupp
 import forms.declaration.additionaldocuments.{DocumentIdentifierAndPart, DocumentWriteOff, DocumentsProduced}
 import forms.declaration.destinationCountries.DestinationCountries
 import forms.declaration.officeOfExit.OfficeOfExit
+import forms.{Choice, ChoiceSpec}
 import models.declaration.DeclarationAdditionalActorsDataSpec._
 import models.declaration.DeclarationHoldersDataSpec._
 import models.declaration.SupplementaryDeclarationData.SchemaMandatoryValues._
 import models.declaration.dectype.DeclarationTypeSupplementary
 import models.declaration.dectype.DeclarationTypeSupplementarySpec._
-import models.declaration.governmentagencygoodsitem.{
-  Amount,
-  Commodity,
-  GoodsMeasure,
-  GovernmentAgencyGoodsItem,
-  GovernmentAgencyGoodsItemAdditionalDocument,
-  Measure
-}
+import models.declaration.governmentagencygoodsitem.Formats._
+import models.declaration.governmentagencygoodsitem.{Amount, GovernmentAgencyGoodsItem}
 import org.mockito.Mockito.{mock, times, verify, when}
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json.{JsArray, JsObject, JsString, JsValue, Json}
+import play.api.libs.json._
 import services.ExportsItemsCacheIds
-import models.declaration.governmentagencygoodsitem.Formats._
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
@@ -389,7 +381,6 @@ class SupplementaryDeclarationDataSpec extends WordSpec with MustMatchers {
 }
 
 object SupplementaryDeclarationDataSpec {
-  val date = Date(Some(12), Some(12), Some(2019))
   lazy val cacheMapAllRecords = CacheMap(
     id = "CacheID",
     data = Map(
@@ -398,7 +389,7 @@ object SupplementaryDeclarationDataSpec {
       AdditionalDeclarationTypeSupplementaryDec.formId -> correctAdditionalDeclarationTypeSupplementaryDecJSON,
       ConsignmentReferences.id -> correctConsignmentReferencesJSON,
       ExporterDetails.id -> correctExporterDetailsJSON,
-      DeclarantDetails.id -> correctDeclarantDetailsJSON,
+      DeclarantDetails.id -> Json.toJson(DeclarantDetailsSpec.correctDeclarantDetailsEORIOnly),
       RepresentativeDetails.formId -> correctRepresentativeDetailsJSON,
       Document.formId -> DocumentSpec.correctPreviousDocumentsJSONList,
       CarrierDetails.id -> CarrierDetailsSpec.correctCarrierDetailsJSON,
@@ -460,29 +451,10 @@ object SupplementaryDeclarationDataSpec {
       )
     )
   )
-
-  def createGovernmentAgencyGoodsItem(): GovernmentAgencyGoodsItem =
-    GovernmentAgencyGoodsItem(
-      sequenceNumeric = 0,
-      statisticalValueAmount = Some(Amount(Some("GBP"), Some(BigDecimal(12)))),
-      commodity = None, //parsed from cached CommodityForm
-      additionalInformations = Seq(),
-      additionalDocuments = Seq(),
-      governmentProcedures = Seq(),
-      packagings = Seq()
-    )
-
   lazy val correctGovernmentAgencyGoodsItemJSON: JsValue = JsArray(Seq(Json.toJson(createGovernmentAgencyGoodsItem())))
-
   lazy val correctStatisticalValueAmountJSON: JsValue =
     JsObject(Map("currencyId" -> JsString("GBP"), "value" -> JsString("44")))
-
-  val correctPackingJSON: JsValue = JsObject(
-    Map("sequenceNumeric" -> JsString("0"), "marksNumbersId" -> JsString("wefdsf"), "typeCode" -> JsString("22"))
-  )
-
   lazy val correctPackageInformationJSON: JsValue = JsArray(Seq(correctPackageInformationJSON))
-
   lazy val supplementaryDeclarationDataAllValues = SupplementaryDeclarationData(
     declarationType = Some(correctDeclarationType),
     consignmentReferences = Some(correctConsignmentReferences),
@@ -512,4 +484,19 @@ object SupplementaryDeclarationDataSpec {
       )
     )
   )
+  val date = Date(Some(12), Some(12), Some(2019))
+  val correctPackingJSON: JsValue = JsObject(
+    Map("sequenceNumeric" -> JsString("0"), "marksNumbersId" -> JsString("wefdsf"), "typeCode" -> JsString("22"))
+  )
+
+  def createGovernmentAgencyGoodsItem(): GovernmentAgencyGoodsItem =
+    GovernmentAgencyGoodsItem(
+      sequenceNumeric = 0,
+      statisticalValueAmount = Some(Amount(Some("GBP"), Some(BigDecimal(12)))),
+      commodity = None, //parsed from cached CommodityForm
+      additionalInformations = Seq(),
+      additionalDocuments = Seq(),
+      governmentProcedures = Seq(),
+      packagings = Seq()
+    )
 }

--- a/test/resources/wco_dec_metadata.xml
+++ b/test/resources/wco_dec_metadata.xml
@@ -13,14 +13,7 @@
         <ns3:InvoiceAmount currencyID="GBP">1212312.12</ns3:InvoiceAmount>
         <ns3:TotalPackageQuantity>123</ns3:TotalPackageQuantity>
         <ns3:Agent>
-            <ns3:Name>Full Name</ns3:Name>
             <ns3:ID>9GB1234567ABCDEF</ns3:ID>
-            <ns3:Address>
-                <ns3:CityName>Town or City</ns3:CityName>
-                <ns3:CountryCode>PL</ns3:CountryCode>
-                <ns3:Line>Address Line</ns3:Line>
-                <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
-            </ns3:Address>
         </ns3:Agent>
         <ns3:BorderTransportMeans>
             <ns3:ID>1234567878ui</ns3:ID>
@@ -32,13 +25,7 @@
             <ns3:RateNumeric>1212121.12345</ns3:RateNumeric>
         </ns3:CurrencyExchange>
         <ns3:Declarant>
-            <ns3:Name>Full Name</ns3:Name>
-            <ns3:Address>
-                <ns3:CityName>Town or City</ns3:CityName>
-                <ns3:CountryCode>PL</ns3:CountryCode>
-                <ns3:Line>Address Line</ns3:Line>
-                <ns3:PostcodeID>AB12 34CD</ns3:PostcodeID>
-            </ns3:Address>
+            <ns3:ID>9GB1234567ABCDEF</ns3:ID>
         </ns3:Declarant>
         <ns3:ExitOffice>
             <ns3:ID>123qwe12</ns3:ID>

--- a/test/services/mapping/declaration/AgentBuilderSpec.scala
+++ b/test/services/mapping/declaration/AgentBuilderSpec.scala
@@ -17,36 +17,37 @@
 package services.mapping.declaration
 import forms.declaration.{RepresentativeDetails, RepresentativeDetailsSpec}
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class AgentBuilderSpec extends WordSpec with Matchers {
 
   "AgentBuilder" should {
     "correctly map to the WCO-DEC Agent instance" when {
-      "all data is supplied" in {
+      "only EORI is supplied" in {
         implicit val cacheMap: CacheMap =
           CacheMap(
             "CacheID",
-            Map(RepresentativeDetails.formId -> RepresentativeDetailsSpec.correctRepresentativeDetailsJSON)
-          )
-        val agent = AgentBuilder.build(cacheMap)
-        agent.getID.getValue should be("9GB1234567ABCDEF")
-        agent.getName.getValue should be("Full Name")
-        agent.getAddress.getLine.getValue should be("Address Line")
-        agent.getAddress.getCityName.getValue should be("Town or City")
-        agent.getAddress.getCountryCode.getValue should be("PL")
-        agent.getAddress.getPostcodeID.getValue should be("AB12 34CD")
-      }
-
-      "fullname is not supplied" in {
-        implicit val cacheMap: CacheMap =
-          CacheMap(
-            "CacheID",
-            Map(RepresentativeDetails.formId -> RepresentativeDetailsSpec.representativeDetailsWithEmptyFullNameJSON)
+            Map(RepresentativeDetails.formId -> RepresentativeDetailsSpec.correctRepresentativeDetailsEORIOnlyJSON)
           )
         val agent = AgentBuilder.build(cacheMap)
         agent.getID.getValue should be("9GB1234567ABCDEF")
         agent.getName should be(null)
+        agent.getAddress should be(null)
+      }
+
+      "only Address is supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(
+              RepresentativeDetails.formId -> Json
+                .toJson(RepresentativeDetailsSpec.correctRepresentativeDetailsAddressOnly)
+            )
+          )
+        val agent = AgentBuilder.build(cacheMap)
+        agent.getID should be(null)
+        agent.getName.getValue should be("Full Name")
         agent.getAddress.getLine.getValue should be("Address Line")
         agent.getAddress.getCityName.getValue should be("Town or City")
         agent.getAddress.getCountryCode.getValue should be("PL")

--- a/test/services/mapping/declaration/DeclarationBuilderSpec.scala
+++ b/test/services/mapping/declaration/DeclarationBuilderSpec.scala
@@ -26,11 +26,8 @@ class DeclarationBuilderSpec extends WordSpec with Matchers {
       val declaration = DeclarationBuilder.build(SupplementaryDeclarationDataSpec.cacheMapAllRecords)
 
       declaration.getAgent.getID.getValue should be("9GB1234567ABCDEF")
-      declaration.getAgent.getName.getValue should be("Full Name")
-      declaration.getAgent.getAddress.getLine.getValue should be("Address Line")
-      declaration.getAgent.getAddress.getCityName.getValue should be("Town or City")
-      declaration.getAgent.getAddress.getCountryCode.getValue should be("PL")
-      declaration.getAgent.getAddress.getPostcodeID.getValue should be("AB12 34CD")
+      declaration.getAgent.getName should be(null)
+      declaration.getAgent.getAddress should be(null)
 
       declaration.getBorderTransportMeans.getID.getValue should be("1234567878ui")
       declaration.getBorderTransportMeans.getIdentificationTypeCode.getValue should be("40")
@@ -41,12 +38,9 @@ class DeclarationBuilderSpec extends WordSpec with Matchers {
 
       declaration.getCurrencyExchange.get(0).getRateNumeric.doubleValue() should be(1212121.12345)
 
-      declaration.getDeclarant.getID should be(null)
-      declaration.getDeclarant.getName.getValue should be("Full Name")
-      declaration.getDeclarant.getAddress.getLine.getValue should be("Address Line")
-      declaration.getDeclarant.getAddress.getCityName.getValue should be("Town or City")
-      declaration.getDeclarant.getAddress.getPostcodeID.getValue should be("AB12 34CD")
-      declaration.getDeclarant.getAddress.getCountryCode.getValue should be("PL")
+      declaration.getDeclarant.getID.getValue should be("9GB1234567ABCDEF")
+      declaration.getDeclarant.getName should be(null)
+      declaration.getDeclarant.getAddress should be(null)
 
       declaration.getExitOffice.getID.getValue should be("123qwe12")
 

--- a/test/services/mapping/declaration/ExporterBuilderSpec.scala
+++ b/test/services/mapping/declaration/ExporterBuilderSpec.scala
@@ -18,29 +18,33 @@ package services.mapping.declaration
 
 import forms.declaration.{ExporterDetails, ExporterDetailsSpec}
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class ExporterBuilderSpec extends WordSpec with Matchers {
 
   "ExporterBuilder" should {
     "correctly map to the WCO-DEC Exporter instance" when {
-      "all data is supplied" in {
+      "only EORI is supplied" in {
         implicit val cacheMap: CacheMap =
-          CacheMap("CacheID", Map(ExporterDetails.id -> ExporterDetailsSpec.correctExporterDetailsJSON))
-        val exporter = ExporterBuilder.build(cacheMap)
-        exporter.getID.getValue should be("9GB1234567ABCDEF")
-        exporter.getName.getValue should be("Full Name")
-        exporter.getAddress.getLine.getValue should be("Address Line")
-        exporter.getAddress.getCityName.getValue should be("Town or City")
-        exporter.getAddress.getCountryCode.getValue should be("PL")
-        exporter.getAddress.getPostcodeID.getValue should be("AB12 34CD")
-      }
-      "fullname is not supplied" in {
-        implicit val cacheMap: CacheMap =
-          CacheMap("CacheID", Map(ExporterDetails.id -> ExporterDetailsSpec.exporterDetailsWithEmptyFullNameJSON))
+          CacheMap(
+            "CacheID",
+            Map(ExporterDetails.id -> Json.toJson(ExporterDetailsSpec.correctExporterDetailsEORIOnly))
+          )
         val exporter = ExporterBuilder.build(cacheMap)
         exporter.getID.getValue should be("9GB1234567ABCDEF")
         exporter.getName should be(null)
+        exporter.getAddress should be(null)
+      }
+      "only address is not supplied" in {
+        implicit val cacheMap: CacheMap =
+          CacheMap(
+            "CacheID",
+            Map(ExporterDetails.id -> Json.toJson(ExporterDetailsSpec.correctExporterDetailsAddressOnly))
+          )
+        val exporter = ExporterBuilder.build(cacheMap)
+        exporter.getID should be(null)
+        exporter.getName.getValue should be("Full Name")
         exporter.getAddress.getLine.getValue should be("Address Line")
         exporter.getAddress.getCityName.getValue should be("Town or City")
         exporter.getAddress.getCountryCode.getValue should be("PL")


### PR DESCRIPTION
After a conversation with @raghu1978 we have realised that a lot of the
mapping logic checks are overly defensive as the production code will
never allow data to be in a given state.

For example on a form where a EORI and an address is being requested,
only one or them will be requested and none of them can be
`None/Null/Empty`.