### PR TITLE
CEDS-1093 Retain other fields values when adding new value

### DIFF
--- a/app/views/declaration/destination_countries_standard.scala.html
+++ b/app/views/declaration/destination_countries_standard.scala.html
@@ -21,7 +21,7 @@
 @import services.Country
 @import uk.gov.hmrc.play.views.html._
 
-@(form: Form[DestinationCountriesStandard], routingCountries: Seq[String])(implicit request: Request[_], messages: Messages, countries: List[Country], appConfig: AppConfig)
+@(form: Form[DestinationCountriesStandard], routingCountries: Seq[String] = Seq.empty)(implicit request: Request[_], messages: Messages, countries: List[Country], appConfig: AppConfig)
 
 @main_template(
     title = messages("declaration.destinationCountries.title"),

--- a/app/views/declaration/item_type.scala.html
+++ b/app/views/declaration/item_type.scala.html
@@ -23,7 +23,8 @@
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.play.views.html._
 
-@(appConfig: AppConfig,
+@(
+    appConfig: AppConfig,
     form: Form[ItemType],
     taricAdditionalCodes: Seq[String] = Seq.empty,
     nationalAdditionalCodes: Seq[String] = Seq.empty
@@ -34,71 +35,71 @@
     appConfig = appConfig
 ) {
 
-  @helpers.form(ItemTypePageController.submitItemType(), 'autocomplete -> "off") {
-    @components.back_link("/customs-declare-exports/declaration/procedure-codes")
+    @helpers.form(ItemTypePageController.submitItemType(), 'autocomplete -> "off") {
+        @components.back_link("/customs-declare-exports/declaration/procedure-codes")
 
-    @components.error_summary(form.errors)
+        @components.error_summary(form.errors)
 
-    @components.section_header(messages("supplementary.items"))
+        @components.section_header(messages("supplementary.items"))
 
-    @components.page_title(Some("declaration.itemType.title"))
+        @components.page_title(Some("declaration.itemType.title"))
 
-    @components.input_text(
-        field = form(combinedNomenclatureCodeKey),
-        label = messages("declaration.itemType.combinedNomenclatureCode.header"),
-        hint = Some(messages("declaration.itemType.combinedNomenclatureCode.header.hint")),
-        labelClass = Some("bold-small")
-    )
+        @components.input_text(
+            field = form(combinedNomenclatureCodeKey),
+            label = messages("declaration.itemType.combinedNomenclatureCode.header"),
+            hint = Some(messages("declaration.itemType.combinedNomenclatureCode.header.hint")),
+            labelClass = Some("bold-small")
+        )
 
-    @components.input_text_multiple_values(
-        field = form(taricAdditionalCodesKey + "[]"),
-        label = messages("declaration.itemType.taricAdditionalCodes.header"),
-        hint = Some(messages("declaration.itemType.taricAdditionalCodes.header.hint")),
-        elements = taricAdditionalCodes,
-        labelClass = Some("bold-small")
-    )
+        @components.input_text_multiple_values(
+            field = form(taricAdditionalCodesKey + "[]"),
+            label = messages("declaration.itemType.taricAdditionalCodes.header"),
+            hint = Some(messages("declaration.itemType.taricAdditionalCodes.header.hint")),
+            elements = taricAdditionalCodes,
+            labelClass = Some("bold-small")
+        )
 
-    @components.input_text_multiple_values(
-        field = form(nationalAdditionalCodesKey + "[]"),
-        label = messages("declaration.itemType.nationalAdditionalCode.header"),
-        hint = Some(messages("declaration.itemType.nationalAdditionalCode.header.hint")),
-        elements = nationalAdditionalCodes,
-        labelClass = Some("bold-small")
-    )
+        @components.input_text_multiple_values(
+            field = form(nationalAdditionalCodesKey + "[]"),
+            label = messages("declaration.itemType.nationalAdditionalCode.header"),
+            hint = Some(messages("declaration.itemType.nationalAdditionalCode.header.hint")),
+            elements = nationalAdditionalCodes,
+            labelClass = Some("bold-small")
+        )
 
-    @components.input_text(
-      field = form("statisticalValue"),
-      label = messages("declaration.itemType.statisticalValue.header"),
-      hint = Some(messages("declaration.itemType.statisticalValue.header.hint")),
-      labelClass = Some("bold-small")
-    )
+        @components.input_text(
+            field = form("statisticalValue"),
+            label = messages("declaration.itemType.statisticalValue.header"),
+            hint = Some(messages("declaration.itemType.statisticalValue.header.hint")),
+            labelClass = Some("bold-small")
+        )
 
-    @components.input_textarea(
-      field = form("descriptionOfGoods"),
-      label = messages("declaration.itemType.description.header"),
-      hint = Some(messages("declaration.itemType.description.header.hint")),
-      labelClass = Some("bold-small")
-    )
+        @components.input_textarea(
+            field = form("descriptionOfGoods"),
+            label = messages("declaration.itemType.description.header"),
+            hint = Some(messages("declaration.itemType.description.header.hint")),
+            labelClass = Some("bold-small")
+        )
 
-    @components.input_text(
-      field = form(cusCodeKey),
-      label = messages("declaration.itemType.cusCode.header"),
-      hint = Some(messages("declaration.itemType.cusCode.header.hint")),
-      labelClass = Some("bold-small")
-    )
+        @components.input_text(
+            field = form(cusCodeKey),
+            label = messages("declaration.itemType.cusCode.header"),
+            hint = Some(messages("declaration.itemType.cusCode.header.hint")),
+            labelClass = Some("bold-small")
+        )
 
-    @if(request.choice.value == AllowedChoiceValues.StandardDec) @{
-      components.input_text(
-          field = form(unDangerousGoodsCodeKey),
-          label = messages("declaration.itemType.unDangerousGoodsCode.header"),
-          hint = Some(messages("declaration.itemType.unDangerousGoodsCode.header.hint")),
-          labelClass = Some("bold-small")
-      )
+        @if(request.choice.value == AllowedChoiceValues.StandardDec) @{
+            components.input_text(
+                field = form(unDangerousGoodsCodeKey),
+                label = messages("declaration.itemType.unDangerousGoodsCode.header"),
+                hint = Some(messages("declaration.itemType.unDangerousGoodsCode.header.hint")),
+                labelClass = Some("bold-small")
+            )
+        }
+
+        <div class="section align='right'">
+            <button id="submit" class="button" name="@SaveAndContinue.toString">@messages("site.save_and_continue")</button>
+        </div>
     }
-
-    <div class="section align='right'">
-        <button id="submit" class="button" name="@SaveAndContinue.toString">@messages("site.save_and_continue")</button>
-    </div>
-  }
 
 }

--- a/test/controllers/declaration/DestinationCountriesControllerSpec.scala
+++ b/test/controllers/declaration/DestinationCountriesControllerSpec.scala
@@ -21,14 +21,10 @@ import controllers.util.{Add, Remove, SaveAndContinue}
 import forms.Choice
 import forms.Choice.choiceId
 import forms.declaration.DestinationCountriesSupplementarySpec._
-import forms.declaration.destinationCountries.{
-  DestinationCountries,
-  DestinationCountriesStandard,
-  DestinationCountriesSupplementary
-}
+import forms.declaration.destinationCountries.{DestinationCountries, DestinationCountriesStandard, DestinationCountriesSupplementary}
 import helpers.views.declaration.DestinationCountriesMessages
-import play.api.test.Helpers._
 import org.mockito.Mockito.reset
+import play.api.test.Helpers._
 
 class DestinationCountriesControllerSpec extends CustomExportsBaseSpec with DestinationCountriesMessages {
 
@@ -211,7 +207,7 @@ class DestinationCountriesControllerSpec extends CustomExportsBaseSpec with Dest
 
       val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
 
-      status(result) must be(SEE_OTHER)
+      status(result) must be(OK)
     }
 
     "show error message for standard declaration" when {
@@ -260,7 +256,7 @@ class DestinationCountriesControllerSpec extends CustomExportsBaseSpec with Dest
 
         val result = route(app, postRequestFormUrlEncoded(uri, body)).get
 
-        status(result) must be(SEE_OTHER)
+        status(result) must be(OK)
       }
     }
 


### PR DESCRIPTION
When a page contains both single and multi-value fields, there was a
problem that after adding new value the single ones would disappear
after page refresh.