### PR TITLE
CEDS-1224 Fix DepartureTransportMeans builder

### DIFF
--- a/app/services/mapping/goodsshipment/consignment/TransportEquipmentBuilder.scala
+++ b/app/services/mapping/goodsshipment/consignment/TransportEquipmentBuilder.scala
@@ -47,6 +47,7 @@ object TransportEquipmentBuilder {
     val transportEquipment = new GoodsShipment.Consignment.TransportEquipment()
     transportEquipment.setSequenceNumeric(new java.math.BigDecimal(seals.size))
     transportEquipment.getSeal.addAll(seals.zipWithIndex.map(data => createSeal(data)).toList.asJava)
+    transportEquipment.getSeal
     Seq(transportEquipment)
   }
 

--- a/test/resources/wco_dec_metadata.xml
+++ b/test/resources/wco_dec_metadata.xml
@@ -72,7 +72,7 @@
                 </ns3:ArrivalTransportMeans>
                 <ns3:DepartureTransportMeans>
                     <ns3:ID>123112yu78</ns3:ID>
-                    <ns3:IdentificationTypeCode>40</ns3:IdentificationTypeCode>
+                    <ns3:IdentificationTypeCode>10</ns3:IdentificationTypeCode>
                 </ns3:DepartureTransportMeans>
                 <ns3:GoodsLocation>
                     <ns3:Name>LOC</ns3:Name>

--- a/test/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/consignment/ConsignmentBuilderSpec.scala
@@ -54,7 +54,7 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers {
         consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 CD3")
 
         consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
-        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("10")
 
         consignment.getArrivalTransportMeans.getModeCode.getValue should be("2")
         consignment.getTransportEquipment.size() should be(0)
@@ -87,7 +87,7 @@ class ConsignmentBuilderSpec extends WordSpec with Matchers {
         consignment.getGoodsLocation.getAddress.getPostcodeID.getValue should be("AB12 CD3")
 
         consignment.getDepartureTransportMeans.getID.getValue should be("123112yu78")
-        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+        consignment.getDepartureTransportMeans.getIdentificationTypeCode.getValue should be("10")
 
         consignment.getArrivalTransportMeans.getModeCode.getValue should be("2")
 

--- a/test/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
+++ b/test/services/mapping/goodsshipment/consignment/DepartureTransportMeansBuilderSpec.scala
@@ -15,7 +15,7 @@
  */
 
 package services.mapping.goodsshipment.consignment
-import forms.declaration.{BorderTransport, TransportDetails}
+import forms.declaration.BorderTransport
 import org.scalatest.{Matchers, WordSpec}
 import play.api.libs.json.Json
 import uk.gov.hmrc.http.cache.client.CacheMap
@@ -28,14 +28,12 @@ class DepartureTransportMeansBuilderSpec extends WordSpec with Matchers {
           "CacheID",
           Map(
             BorderTransport.formId ->
-              Json.toJson(BorderTransport("3", "10", Some("123112yu78"))),
-            TransportDetails.formId -> Json
-              .toJson(TransportDetails(Some("Portugal"), true, "40", Some("1234567878ui"), Some("A")))
+              Json.toJson(BorderTransport("3", "10", Some("123112yu78")))
           )
         )
       val departureTransportMeans = DepartureTransportMeansBuilder.build
       departureTransportMeans.getID.getValue should be("123112yu78")
-      departureTransportMeans.getIdentificationTypeCode.getValue should be("40")
+      departureTransportMeans.getIdentificationTypeCode.getValue should be("10")
       departureTransportMeans.getName should be(null)
       departureTransportMeans.getTypeCode should be(null)
       departureTransportMeans.getModeCode should be(null)


### PR DESCRIPTION
`DepartureTransportMeans.identificationTypeCode` should be mapped based
on the `BorderTransport` and not on the `TransportDetails`