### PR TITLE
CEDS-942 Change submission notifications handling

### DIFF
--- a/app/connectors/CustomsDeclareExportsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsConnector.scala
@@ -67,8 +67,8 @@ class CustomsDeclareExportsConnector @Inject()(appConfig: AppConfig, httpClient:
       s"${appConfig.customsDeclareExports}${appConfig.fetchSubmissionNotifications}/$conversationId"
     )
 
-  def fetchSubmissions()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[SubmissionData]] =
-    httpClient.GET[Seq[SubmissionData]](s"${appConfig.customsDeclareExports}${appConfig.fetchSubmissions}").map {
+  def fetchSubmissions()(implicit hc: HeaderCarrier, ec: ExecutionContext): Future[Seq[Submission]] =
+    httpClient.GET[Seq[Submission]](s"${appConfig.customsDeclareExports}${appConfig.fetchSubmissions}").map {
       response =>
         logger.debug(s"CUSTOMS_DECLARE_EXPORTS fetch submission response is --> ${response.toString}")
         response

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -61,7 +61,7 @@ class ChoiceController @Inject()(
               case CancelDec =>
                 Redirect(controllers.routes.CancelDeclarationController.displayForm())
               case Submissions =>
-                Redirect(controllers.routes.NotificationsController.listOfSubmissions())
+                Redirect(controllers.routes.SubmissionsController.displayListOfSubmissions())
               case _ =>
                 Redirect(controllers.routes.ChoiceController.displayChoiceForm())
             }

--- a/app/controllers/SubmissionsController.scala
+++ b/app/controllers/SubmissionsController.scala
@@ -26,25 +26,22 @@ import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 
 import scala.concurrent.ExecutionContext
 
-class NotificationsController @Inject()(
+class SubmissionsController @Inject()(
   appConfig: AppConfig,
   authenticate: AuthAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   mcc: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+  extends FrontendController(mcc) with I18nSupport {
 
-  def listOfNotifications(): Action[AnyContent] = authenticate.async { implicit request =>
-    customsDeclareExportsConnector.fetchNotifications().map { results =>
-      Ok(views.html.notifications(appConfig, results))
-    }
-  }
-
-  def listOfNotificationsForSubmission(conversationId: String): Action[AnyContent] =
-    authenticate.async { implicit request =>
-      customsDeclareExportsConnector.fetchNotificationsByConversationId(conversationId).map { results =>
-        Ok(views.html.submission_notifications(appConfig, results))
+  def displayListOfSubmissions(): Action[AnyContent] = authenticate.async { implicit request =>
+    for {
+      submissions <- customsDeclareExportsConnector.fetchSubmissions()
+      notifications <- customsDeclareExportsConnector.fetchNotifications()
+      result = submissions.map { submission =>
+        (submission, notifications.count(notification => notification.conversationId == submission.conversationId))
       }
-    }
+    } yield Ok(views.html.submissions(appConfig, result))
+  }
 
 }

--- a/app/models/Submission.scala
+++ b/app/models/Submission.scala
@@ -22,26 +22,12 @@ case class Submission(
   eori: String,
   conversationId: String,
   ducr: String,
-  lrn: Option[String] = None,
-  mrn: Option[String] = None,
+  mrn: Option[String],
+  lrn: Option[String],
+  submittedTimestamp: Long,
   status: Status
 )
 
 object Submission {
   implicit val format = Json.format[Submission]
-}
-
-case class SubmissionData(
-  eori: String,
-  conversationId: String,
-  ducr: String,
-  mrn: Option[String],
-  lrn: Option[String],
-  submittedTimestamp: Long,
-  status: Status,
-  noOfNotifications: Int
-)
-
-object SubmissionData {
-  implicit val format = Json.format[SubmissionData]
 }

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@import java.time.{Instant, ZoneId}
 @import java.time.format.DateTimeFormatter
+@import java.time.{Instant, ZoneId}
 
 @import config.AppConfig
 
@@ -39,16 +39,16 @@
                 <th class="table-cell">@messages("submissions.noOfNotifications")</th>
             </tr>
 
-            @for(submission <- submissions){
+            @for( (submission, notificationsAmount) <- submissions ){
                 <tr class="table-row">
-                    <td class="table-cell">@submission._1.ducr</td>
-                    <td class="table-cell">@submission._1.lrn.getOrElse("")</td>
-                    <td class="table-cell">@submission._1.mrn.getOrElse("")</td>
-                    <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(submission._1.submittedTimestamp))</td>
-                    <td class="table-cell">@submission._1.status</td>
+                    <td class="table-cell">@submission.ducr</td>
+                    <td class="table-cell">@submission.lrn.getOrElse("")</td>
+                    <td class="table-cell">@submission.mrn.getOrElse("")</td>
+                    <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(submission.submittedTimestamp))</td>
+                    <td class="table-cell">@submission.status</td>
                     <td class="table-cell">
-                        <a href="/customs-declare-exports/notifications/@submission._1.conversationId">
-                            @submission._2
+                        <a href="/customs-declare-exports/notifications/@submission.conversationId">
+                            @notificationsAmount
                         </a>
                     </td>
                 </tr>

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -14,12 +14,12 @@
  * limitations under the License.
  *@
 
-@import config.AppConfig
-@import java.time.Instant
-@import java.time.ZoneId
+@import java.time.{Instant, ZoneId}
 @import java.time.format.DateTimeFormatter
 
-@(appConfig: AppConfig, submissions: Seq[SubmissionData])(implicit request: Request[_], messages: Messages)
+@import config.AppConfig
+
+@(appConfig: AppConfig, submissions: Seq[(Submission, Int)])(implicit request: Request[_], messages: Messages)
 
 @main_template(
     title = messages("submissions.title"),
@@ -41,14 +41,14 @@
 
             @for(submission <- submissions){
                 <tr class="table-row">
-                    <td class="table-cell">@submission.ducr</td>
-                    <td class="table-cell">@submission.lrn.getOrElse("")</td>
-                    <td class="table-cell">@submission.mrn.getOrElse("")</td>
-                    <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(submission.submittedTimestamp))</td>
-                    <td class="table-cell">@submission.status</td>
+                    <td class="table-cell">@submission._1.ducr</td>
+                    <td class="table-cell">@submission._1.lrn.getOrElse("")</td>
+                    <td class="table-cell">@submission._1.mrn.getOrElse("")</td>
+                    <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").withZone(ZoneId.systemDefault()).format(Instant.ofEpochMilli(submission._1.submittedTimestamp))</td>
+                    <td class="table-cell">@submission._1.status</td>
                     <td class="table-cell">
-                        <a href="/customs-declare-exports/notifications/@submission.conversationId">
-                            @submission.noOfNotifications
+                        <a href="/customs-declare-exports/notifications/@submission._1.conversationId">
+                            @submission._2
                         </a>
                     </td>
                 </tr>

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -14,7 +14,7 @@ GET        /notifications/:conversationId               controllers.Notification
 
 # Submissions
 
-GET        /submissions                                 controllers.NotificationsController.listOfSubmissions()
+GET        /submissions                                 controllers.SubmissionsController.displayListOfSubmissions()
 
 # Cancel declaration
 

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -85,8 +85,8 @@ microservice {
       host = localhost
       port = 6792
       submit-declaration = "/declaration"
-      fetch-notifications = "/customs-declare-exports/notifications"
-      fetch-submission-notifications = "/customs-declare-exports/submission-notifications"
+      fetch-notifications = "/notifications"
+      fetch-submission-notifications = "/submission-notifications"
       fetch-submissions = "/submissions"
       cancel-declaration = "/cancel-declaration"
     }

--- a/test/base/MockConnectors.scala
+++ b/test/base/MockConnectors.scala
@@ -24,7 +24,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
 import org.scalatest.mockito.MockitoSugar
-import play.api.test.Helpers.{ACCEPTED, BAD_REQUEST, OK}
+import play.api.test.Helpers.{ACCEPTED, BAD_REQUEST}
 import uk.gov.hmrc.http.HttpResponse
 
 import scala.concurrent.Future
@@ -52,24 +52,23 @@ trait MockConnectors extends MockitoSugar {
     when(mockCustomsDeclareExportsConnector.fetchNotificationsByConversationId(any())(any(), any()))
       .thenReturn(
         Future.successful(
-          Seq(ExportsNotification(conversationId = "1234", eori = "eori", metadata = DeclarationMetadata()))
+          Seq(ExportsNotification(conversationId = "conversationId", eori = "eori", metadata = DeclarationMetadata()))
         )
       )
 
-  def listOfSubmissions(): OngoingStubbing[Future[Seq[SubmissionData]]] =
+  def listOfSubmissions(): OngoingStubbing[Future[Seq[Submission]]] =
     when(mockCustomsDeclareExportsConnector.fetchSubmissions()(any(), any()))
       .thenReturn(
         Future.successful(
           Seq(
-            SubmissionData(
+            Submission(
               eori = "eori",
               conversationId = "conversationId",
               ducr = "ducr",
               mrn = None,
               lrn = None,
               submittedTimestamp = System.currentTimeMillis(),
-              status = Accepted,
-              noOfNotifications = 0
+              status = Accepted
             )
           )
         )

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -52,7 +52,7 @@ class AppConfigSpec extends CustomExportsBaseSpec {
         |microservice.services.customs-declare-exports.port=9875
         |microservice.services.customs-declare-exports.submit-declaration=/declaration
         |microservice.services.customs-declare-exports.cancel-declaration=/cancel-declaration
-        |microservice.services.customs-declare-exports.fetch-notifications=/customs-declare-exports/notifications
+        |microservice.services.customs-declare-exports.fetch-notifications=/notifications
         |microservice.services.customs-declare-exports-movements.host=localhostm
         |microservice.services.customs-declare-exports-movements.port=9876
         |microservice.services.customs-declare-exports-movements.save-movement-uri=/save-movement-submission
@@ -144,11 +144,11 @@ class AppConfigSpec extends CustomExportsBaseSpec {
     }
 
     "have fetch notification URL" in {
-      validConfigService.fetchNotifications must be("/customs-declare-exports/notifications")
+      validConfigService.fetchNotifications must be("/notifications")
     }
 
     "have fetch submission notification URL" in {
-      config.fetchSubmissionNotifications must be("/customs-declare-exports/submission-notifications")
+      config.fetchSubmissionNotifications must be("/submission-notifications")
     }
 
     "have fetchSubmissions URL" in {

--- a/test/connectors/CustomsDeclareExportsConnectorSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorSpec.scala
@@ -96,7 +96,6 @@ class CustomsDeclareExportsConnectorSpec extends CustomExportsBaseSpec {
 }
 
 object CustomsDeclareExportsConnectorSpec {
-  val submission = Submission("eori", "id", "ducr", Some("lrn"), Some("mrn"), Accepted)
   val hc: HeaderCarrier = HeaderCarrier(authorization = Some(Authorization(createRandomAlphanumericString(255))))
   val mrn = TestHelper.createRandomAlphanumericString(10)
   val metadata = MetaData()
@@ -107,15 +106,14 @@ object CustomsDeclareExportsConnectorSpec {
     ExportsNotification(conversationId = conversationId, eori = eori, metadata = DeclarationMetadata())
   val notifications = Seq(exportNotification)
 
-  val submissionData = SubmissionData(
+  val submissionData = Submission(
     eori = eori,
     conversationId = conversationId,
     ducr = "",
     mrn = Some(mrn),
     lrn = None,
     submittedTimestamp = 20190318,
-    status = Cancelled,
-    noOfNotifications = 2
+    status = Cancelled
   )
   val submissions = Seq(submissionData)
 

--- a/test/connectors/NrsConnectorSpec.scala
+++ b/test/connectors/NrsConnectorSpec.scala
@@ -17,16 +17,12 @@
 package connectors
 
 import base.ExportsTestData._
-import base.{CustomExportsBaseSpec, MockHttpClient, TestHelper}
+import base.{CustomExportsBaseSpec, MockHttpClient}
 import models._
-import uk.gov.hmrc.http.HeaderCarrier
-import uk.gov.hmrc.http.logging.Authorization
 
 import scala.concurrent.Future
 
 class NrsConnectorSpec extends CustomExportsBaseSpec {
-
-  val submission = Submission("eori", "id", "ducr", Some("lrn"), Some("mrn"), Accepted)
 
   val expectedHeaders: Seq[(String, String)] =
     Seq(("Content-Type", "application/json"), ("X-API-Key", appConfig.nrsApiKey))
@@ -50,7 +46,7 @@ class NrsConnectorSpec extends CustomExportsBaseSpec {
   }
 
   def submitNonRepudiation()(test: Future[NrsSubmissionResponse] => Unit): Unit = {
-    val nrsSubmission = NRSSubmission(submission.toString, nrsMetadata)
+    val nrsSubmission = NRSSubmission("", nrsMetadata)
     val expectedUrl = s"${appConfig.nrsServiceUrl}/submission"
     val http =
       new MockHttpClient(

--- a/test/controllers/NotificationsControllerSpec.scala
+++ b/test/controllers/NotificationsControllerSpec.scala
@@ -17,6 +17,8 @@
 package controllers
 
 import base.CustomExportsBaseSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito._
 import play.api.test.Helpers._
 
 class NotificationsControllerSpec extends CustomExportsBaseSpec {
@@ -27,7 +29,7 @@ class NotificationsControllerSpec extends CustomExportsBaseSpec {
 
   "NotificationController" should {
 
-    "return list of notification" in {
+    "return list of all notifications" in {
       authorizedUser()
       listOfNotifications()
 
@@ -38,9 +40,11 @@ class NotificationsControllerSpec extends CustomExportsBaseSpec {
       stringResult must include(messages("notifications.title"))
       stringResult must include(messages("notifications.status"))
       stringResult must include(messages("notifications.dateAndTime"))
+
+      verify(mockCustomsDeclareExportsConnector, times(1)).fetchNotifications()(any(), any())
     }
 
-    "return list of notifications for submission" in {
+    "return list of notifications for single submission" in {
       authorizedUser()
       listOfSubmissionNotifications()
 
@@ -51,23 +55,8 @@ class NotificationsControllerSpec extends CustomExportsBaseSpec {
       stringResult must include(messages("notifications.title"))
       stringResult must include(messages("notifications.status"))
       stringResult must include(messages("notifications.dateAndTime"))
-    }
 
-    "return list of submissions" in {
-      authorizedUser()
-      listOfSubmissions()
-
-      val result = route(app, getRequest(submissionsUri)).get
-      val stringResult = contentAsString(result)
-
-      status(result) must be(OK)
-      stringResult must include(messages("submissions.title"))
-      stringResult must include(messages("submissions.ducr"))
-      stringResult must include(messages("submissions.lrn"))
-      stringResult must include(messages("submissions.mrn"))
-      stringResult must include(messages("submissions.submittedTimestamp"))
-      stringResult must include(messages("submissions.status"))
-      stringResult must include(messages("submissions.noOfNotifications"))
+      verify(mockCustomsDeclareExportsConnector, times(1)).fetchNotificationsByConversationId(any())(any(), any())
     }
   }
 }

--- a/test/controllers/SubmissionsControllerSpec.scala
+++ b/test/controllers/SubmissionsControllerSpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+import base.CustomExportsBaseSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import play.api.test.Helpers._
+
+class SubmissionsControllerSpec extends CustomExportsBaseSpec {
+
+  val notificationsUri = uriWithContextPath("/notifications")
+  val submissionsUri = uriWithContextPath("/submissions")
+
+  "Submissions Controller" should {
+
+    "return 200 code" in {
+
+      authorizedUser()
+      listOfNotifications()
+      listOfSubmissions()
+
+      val result = route(app, getRequest(submissionsUri)).get
+
+      status(result) must be(OK)
+    }
+
+    "display submissions page with number of notifications for each submission" in {
+
+      authorizedUser()
+      listOfNotifications()
+      listOfSubmissions()
+
+      val result = route(app, getRequest(submissionsUri)).get
+      val stringResult = contentAsString(result)
+
+      stringResult must include(messages("submissions.title"))
+      stringResult must include(messages("submissions.ducr"))
+      stringResult must include(messages("submissions.lrn"))
+      stringResult must include(messages("submissions.mrn"))
+      stringResult must include(messages("submissions.submittedTimestamp"))
+      stringResult must include(messages("submissions.status"))
+      stringResult must include(messages("submissions.noOfNotifications"))
+    }
+
+    "call CustomsDeclareExportsConnector 2 times: for submissions and for notifications" in {
+
+      authorizedUser()
+      listOfNotifications()
+      listOfSubmissions()
+
+      val result = route(app, getRequest(submissionsUri)).get
+
+      status(result) must be(OK)
+
+      val inOrderCheck = Mockito.inOrder(mockCustomsDeclareExportsConnector)
+      inOrderCheck.verify(mockCustomsDeclareExportsConnector).fetchSubmissions()(any(), any())
+      inOrderCheck.verify(mockCustomsDeclareExportsConnector).fetchNotifications()(any(), any())
+    }
+  }
+
+}


### PR DESCRIPTION
Now, instead of one call to the backend, there are two, but the logic
around calculating the number of notifications for submission
has been moved to SubmissionController from backend service.