### PR TITLE
CEDS-1244 Correct the TXM auditing configuration

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -51,9 +51,11 @@ json.encryption.key = ${sso.encryption.key}
 
 play.i18n.langs = ["en", "cy"]
 
-controllers.declaration.DestinationCountriesController {
-  needsLogging = true
-  needsAuditing = false
+controllers {
+  controllers.declaration.DestinationCountriesController {
+    needsLogging = true
+    needsAuditing = false
+  }
 }
 
 microservice {


### PR DESCRIPTION
Controllers that do require TXM auditing configuration need to be
wrapped in the controllers object.