### PR TITLE
WIP: CEDS-1046 Map standard journey fields

### DIFF
--- a/app/services/mapping/goodsshipment/DestinationBuilder.scala
+++ b/app/services/mapping/goodsshipment/DestinationBuilder.scala
@@ -15,7 +15,9 @@
  */
 
 package services.mapping.goodsshipment
-import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesSupplementary}
+import forms.Choice
+import forms.Choice.AllowedChoiceValues
+import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesStandard, DestinationCountriesSupplementary}
 import services.Countries.allCountries
 import uk.gov.hmrc.http.cache.client.CacheMap
 import wco.datamodel.wco.dec_dms._2.Declaration.GoodsShipment
@@ -26,19 +28,35 @@ object DestinationBuilder {
 
   def build(implicit cacheMap: CacheMap): GoodsShipment.Destination =
     cacheMap
-      .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
-      .filter(isDefined)
-      .map(createExportCountry)
+      .getEntry[Choice](Choice.choiceId)
+      .map {
+        case Choice(AllowedChoiceValues.SupplementaryDec) => buildSupplementary(cacheMap)
+        case Choice(AllowedChoiceValues.StandardDec)      => buildStandard(cacheMap)
+      }
       .orNull
 
-  private def isDefined(country: DestinationCountriesSupplementary): Boolean = country.countryOfDestination.nonEmpty
+  def buildSupplementary(implicit cacheMap: CacheMap): GoodsShipment.Destination =
+    cacheMap
+      .getEntry[DestinationCountriesSupplementary](DestinationCountries.formId)
+      .filter(data => isDefined(data.countryOfDestination))
+      .map(data => createExportCountry(data.countryOfDestination))
+      .orNull
 
-  private def createExportCountry(data: DestinationCountriesSupplementary): GoodsShipment.Destination = {
+  def buildStandard(implicit cacheMap: CacheMap): GoodsShipment.Destination =
+    cacheMap
+      .getEntry[DestinationCountriesStandard](DestinationCountries.formId)
+      .filter(data => isDefined(data.countryOfDestination))
+      .map(data => createExportCountry(data.countryOfDestination))
+      .orNull
+
+  private def isDefined(countryOfDestination: String): Boolean = countryOfDestination.nonEmpty
+
+  private def createExportCountry(countryOfDestination: String): GoodsShipment.Destination = {
 
     val countryCode = new DestinationCountryCodeType()
     countryCode.setValue(
       allCountries
-        .find(country => data.countryOfDestination.contains(country.countryCode))
+        .find(country => countryOfDestination.contains(country.countryCode))
         .map(_.countryCode)
         .getOrElse("")
     )

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -93,7 +93,7 @@ microservice {
 
     features {
       welsh-translation = false
-      use-new-wco-dec-mapping-strategy = false
+      use-new-wco-dec-mapping-strategy = true
       default = disabled
     }
 

--- a/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/DestinationBuilderSpec.scala
@@ -17,34 +17,67 @@
 package services.mapping.goodsshipment
 
 import forms.declaration.DestinationCountriesSupplementarySpec
-import forms.declaration.destinationCountries.DestinationCountries
+import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesStandard}
+import forms.{Choice, ChoiceSpec}
 import org.scalatest.{Matchers, WordSpec}
+import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 class DestinationBuilderSpec extends WordSpec with Matchers {
 
   "DestinationBuilder" should {
     "correctly map to the WCO-DEC GoodsShipment.Destination instance" when {
-      "countryOfDestination has been supplied" in {
-        implicit val cacheMap: CacheMap =
-          CacheMap(
-            "CacheID",
-            Map(
-              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+      "submitting a supplementary journey" when {
+
+        "countryOfDestination has been supplied" in {
+          implicit val cacheMap: CacheMap =
+            CacheMap(
+              "CacheID",
+              Map(
+                Choice.choiceId -> ChoiceSpec.correctSupplementaryChoiceJSON,
+                DestinationCountries.formId -> DestinationCountriesSupplementarySpec.correctDestinationCountriesSupplementaryJSON
+              )
             )
-          )
-        val destination = DestinationBuilder.build(cacheMap)
-        destination.getCountryCode.getValue should be("PL")
+          val destination = DestinationBuilder.build(cacheMap)
+          destination.getCountryCode.getValue should be("PL")
+        }
+        "countryOfDestination has not been supplied" in {
+          implicit val cacheMap: CacheMap =
+            CacheMap(
+              "CacheID",
+              Map(
+                Choice.choiceId -> ChoiceSpec.correctSupplementaryChoiceJSON,
+                DestinationCountries.formId -> DestinationCountriesSupplementarySpec.emptyDestinationCountriesSupplementaryJSON
+              )
+            )
+          DestinationBuilder.build(cacheMap) should be(null)
+        }
       }
-      "countryOfDestination has not been supplied" in {
-        implicit val cacheMap: CacheMap =
-          CacheMap(
-            "CacheID",
-            Map(
-              DestinationCountries.formId -> DestinationCountriesSupplementarySpec.emptyDestinationCountriesSupplementaryJSON
+
+      "submitting a standard journey" when {
+        "countryOfDestination has been supplied" in {
+          implicit val cacheMap: CacheMap =
+            CacheMap(
+              "CacheID",
+              Map(
+                Choice.choiceId -> ChoiceSpec.correctStandardChoiceJSON,
+                DestinationCountries.formId -> Json.toJson(DestinationCountriesStandard("GB", Seq("PT"), "PL"))
+              )
             )
-          )
-        DestinationBuilder.build(cacheMap) should be(null)
+          val destination = DestinationBuilder.build(cacheMap)
+          destination.getCountryCode.getValue should be("PL")
+        }
+        "countryOfDestination has not been supplied" in {
+          implicit val cacheMap: CacheMap =
+            CacheMap(
+              "CacheID",
+              Map(
+                Choice.choiceId -> ChoiceSpec.correctStandardChoiceJSON,
+                DestinationCountries.formId -> Json.toJson(DestinationCountriesStandard("", Seq(""), ""))
+              )
+            )
+          DestinationBuilder.build(cacheMap) should be(null)
+        }
       }
     }
   }


### PR DESCRIPTION
The fulldec is not supported in the new or old mapping strategy,
simply because we did not do the mapping for destination `ExportCountry`
 and `DestinationCountry` (both of them have a supplementary/standard form)

We need to go to the form and check which fields we need to map to.