### PR TITLE
CEDS-1203 Change ENTER key to trigger Add button instead of Remove

### DIFF
--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -57,7 +57,7 @@ class TransportContainerController @Inject()(
       }
   }
 
-  def handlePost(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
 
     val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded(_))

--- a/app/views/components/single_value_elements_table.scala.html
+++ b/app/views/components/single_value_elements_table.scala.html
@@ -20,19 +20,17 @@
     elements: Seq[String],
     buttonMessagesKey: String = "site.remove"
 )(implicit messages: Messages)
-@if(elements.nonEmpty) {
 
-    <div class="field-group">
-        <table >
-        @for(elem <- elements) {
-            <tr>
-                <th>@elem</th>
-                <th>
-                    <button class="button--secondary" name="@Remove.toString" value="@elem">@messages(buttonMessagesKey)</button>
-                </th>
-            </tr>
-        }
-        </table>
-        <br><br>
-    </div>
-}
+<div class="field-group">
+    <table >
+    @for(elem <- elements) {
+        <tr>
+            <th>@elem</th>
+            <th>
+                <button class="button--secondary" name="@Remove.toString" value="@elem">@messages(buttonMessagesKey)</button>
+            </th>
+        </tr>
+    }
+    </table>
+    <br><br>
+</div>

--- a/app/views/declaration/add_transport_containers.scala.html
+++ b/app/views/declaration/add_transport_containers.scala.html
@@ -16,10 +16,9 @@
 
 @import config.AppConfig
 @import controllers.declaration.routes._
+@import controllers.util.Remove
 @import forms.declaration.TransportInformationContainer
 @import uk.gov.hmrc.play.views.html._
-@import utils.RadioOption
-@import controllers.util.Remove
 @(form: Form[TransportInformationContainer], containers: Seq[TransportInformationContainer])(implicit appConfig: AppConfig, request: Request[_], messages: Messages)
 
 @main_template(
@@ -29,14 +28,12 @@
 
     @components.back_link("/customs-declare-exports/declaration/transport-details")
 
-    @helpers.form(TransportContainerController.handlePost(), 'autoComplete -> "off") {
+    @components.error_summary(form.errors)
 
-        @components.error_summary(form.errors)
+    @components.page_title(Some("supplementary.transportInfo.containers.title"), None)
 
-        @components.page_title(Some("supplementary.transportInfo.containers.title"), None)
-
-
-        @if(containers.nonEmpty) {
+    @if(containers.nonEmpty) {
+        @helpers.form(TransportContainerController.submitForm(), 'autoComplete -> "off") {
             <div class="field-group">
                 <table >
                     <thead>
@@ -49,7 +46,7 @@
                     <tr>
                         <td>@container.id</td>
                         <td>
-                            <button class="button--secondary" name="@Remove.toString" value="@index">@messages("site.remove")</button>
+                            <button class="button--secondary" name=@Remove.toString value=@index>@messages("site.remove")</button>
                         </td>
                     </tr>
                 }
@@ -57,8 +54,9 @@
                 <br><br>
             </div>
         }
+    }
 
-
+    @helpers.form(TransportContainerController.submitForm(), 'autoComplete -> "off") {
         @components.input_text(
             field = form("id"),
             label = messages("supplementary.transportInfo.containerId")

--- a/app/views/declaration/additional_information.scala.html
+++ b/app/views/declaration/additional_information.scala.html
@@ -26,23 +26,24 @@
     title = messages("supplementary.additionalInformation"),
     appConfig = appConfig
 ) {
-    @helpers.form(AdditionalInformationController.saveAdditionalInfo(), 'autoComplete -> "off") {
-        @components.back_link("/customs-declare-exports/declaration/commodity-measure")
 
-        @components.error_summary(form.errors)
+    @components.back_link("/customs-declare-exports/declaration/commodity-measure")
 
-        @components.section_header(messages("supplementary.summary.yourReferences.header"))
+    @components.error_summary(form.errors)
 
-        @components.page_title(Some("supplementary.additionalInformation.title"))
+    @components.section_header(messages("supplementary.summary.yourReferences.header"))
 
-        @if(items.nonEmpty) {
+    @components.page_title(Some("supplementary.additionalInformation.title"))
+
+    @if(items.nonEmpty) {
+        @helpers.form(AdditionalInformationController.saveAdditionalInfo(), 'autoComplete -> "off") {
             <div class="field-group">
                 <table >
                 @items.zipWithIndex.map { case (item, index) =>
                 <tr>
                     <th>@item</th>
                     <th>
-                        <button class="button--secondary" name="@Remove.toString" value="@index">@messages("site.remove")</button>
+                        <button class="button--secondary" name="@Remove.toString" value=@index>@messages("site.remove")</button>
                 </th>
                 </tr>
                 }
@@ -50,7 +51,9 @@
                 <br><br>
             </div>
         }
+    }
 
+    @helpers.form(AdditionalInformationController.saveAdditionalInfo(), 'autoComplete -> "off") {
         @components.input_text(
             field = form("code"),
             label = messages("supplementary.additionalInformation.code"),

--- a/app/views/declaration/declaration_holder.scala.html
+++ b/app/views/declaration/declaration_holder.scala.html
@@ -25,17 +25,22 @@
     title = messages("supplementary.declarationHolder.title"),
     appConfig = appConfig
 ) {
+
+    @components.back_link("/customs-declare-exports/declaration/additional-actors")
+
+    @components.error_summary(form.errors)
+
+    @components.section_header(messages("supplementary.summary.parties.header"))
+
+    @components.page_title(Some("supplementary.declarationHolder.title"))
+
+    @if(holders.nonEmpty) {
+        @helpers.form(DeclarationHolderController.submitHoldersOfAuthorisation(), 'autoComplete -> "off") {
+            @components.single_value_elements_table(holders.map(_.toString))
+        }
+    }
+
     @helpers.form(DeclarationHolderController.submitHoldersOfAuthorisation(), 'autoComplete -> "off") {
-        @components.back_link("/customs-declare-exports/declaration/additional-actors")
-
-        @components.error_summary(form.errors)
-
-        @components.section_header(messages("supplementary.summary.parties.header"))
-
-        @components.page_title(Some("supplementary.declarationHolder.title"))
-
-        @components.single_value_elements_table(holders.map(_.toString))
-
         @components.input_text(
             field = form("authorisationTypeCode"),
             label = messages("supplementary.declarationHolder.authorisationCode"),

--- a/app/views/declaration/documents_produced.scala.html
+++ b/app/views/declaration/documents_produced.scala.html
@@ -30,11 +30,10 @@
     appConfig = appConfig
 ) {
 
-    @helpers.form(DocumentsProducedController.saveForm(), 'autoComplete -> "off") {
+    @components.back_link("/customs-declare-exports/declaration/additional-information")
 
-        @components.back_link("/customs-declare-exports/declaration/additional-information")
-
-        @if(documents.nonEmpty) {
+    @if(documents.nonEmpty) {
+        @helpers.form(DocumentsProducedController.saveForm(), 'autoComplete -> "off") {
             <table class="form-group">
                 <thead>
                     <tr>
@@ -62,19 +61,21 @@
                         <td>@item.dateOfValidity</td>
                         <td>@item.documentWriteOff.map(_.measurementUnit)</td>
                         <td>@item.documentWriteOff.map(_.documentQuantity)</td>
-                        <td><button class="button--secondary" name="@Remove.toString" value="@index">@messages("site.remove")</button></td>
+                        <td><button class="button--secondary" name=@Remove.toString value=@index>@messages("site.remove")</button></td>
                     </tr>
                 }
                 </tbody>
             </table>
         }
+    }
 
-        @components.error_summary(form.errors)
+    @components.error_summary(form.errors)
 
-        @components.section_header(messages("supplementary.summary.yourReferences.header"))
+    @components.section_header(messages("supplementary.summary.yourReferences.header"))
 
-        @components.page_title(Some("supplementary.addDocument.title"), Some("supplementary.addDocument.hint"))
+    @components.page_title(Some("supplementary.addDocument.title"), Some("supplementary.addDocument.hint"))
 
+    @helpers.form(DocumentsProducedController.saveForm(), 'autoComplete -> "off") {
         @components.input_text(
             field = form(documentTypeCodeKey),
             label = messages("supplementary.addDocument.documentTypeCode"),

--- a/app/views/declaration/package_information.scala.html
+++ b/app/views/declaration/package_information.scala.html
@@ -33,16 +33,17 @@
     title = messages("supplementary.packageInformation.title"),
     appConfig = appConfig
 ) {
-    @helpers.form(PackageInformationController.submitForm(), 'autoComplete -> "off") {
-        @components.back_link("/customs-declare-exports/declaration/item-type")
 
-        @components.error_summary(form.errors)
+    @components.back_link("/customs-declare-exports/declaration/item-type")
 
-        @components.section_header(messages("supplementary.items"))
+    @components.error_summary(form.errors)
 
-        @components.page_title(Some("supplementary.packageInformation.title"))
+    @components.section_header(messages("supplementary.items"))
 
-        @if(packages.nonEmpty) {
+    @components.page_title(Some("supplementary.packageInformation.title"))
+
+    @if(packages.nonEmpty) {
+        @helpers.form(PackageInformationController.submitForm(), 'autoComplete -> "off") {
             <table class="form-group">
                 <caption>@tableHeader</caption>
                 <thead>
@@ -60,14 +61,18 @@
                     <td>@item.numberOfPackages</td>
                     <td>@item.shippingMarks</td>
                     <td>
-                        <button class="button--secondary" name=@messages("site.remove") value="@index">@messages("site.remove")</button>
+                        <button class="button--secondary" name=@messages("site.remove") value=@index>
+                            @messages("site.remove")
+                        </button>
                     </td>
                 </tr>
                 }
                 </tbody>
             </table>
         }
+    }
 
+    @helpers.form(PackageInformationController.submitForm(), 'autoComplete -> "off") {
         @components.input_text(
             field = form("typesOfPackages"),
             label = messages("supplementary.packageInformation.typesOfPackages"),

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -27,14 +27,15 @@
     title = messages("supplementary.previousDocuments"),
     appConfig = appConfig
 ) {
-    @helpers.form(PreviousDocumentsController.savePreviousDocuments(), 'autoComplete -> "off") {
-        @components.back_link("/customs-declare-exports/declaration/transaction-type")
 
-        @components.error_summary(form.errors)
+    @components.back_link("/customs-declare-exports/declaration/transaction-type")
 
-        @components.section_header(messages("supplementary.consignmentReferences.heading"))
+    @components.error_summary(form.errors)
 
-        @if(documents.nonEmpty) {
+    @components.section_header(messages("supplementary.consignmentReferences.heading"))
+
+    @if(documents.nonEmpty) {
+        @helpers.form(PreviousDocumentsController.savePreviousDocuments(), 'autoComplete -> "off") {
             <table class="form-group">
                 <caption>@messages("supplementary.previousDocuments")</caption>
                 <thead>
@@ -54,14 +55,18 @@
                     <td>@document.documentReference</td>
                     <td>@document.goodsItemIdentifier.getOrElse("")</td>
                     <td>
-                        <button class="button--secondary" name=@messages("site.remove") value="@index">@messages("site.remove") </button>
+                        <button class="button--secondary" name=@messages("site.remove") value=@index>
+                            @messages("site.remove")
+                        </button>
                     </td>
                 </tr>
                 }
                 </tbody>
             </table>
         }
+    }
 
+    @helpers.form(PreviousDocumentsController.savePreviousDocuments(), 'autoComplete -> "off") {
         @components.page_title(Some("supplementary.previousDocuments.title"), Some("supplementary.previousDocuments.hint"))
 
         @components.input_radio(

--- a/app/views/declaration/seal.scala.html
+++ b/app/views/declaration/seal.scala.html
@@ -19,6 +19,7 @@
 @import forms.declaration.Seal
 @import uk.gov.hmrc.play.views.html._
 @import controllers.util.Remove
+
 @(form: Form[Seal], seals: Seq[Seal], hasContainers:Boolean)(implicit appConfig: AppConfig, request: Request[_], messages: Messages)
 
 @main_template(
@@ -26,17 +27,17 @@
     appConfig = appConfig
 ) {
 
-    @{if(hasContainers) components.back_link("/customs-declare-exports/declaration/add-transport-containers")
-        else  components.back_link("/customs-declare-exports/declaration/transport-details")
-}
+    @{
+        if(hasContainers)   components.back_link("/customs-declare-exports/declaration/add-transport-containers")
+        else                components.back_link("/customs-declare-exports/declaration/transport-details")
+    }
 
-    @helpers.form(SealController.submitForm(), 'autoComplete -> "off") {
+    @components.error_summary(form.errors)
 
-        @components.error_summary(form.errors)
+    @components.page_title(Some("standard.seal.title"), None)
 
-        @components.page_title(Some("standard.seal.title"), None)
-
-        @if(seals.nonEmpty) {
+    @if(seals.nonEmpty) {
+        @helpers.form(SealController.submitForm(), 'autoComplete -> "off") {
             <div class="field-group">
                 <table >
                     <thead>
@@ -57,7 +58,9 @@
                 <br><br>
             </div>
         }
+    }
 
+    @helpers.form(SealController.submitForm(), 'autoComplete -> "off") {
         @components.input_text(
             field = form("id"),
             label = messages("standard.seal.id")

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -94,7 +94,7 @@ POST        /office-of-exit                 controllers.declaration.OfficeOfExit
 
 GET         /add-transport-containers       controllers.declaration.TransportContainerController.displayPage()
 
-POST        /add-transport-containers       controllers.declaration.TransportContainerController.handlePost()
+POST        /add-transport-containers       controllers.declaration.TransportContainerController.submitForm()
 
 # Total number of items
 

--- a/test/controllers/declaration/DeclarationHolderControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderControllerSpec.scala
@@ -68,9 +68,9 @@ class DeclarationHolderControllerSpec
 
     "validate request and show error" when {
 
-      "adding holder" when {
+      "adding holder" which {
 
-        "without EORI number" in {
+        "has no EORI number" in {
 
           val body = Seq(("authorisationTypeCode", "1234"), addActionUrlEncoded)
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -84,7 +84,7 @@ class DeclarationHolderControllerSpec
           getElementByCss(page, "#error-message-eori-input").text() must be(messages(eoriEmpty))
         }
 
-        "with longer EORI" in {
+        "has longer EORI" in {
           val body = Seq(("eori", createRandomAlphanumericString(18)), addActionUrlEncoded)
 
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -93,7 +93,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(eoriError))
         }
 
-        "with EORI with special characters" in {
+        "has EORI with special characters" in {
 
           val body = Seq(("authorisationTypeCode", "1234"), ("eori", "e@#$1"), addActionUrlEncoded)
 
@@ -103,7 +103,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(eoriError))
         }
 
-        "without Authorisation code" in {
+        "has no Authorisation code" in {
 
           val body = Seq(("eori", "eori1"), addActionUrlEncoded)
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -119,7 +119,7 @@ class DeclarationHolderControllerSpec
           )
         }
 
-        "with longer Authorisation code" in {
+        "has longer Authorisation code" in {
 
           val body = Seq(("authorisationTypeCode", "12345"), ("eori", "eori1"), addActionUrlEncoded)
 
@@ -129,7 +129,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(authorisationCodeError))
         }
 
-        "with Authorisation code with special characters" in {
+        "has Authorisation code with special characters" in {
 
           val body = Seq(("authorisationTypeCode", "1$#4"), ("eori", "eori1"), addActionUrlEncoded)
 
@@ -139,7 +139,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(authorisationCodeError))
         }
 
-        "with both inputs empty" in {
+        "has both inputs empty" in {
 
           val body = addActionUrlEncoded
 
@@ -158,7 +158,7 @@ class DeclarationHolderControllerSpec
           getElementByCss(page, "#error-message-eori-input").text() must be(messages(eoriEmpty))
         }
 
-        "with duplicated holder" in {
+        "is duplicated" in {
 
           val cachedData = DeclarationHoldersData(Seq(DeclarationHolder(Some("1234"), Some("eori"))))
           withCaching[DeclarationHoldersData](Some(cachedData), formId)
@@ -173,7 +173,7 @@ class DeclarationHolderControllerSpec
           checkErrorLink(page, 1, duplicatedItem, "#")
         }
 
-        "with more than 99 holders" in {
+        "has more than 99 holders" in {
 
           withCaching[DeclarationHoldersData](Some(cacheWithMaximumAmountOfHolders), formId)
           val body = Seq(("authorisationTypeCode", "1234"), ("eori", "eori1"), addActionUrlEncoded)
@@ -188,9 +188,9 @@ class DeclarationHolderControllerSpec
         }
       }
 
-      "saving holder" when {
+      "saving holder" which {
 
-        "without EORI number" in {
+        "has no EORI number" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -206,7 +206,7 @@ class DeclarationHolderControllerSpec
           getElementByCss(page, "#error-message-eori-input").text() must be(messages(eoriEmpty))
         }
 
-        "with longer EORI" in {
+        "has longer EORI" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -217,7 +217,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(eoriError))
         }
 
-        "with EORI with special characters" in {
+        "has EORI with special characters" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -228,7 +228,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(eoriError))
         }
 
-        "without Authorisation code" in {
+        "has no Authorisation code" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -246,7 +246,7 @@ class DeclarationHolderControllerSpec
           )
         }
 
-        "with longer Authorisation code" in {
+        "has longer Authorisation code" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -257,7 +257,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(authorisationCodeError))
         }
 
-        "with Authorisation code with special characters" in {
+        "has Authorisation code with special characters" in {
 
           withCaching[DeclarationHoldersData](None, formId)
 
@@ -268,7 +268,7 @@ class DeclarationHolderControllerSpec
           contentAsString(result) must include(messages(authorisationCodeError))
         }
 
-        "with both input empty" in {
+        "has both input empty" in {
 
           val result = route(app, postRequestFormUrlEncoded(uri, saveAndContinueActionUrlEncoded)).get
           val page = contentAsString(result)
@@ -285,7 +285,7 @@ class DeclarationHolderControllerSpec
           getElementByCss(page, "#error-message-eori-input").text() must be(messages(eoriEmpty))
         }
 
-        "with duplicated holder" in {
+        "has duplicated holder" in {
 
           val cachedData = DeclarationHoldersData(Seq(DeclarationHolder(Some("1234"), Some("eori"))))
           withCaching[DeclarationHoldersData](Some(cachedData), formId)
@@ -300,7 +300,7 @@ class DeclarationHolderControllerSpec
           checkErrorLink(page, 1, duplicatedItem, "#")
         }
 
-        "with more than 99 holders" in {
+        "has more than 99 holders" in {
 
           withCaching[DeclarationHoldersData](Some(cacheWithMaximumAmountOfHolders), formId)
 

--- a/test/services/ItemsCachingServiceSpec.scala
+++ b/test/services/ItemsCachingServiceSpec.scala
@@ -16,16 +16,16 @@
 
 package services
 
-import base.TestHelper._
 import base.CustomExportsBaseSpec
+import base.TestHelper._
 import forms.declaration.{CommodityMeasure, ItemType, PackageInformation}
 import models.declaration.{AdditionalInformationData, DocumentsProducedData, ProcedureCodesData}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{verify, when}
 import org.scalatest.OptionValues
+import uk.gov.hmrc.http.HttpResponse
 import uk.gov.hmrc.http.cache.client.CacheMap
-import uk.gov.hmrc.http.{HttpResponse}
 import uk.gov.hmrc.wco.dec.GovernmentAgencyGoodsItem
 
 import scala.concurrent.Future
@@ -68,9 +68,9 @@ class ItemsCachingServiceSpec extends CustomExportsBaseSpec with GoodsItemCachin
       val cacheMap = getCacheMap(input, CommodityMeasure.commodityFormId)
       val commodity = itemsCachingService.commodityFromGoodsMeasure(cacheMap).value
       commodity.goodsMeasure.getOrElse(fail()).grossMassMeasure.value.unitCode.value.toString mustBe "KGM"
-      commodity.goodsMeasure.getOrElse(fail()).grossMassMeasure.value.value.value.toString mustBe input.grossMass
+      commodity.goodsMeasure.getOrElse(fail()).grossMassMeasure.value.value.value mustBe BigDecimal(input.grossMass)
       commodity.goodsMeasure.getOrElse(fail()).netWeightMeasure.value.unitCode.value.toString mustBe "KGM"
-      commodity.goodsMeasure.getOrElse(fail()).netWeightMeasure.value.value.value.toString mustBe input.netMass
+      commodity.goodsMeasure.getOrElse(fail()).netWeightMeasure.value.value.value mustBe BigDecimal(input.netMass)
       commodity.goodsMeasure
         .getOrElse(fail())
         .tariffQuantity


### PR DESCRIPTION
Pages that allow entering multiple values and have tables with values
already entered did not handle pressing ENTER key properly. It triggered
the first submit button found on the page, which was 'Remove' button in
most cases.
This commit changes it to trigger 'Add' button instead.