### PR TITLE
CEDS-1244 Stop logging TXM implicit audit events

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,8 +51,8 @@ json.encryption.key = ${sso.encryption.key}
 
 play.i18n.langs = ["en", "cy"]
 
-controllers.declaration.DestinationCountriesController = {
-  needsLogging = false
+controllers.declaration.DestinationCountriesController {
+  needsLogging = true
   needsAuditing = false
 }
 


### PR DESCRIPTION
At the moment TXM is stating that all of our
`DestinationCountriesController` audit events are exceeding the response
body limit.
This is happening regardless of us setting `needsAuditing` to `false`.
With this change I want to understand if the Audit config is correctly
setup, because once it is deployed to QA it should stop logging the
errors.
If it does not stop logging, than this is a sign that the configuration
is not setup correctly.
I believe it is to do with the format of the configuration.