### PR TITLE
[CEDS-1244] - disable audit for destination-countries page

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,6 +51,11 @@ json.encryption.key = ${sso.encryption.key}
 
 play.i18n.langs = ["en", "cy"]
 
+controllers.declaration.DestinationCountriesController = {
+  needsLogging = true
+  needsAuditing = false
+}
+
 microservice {
   metrics {
     graphite {


### PR DESCRIPTION
The config is to exclude the controller to not to audit the requests on the page.
this is the initial fix  with config, there should be long term fix with customised filer for audit that has been suggested by TXM team if we have more pages with issues when the code list has been introduced