### PR TITLE
CEDS-1303: add reactivemongo cache model

### DIFF
--- a/app/controllers/declaration/AdditionalDeclarationTypePageController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypePageController.scala
@@ -20,18 +20,13 @@ import config.AppConfig
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.util.CacheIdGenerator.cacheId
 import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
-import forms.declaration.additionaldeclarationtype.{
-  AdditionalDeclarationType,
-  AdditionalDeclarationTypeStandardDec,
-  AdditionalDeclarationTypeSupplementaryDec,
-  AdditionalDeclarationTypeTrait
-}
+import forms.declaration.additionaldeclarationtype._
 import javax.inject.Inject
 import models.requests.JourneyRequest
-import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.CustomsCacheService
+import services.cache.{ExportsCacheService, ExportsCacheModel}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.additionaldeclarationtype.declaration_type
 
@@ -41,9 +36,12 @@ class AdditionalDeclarationTypePageController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
+  exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+    extends  {
+  val cacheService = exportsCacheService
+}  with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val decType = extractFormType(request)
@@ -59,12 +57,13 @@ class AdditionalDeclarationTypePageController @Inject()(
       .form()
       .bindFromRequest()
       .fold(
-        (formWithErrors: Form[AdditionalDeclarationType]) =>
-          Future.successful(BadRequest(declaration_type(formWithErrors))),
-        validAdditionalDeclarationType =>
+        formWithErrors => Future.successful(BadRequest(declaration_type(formWithErrors))),
+        validAdditionalDeclarationType => {
+          updateCache(journeySessionId, validAdditionalDeclarationType)
           customsCacheService
             .cache[AdditionalDeclarationType](cacheId, decType.formId, validAdditionalDeclarationType)
             .map(_ => Redirect(controllers.declaration.routes.ConsignmentReferencesController.displayPage()))
+        }
       )
   }
 
@@ -73,4 +72,13 @@ class AdditionalDeclarationTypePageController @Inject()(
       case SupplementaryDec => AdditionalDeclarationTypeSupplementaryDec
       case StandardDec      => AdditionalDeclarationTypeStandardDec
     }
+
+  private def updateCache(
+    sessionId: String,
+    formData: AdditionalDeclarationType
+  ): Future[Either[String, ExportsCacheModel]] =
+    updateHeaderLevelCache(sessionId, model => {
+      exportsCacheService.update(sessionId, model.copy(additionalDeclarationType = Some(formData)))
+    })
+
 }

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -60,13 +60,12 @@ class ConsignmentReferencesController @Inject()(
       .fold(
         (formWithErrors: Form[ConsignmentReferences]) =>
           Future.successful(BadRequest(consignment_references(appConfig, formWithErrors))),
-        validConsignmentReferences => {
-         updateCache(journeySessionId, validConsignmentReferences)
-
-          customsCacheService
-            .cache[ConsignmentReferences](cacheId, ConsignmentReferences.id, validConsignmentReferences)
-            .map(_ => Redirect(controllers.declaration.routes.ExporterDetailsPageController.displayForm()))
-        }
+        validConsignmentReferences =>
+          for {
+            _ <- updateCache(journeySessionId, validConsignmentReferences)
+            _ <- customsCacheService
+              .cache[ConsignmentReferences](cacheId, ConsignmentReferences.id, validConsignmentReferences)
+          } yield Redirect(controllers.declaration.routes.ExporterDetailsPageController.displayForm())
       )
   }
 
@@ -77,6 +76,5 @@ class ConsignmentReferencesController @Inject()(
     updateHeaderLevelCache(sessionId, model => {
       exportsCacheService.update(sessionId, model.copy(consignmentReferences = Some(formData)))
     })
-
 
 }

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -26,6 +26,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.CustomsCacheService
+import services.cache.{ExportsCacheModel, ExportsCacheService}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.consignment_references
 
@@ -37,9 +38,12 @@ class ConsignmentReferencesController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
+  exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+    extends {
+  val cacheService = exportsCacheService
+} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     customsCacheService
@@ -57,11 +61,22 @@ class ConsignmentReferencesController @Inject()(
         (formWithErrors: Form[ConsignmentReferences]) =>
           Future.successful(BadRequest(consignment_references(appConfig, formWithErrors))),
         validConsignmentReferences => {
+         updateCache(journeySessionId, validConsignmentReferences)
+
           customsCacheService
             .cache[ConsignmentReferences](cacheId, ConsignmentReferences.id, validConsignmentReferences)
             .map(_ => Redirect(controllers.declaration.routes.ExporterDetailsPageController.displayForm()))
         }
       )
   }
+
+  private def updateCache(
+    sessionId: String,
+    formData: ConsignmentReferences
+  ): Future[Either[String, ExportsCacheModel]] =
+    updateHeaderLevelCache(sessionId, model => {
+      exportsCacheService.update(sessionId, model.copy(consignmentReferences = Some(formData)))
+    })
+
 
 }

--- a/app/controllers/declaration/ExporterDetailsPageController.scala
+++ b/app/controllers/declaration/ExporterDetailsPageController.scala
@@ -25,6 +25,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.CustomsCacheService
+import services.cache.{ExportsCacheModel, ExportsCacheService}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.exporter_details
 
@@ -35,9 +36,12 @@ class ExporterDetailsPageController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
+  exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents
 )(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+    extends {
+  val cacheService = exportsCacheService
+} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     customsCacheService.fetchAndGetEntry[ExporterDetails](cacheId, ExporterDetails.id).map {
@@ -52,10 +56,18 @@ class ExporterDetailsPageController @Inject()(
       .fold(
         (formWithErrors: Form[ExporterDetails]) =>
           Future.successful(BadRequest(exporter_details(appConfig, formWithErrors))),
-        form =>
+        form => {
+          updateCache(journeySessionId, form)
+
           customsCacheService.cache[ExporterDetails](cacheId, ExporterDetails.id, form).map { _ =>
             Redirect(controllers.declaration.routes.ConsigneeDetailsPageController.displayForm())
+          }
         }
       )
   }
+
+  private def updateCache(sessionId: String, formData: ExporterDetails): Future[Either[String, ExportsCacheModel]] =
+    updateHeaderLevelCache(sessionId, model => {
+      exportsCacheService.update(sessionId, model.copy(exporterDetails = Some(formData)))
+    })
 }

--- a/app/controllers/declaration/ExporterDetailsPageController.scala
+++ b/app/controllers/declaration/ExporterDetailsPageController.scala
@@ -56,13 +56,11 @@ class ExporterDetailsPageController @Inject()(
       .fold(
         (formWithErrors: Form[ExporterDetails]) =>
           Future.successful(BadRequest(exporter_details(appConfig, formWithErrors))),
-        form => {
-          updateCache(journeySessionId, form)
-
-          customsCacheService.cache[ExporterDetails](cacheId, ExporterDetails.id, form).map { _ =>
-            Redirect(controllers.declaration.routes.ConsigneeDetailsPageController.displayForm())
-          }
-        }
+        form =>
+          for {
+            _ <- updateCache(journeySessionId, form)
+            _ <- customsCacheService.cache[ExporterDetails](cacheId, ExporterDetails.id, form)
+          } yield Redirect(controllers.declaration.routes.ConsigneeDetailsPageController.displayForm())
       )
   }
 

--- a/app/controllers/declaration/ModelCacheable.scala
+++ b/app/controllers/declaration/ModelCacheable.scala
@@ -25,22 +25,20 @@ import scala.concurrent.{ExecutionContext, Future}
 trait ModelCacheable {
   val cacheService: ExportsCacheService
 
-
-  protected def updateHeaderLevelCache(sessionId: String,
-                                       update: ExportsCacheModel => Future[Either[String, ExportsCacheModel]])
-                                      (implicit ec: ExecutionContext): Future[Either[String, ExportsCacheModel]] =
+  protected def updateHeaderLevelCache(
+    sessionId: String,
+    update: ExportsCacheModel => Future[Either[String, ExportsCacheModel]]
+  )(implicit ec: ExecutionContext): Future[Either[String, ExportsCacheModel]] =
     cacheService.get(sessionId).flatMap {
       case Right(model) => update(model)
     }
 
-
-
 }
 
 trait SessionIdAware {
-  def journeySessionId(implicit request: JourneyRequest[AnyContent]) =
+  def journeySessionId(implicit request: JourneyRequest[_]) =
     request.authenticatedRequest.session.data("sessionId")
 
-   def authenticatedSessionId(implicit request: AuthenticatedRequest[AnyContent]) =
+  def authenticatedSessionId(implicit request: AuthenticatedRequest[AnyContent]) =
     request.session.data("sessionId")
 }

--- a/app/controllers/declaration/ModelCacheable.scala
+++ b/app/controllers/declaration/ModelCacheable.scala
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declaration
+
+import models.requests.{AuthenticatedRequest, JourneyRequest}
+import play.api.mvc.AnyContent
+import services.cache.{ExportsCacheModel, ExportsCacheService}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait ModelCacheable {
+  val cacheService: ExportsCacheService
+
+
+  protected def updateHeaderLevelCache(sessionId: String,
+                                       update: ExportsCacheModel => Future[Either[String, ExportsCacheModel]])
+                                      (implicit ec: ExecutionContext): Future[Either[String, ExportsCacheModel]] =
+    cacheService.get(sessionId).flatMap {
+      case Right(model) => update(model)
+    }
+
+
+
+}
+
+trait SessionIdAware {
+  def journeySessionId(implicit request: JourneyRequest[AnyContent]) =
+    request.authenticatedRequest.session.data("sessionId")
+
+   def authenticatedSessionId(implicit request: AuthenticatedRequest[AnyContent]) =
+    request.session.data("sessionId")
+}

--- a/app/controllers/declaration/ProcedureCodesPageController.scala
+++ b/app/controllers/declaration/ProcedureCodesPageController.scala
@@ -31,6 +31,7 @@ import play.api.data.{Form, FormError}
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.CustomsCacheService
+import services.cache.{ExportsCacheModel, ExportsCacheService}
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.procedure_codes
@@ -38,14 +39,15 @@ import views.html.declaration.procedure_codes
 import scala.concurrent.{ExecutionContext, Future}
 
 class ProcedureCodesPageController @Inject()(
-  appConfig: AppConfig,
-  authenticate: AuthAction,
-  journeyType: JourneyAction,
-  errorHandler: ErrorHandler,
-  customsCacheService: CustomsCacheService,
-  mcc: MessagesControllerComponents
-)(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+                                              appConfig: AppConfig,
+                                              authenticate: AuthAction,
+                                              journeyType: JourneyAction,
+                                              errorHandler: ErrorHandler,
+                                              customsCacheService: CustomsCacheService,
+                                              exportsCacheService: ExportsCacheService,
+                                              mcc: MessagesControllerComponents
+                                            )(implicit ec: ExecutionContext)
+  extends {val cacheService = exportsCacheService} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     customsCacheService.fetchAndGetEntry[ProcedureCodesData](goodsItemCacheId, formId).map {
@@ -58,7 +60,7 @@ class ProcedureCodesPageController @Inject()(
   def submitProcedureCodes(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
 
-    val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded(_))
+    val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded)
 
     val cachedData = customsCacheService
       .fetchAndGetEntry[ProcedureCodesData](goodsItemCacheId, formId)
@@ -71,20 +73,30 @@ class ProcedureCodesPageController @Inject()(
             Future.successful(BadRequest(procedure_codes(appConfig, formWithErrors, cache.additionalProcedureCodes))),
           validForm => {
             actionTypeOpt match {
-              case Some(Add)             => addAnotherCodeHandler(validForm, cache)
-              case Some(SaveAndContinue) => saveAndContinueHandler(validForm, cache)
-              case Some(Remove(values))  => removeCodeHandler(retrieveProcedureCode(values), cache)
-              case _                     => errorHandler.displayErrorPage()
+              case Some(Add) => addAnotherCodeHandler(validForm, cache)
+              case Some(SaveAndContinue) => {
+                updateCache(journeySessionId, validForm)
+                saveAndContinueHandler(validForm, cache)
+              }
+              case Some(Remove(values)) => removeCodeHandler(retrieveProcedureCode(values), cache)
+              case _ => errorHandler.displayErrorPage()
             }
           }
         )
     }
   }
 
+  private def updateCache(sessionId: String, procedureCodes: ProcedureCodes): Future[Either[String, ExportsCacheModel]] = {
+    updateHeaderLevelCache(sessionId, model => {
+      val item = model.items.head.copy(procedureCodes = Some(procedureCodes))
+      exportsCacheService.update(sessionId, model.copy(items = List(item)))
+    })
+  }
+
   private def addAnotherCodeHandler(
-    userInput: ProcedureCodes,
-    cachedData: ProcedureCodesData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
+                                     userInput: ProcedureCodes,
+                                     cachedData: ProcedureCodesData
+                                   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
     (userInput.additionalProcedureCode, cachedData.additionalProcedureCodes) match {
       case (_, codes) if codes.length >= limitOfCodes =>
         handleErrorPage(
@@ -116,9 +128,9 @@ class ProcedureCodesPageController @Inject()(
     }
 
   private def removeCodeHandler(
-    code: String,
-    cachedData: ProcedureCodesData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
+                                 code: String,
+                                 cachedData: ProcedureCodesData
+                               )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
     if (cachedData.containsAdditionalCode(code)) {
       val updatedCache =
         cachedData.copy(additionalProcedureCodes = cachedData.additionalProcedureCodes.filterNot(_ == code))
@@ -130,9 +142,9 @@ class ProcedureCodesPageController @Inject()(
 
   //scalastyle:off method.length
   private def saveAndContinueHandler(
-    userInput: ProcedureCodes,
-    cachedData: ProcedureCodesData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
+                                      userInput: ProcedureCodes,
+                                      cachedData: ProcedureCodesData
+                                    )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
     (userInput, cachedData.additionalProcedureCodes) match {
       case (procedureCode, Seq()) =>
         procedureCode match {
@@ -189,15 +201,16 @@ class ProcedureCodesPageController @Inject()(
             }
         }
     }
+
   //scalastyle:on method.length
 
   private def retrieveProcedureCode(values: Seq[String]): String = values.headOption.getOrElse("")
 
   private def handleErrorPage(
-    fieldWithError: Seq[(String, String)],
-    userInput: ProcedureCodes,
-    additionalProcedureCodes: Seq[String]
-  )(implicit request: Request[_]): Future[Result] = {
+                               fieldWithError: Seq[(String, String)],
+                               userInput: ProcedureCodes,
+                               additionalProcedureCodes: Seq[String]
+                             )(implicit request: Request[_]): Future[Result] = {
     val updatedErrors = fieldWithError.map((FormError.apply(_: String, _: String)).tupled)
 
     val formWithError = form.fill(userInput).copy(errors = updatedErrors)

--- a/app/services/cache/ExportItem.scala
+++ b/app/services/cache/ExportItem.scala
@@ -21,8 +21,7 @@ import java.util.UUID
 import forms.declaration.ProcedureCodes
 import play.api.libs.json.Json
 
-case class ExportItem(id: UUID = UUID.randomUUID(),
-                      procedureCodes: Option[ProcedureCodes] = None)
+case class ExportItem(id: UUID = UUID.randomUUID(), procedureCodes: Option[ProcedureCodes] = None)
 
 object ExportItem {
   implicit val format = Json.format[ExportItem]

--- a/app/services/cache/ExportItem.scala
+++ b/app/services/cache/ExportItem.scala
@@ -1,0 +1,29 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+import java.util.UUID
+
+import forms.declaration.ProcedureCodes
+import play.api.libs.json.Json
+
+case class ExportItem(id: UUID = UUID.randomUUID(),
+                      procedureCodes: Option[ProcedureCodes] = None)
+
+object ExportItem {
+  implicit val format = Json.format[ExportItem]
+}

--- a/app/services/cache/ExportsCacheModelRepository.scala
+++ b/app/services/cache/ExportsCacheModelRepository.scala
@@ -41,19 +41,11 @@ class ExportsCacheModelRepository @Inject()(mc: ReactiveMongoComponent)(implicit
 
   implicit val journeyFormats = ExportsCacheModel.format
 
-  def get(sessionId: String): Future[Option[ExportsCacheModel]] =
-    find("sessionId" -> sessionId).map(_.headOption)
-
-  def getWithEither(sessionId: String): Future[Either[String, ExportsCacheModel]] =
+  def get(sessionId: String): Future[Either[String, ExportsCacheModel]] =
     find("sessionId" -> sessionId).map(_.headOption).map {
       case Some(model) => Right(model)
       case None        => Left(s"Unable to find model with sessionID: $sessionId")
     }
-
-  def save(journeyCacheModel: ExportsCacheModel): Future[Boolean] = insert(journeyCacheModel).map { res =>
-    if (!res.ok) logger.error(s"Errors when persisting cacheModel: ${res.writeErrors.mkString("--")}")
-    res.ok
-  }
 
   def upsert(sessionId: String, journeyCacheModel: ExportsCacheModel): Future[Option[ExportsCacheModel]] =
     collection

--- a/app/services/cache/ExportsCacheModelRepository.scala
+++ b/app/services/cache/ExportsCacheModelRepository.scala
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+import java.time.LocalDateTime
+
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
+import forms.declaration.{ConsignmentReferences, DispatchLocation, ExporterDetails}
+import javax.inject.Inject
+import play.api.libs.json.{JsObject, Json}
+import play.modules.reactivemongo.ReactiveMongoComponent
+import reactivemongo.bson.BSONObjectID
+import reactivemongo.play.json.ImplicitBSONHandlers._
+import reactivemongo.play.json.commands.JSONFindAndModifyCommand.FindAndModifyResult
+import uk.gov.hmrc.mongo.ReactiveRepository
+import uk.gov.hmrc.mongo.json.ReactiveMongoFormats.objectIdFormats
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class ExportsCacheModelRepository @Inject()(mc: ReactiveMongoComponent)(implicit ec: ExecutionContext)
+    extends ReactiveRepository[ExportsCacheModel, BSONObjectID](
+      "exportsJourneyCache",
+      mc.mongoConnector.db,
+      ExportsCacheModel.format,
+      objectIdFormats
+    ) {
+
+  implicit val journeyFormats = ExportsCacheModel.format
+
+  def get(sessionId: String): Future[Option[ExportsCacheModel]] =
+    find("sessionId" -> sessionId).map(_.headOption)
+
+  def getWithEither(sessionId: String): Future[Either[String, ExportsCacheModel]] =
+    find("sessionId" -> sessionId).map(_.headOption).map {
+      case Some(model) => Right(model)
+      case None        => Left(s"Unable to find model with sessionID: $sessionId")
+    }
+
+  def save(journeyCacheModel: ExportsCacheModel): Future[Boolean] = insert(journeyCacheModel).map { res =>
+    if (!res.ok) logger.error(s"Errors when persisting cacheModel: ${res.writeErrors.mkString("--")}")
+    res.ok
+  }
+
+  def upsert(sessionId: String, journeyCacheModel: ExportsCacheModel): Future[Option[ExportsCacheModel]] =
+    collection
+      .findAndUpdate(
+        selector = bySessionId(sessionId),
+        update = journeyCacheModel,
+        fetchNewObject = true,
+        upsert = true
+      )
+      .map { updateResult =>
+        if (updateResult.value.isEmpty) logDatabaseUpdateError(updateResult)
+        updateResult.result[ExportsCacheModel]
+      }
+
+  private def bySessionId(id: String): JsObject =
+    Json.obj("sessionId" -> id)
+
+  private def logDatabaseUpdateError(res: FindAndModifyResult): Unit =
+    res.lastError.foreach(_.err.foreach(errorMsg => logger.error(s"Problem during database update: $errorMsg")))
+
+}
+
+case class ExportsCacheModel(
+  sessionId: String,
+  draftId: String,
+  createdDateTime: LocalDateTime,
+  updatedDateTime: LocalDateTime,
+  choice: String,
+  dispatchLocation: Option[DispatchLocation] = None,
+  additionalDeclarationType: Option[AdditionalDeclarationType] = None,
+  consignmentReferences: Option[ConsignmentReferences] = None,
+  exporterDetails: Option[ExporterDetails] = None,
+  items: List[ExportItem] = Nil
+)
+
+object ExportsCacheModel {
+  implicit val format = Json.format[ExportsCacheModel]
+}

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+import java.time.LocalDateTime.now
+
+import javax.inject.{Inject, Singleton}
+import play.api.Logger
+
+import scala.concurrent.{ExecutionContext, Future}
+
+@Singleton
+class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsCacheModelRepository)(implicit ec: ExecutionContext) {
+  private val logger = Logger(this.getClass)
+
+  def get(sessionId: String): Future[Either[String, ExportsCacheModel]] = journeyCacheModelRepo.getWithEither(sessionId)
+
+  def getBySessionIdAndFormId(sessionId: String): Future[Option[ExportsCacheModel]] = journeyCacheModelRepo.get(sessionId)
+
+  def update(sessionId: String, model: ExportsCacheModel): Future[Either[String, ExportsCacheModel]] = {
+    journeyCacheModelRepo.upsert(sessionId, model.copy(updatedDateTime = now())).map {
+      case Some(retrievedModel) => Right(retrievedModel)
+      case None => Left("unable to sss")
+    }
+  }.recover {
+    case exception: Throwable =>
+      logger.error(s"There is a problem saving the cacheModel with exception: ${exception.getMessage}")
+      Left(exception.getMessage)
+  }
+
+  def save(model: ExportsCacheModel): Future[Either[String, Unit]] = {
+    journeyCacheModelRepo.save(model).map {
+      case false => Left("Failed saving cacheModel")
+      case true => Right(())
+    }.recover {
+      case exception: Throwable =>
+        logger.error(s"There is a problem saving the cacheModel with exception: ${exception.getMessage}")
+        Left(exception.getMessage)
+    }
+  }
+}
+

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -19,38 +19,18 @@ package services.cache
 import java.time.LocalDateTime.now
 
 import javax.inject.{Inject, Singleton}
-import play.api.Logger
 
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsCacheModelRepository)(implicit ec: ExecutionContext) {
-  private val logger = Logger(this.getClass)
 
-  def get(sessionId: String): Future[Either[String, ExportsCacheModel]] = journeyCacheModelRepo.getWithEither(sessionId)
+  def get(sessionId: String): Future[Either[String, ExportsCacheModel]] = journeyCacheModelRepo.get(sessionId)
 
-  def getBySessionIdAndFormId(sessionId: String): Future[Option[ExportsCacheModel]] = journeyCacheModelRepo.get(sessionId)
-
-  def update(sessionId: String, model: ExportsCacheModel): Future[Either[String, ExportsCacheModel]] = {
+  def update(sessionId: String, model: ExportsCacheModel): Future[Either[String, ExportsCacheModel]] =
     journeyCacheModelRepo.upsert(sessionId, model.copy(updatedDateTime = now())).map {
       case Some(retrievedModel) => Right(retrievedModel)
-      case None => Left("unable to sss")
+      case None                 => Left(s"Unable to retrieve a model for session id $sessionId")
     }
-  }.recover {
-    case exception: Throwable =>
-      logger.error(s"There is a problem saving the cacheModel with exception: ${exception.getMessage}")
-      Left(exception.getMessage)
-  }
 
-  def save(model: ExportsCacheModel): Future[Either[String, Unit]] = {
-    journeyCacheModelRepo.save(model).map {
-      case false => Left("Failed saving cacheModel")
-      case true => Right(())
-    }.recover {
-      case exception: Throwable =>
-        logger.error(s"There is a problem saving the cacheModel with exception: ${exception.getMessage}")
-        Left(exception.getMessage)
-    }
-  }
 }
-

--- a/app/views/declaration/items_summary.scala.html
+++ b/app/views/declaration/items_summary.scala.html
@@ -80,7 +80,12 @@
                 @messages("site.add.anotherItem")
             }
         </a><p></p>
-        @if(items.size > 0) {
+
+        @helpers.form(ItemsSummaryController.addItem(), 'autoComplete -> "off") {
+            @components.submit_button()
+        }
+
+        @if(items.nonEmpty) {
             <a href="@WarehouseIdentificationController.displayForm().url" class="button" id="next">@messages("site.save_and_continue")</a>
         }
     </div>

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -159,6 +159,7 @@ POST        /additional-fiscal-references        controllers.declaration.Additio
 # Items Summary
 
 GET         /export-items                        controllers.declaration.ItemsSummaryController.displayForm()
+POST        /export-items                        controllers.declaration.ItemsSummaryController.addItem()
 
 # Border Transport
 

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -25,18 +25,22 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
 import play.api.libs.json.{JsObject, JsString}
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
   private val choiceUri = uriWithContextPath("/choice")
+  private val sessionId = "12345"
 
   before {
     authorizedUser()
+    withNewCaching(createModel(sessionId))
     withCaching[Choice](None, Choice.choiceId)
   }
 
   after {
     reset(mockCustomsCacheService)
+    reset(mockExportsCacheService)
   }
 
   "Choice Controller on GET" should {
@@ -90,6 +94,8 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       verify(mockCustomsCacheService)
         .cache[Choice](any(), ArgumentMatchers.eq(Choice.choiceId), any())(any(), any(), any())
+
+      verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
     }
 
     "redirect to dispatch location page when 'Supplementary declaration' is selected" in {

--- a/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
@@ -34,6 +34,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.Future
@@ -50,6 +51,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
     val journeyRequest = JourneyRequest(authenticatedRequest, Choice(AllowedChoiceValues.StandardDec))
     val cacheId = CacheIdGenerator.cacheId()(journeyRequest)
 
+    withNewCaching(createModel())
     withCaching[Choice](Some(Choice(AllowedChoiceValues.StandardDec)), choiceId)
     mockCacheBehaviour(cacheId, AdditionalDeclarationTypeStandardDec.formId)(None)
   }
@@ -58,6 +60,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
     val journeyRequest = JourneyRequest(authenticatedRequest, Choice(AllowedChoiceValues.SupplementaryDec))
     val cacheId = CacheIdGenerator.cacheId()(journeyRequest)
 
+    withNewCaching(createModel())
     withCaching[Choice](Some(Choice(AllowedChoiceValues.SupplementaryDec)), choiceId)
     mockCacheBehaviour(cacheId, AdditionalDeclarationTypeStandardDec.formId)(None)
   }
@@ -87,6 +90,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
 
   after {
     reset(mockCustomsCacheService)
+    reset(mockExportsCacheService)
   }
 
   "Additional Declaration Type Controller on GET" should {
@@ -145,6 +149,9 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           ArgumentMatchers.eq(AdditionalDeclarationTypeSupplementaryDec.formId),
           any()
         )(any(), any(), any())
+
+        verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
+        verify(mockExportsCacheService).get(any())
       }
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
@@ -157,6 +164,9 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           ArgumentMatchers.eq(AdditionalDeclarationTypeSupplementaryDec.formId),
           any()
         )(any(), any(), any())
+
+        verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
+        verify(mockExportsCacheService).get(any())
       }
     }
 

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -37,12 +37,14 @@ class ConsignmentReferencesControllerSpec
 
   before {
     authorizedUser()
+    withNewCaching(createModel())
     withCaching[ConsignmentReferences](None, ConsignmentReferences.id)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
   after {
     reset(mockCustomsCacheService)
+    reset(mockExportsCacheService)
   }
 
   "Consignment References Controller on GET" should {
@@ -95,6 +97,8 @@ class ConsignmentReferencesControllerSpec
             any(),
             any()
           )
+        verify(mockExportsCacheService).update(any(), any())
+        verify(mockExportsCacheService).get(any())
       }
     }
 

--- a/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
+++ b/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
@@ -26,6 +26,7 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
 
@@ -34,12 +35,14 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
 
   before {
     authorizedUser()
+    withNewCaching(createModel())
     withCaching[DispatchLocation](None, DispatchLocation.formId)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
   after {
     reset(mockCustomsCacheService)
+    reset(mockExportsCacheService)
   }
 
   "Declaration Type Controller on GET" should {
@@ -67,6 +70,9 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
 
       verify(mockCustomsCacheService)
         .cache[DispatchLocation](any(), ArgumentMatchers.eq(DispatchLocation.formId), any())(any(), any(), any())
+
+      verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
+      verify(mockExportsCacheService).get(any())
     }
 
     "return 303 code" in {

--- a/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
@@ -31,6 +31,7 @@ class ExporterDetailsPageControllerSpec extends CustomExportsBaseSpec with Commo
 
   before {
     authorizedUser()
+    withNewCaching(createModel())
     withCaching[ExporterDetails](None)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }

--- a/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
@@ -36,6 +36,7 @@ class ProcedureCodesPageControllerSpec
 
   before {
     authorizedUser()
+    withNewCaching(createModel())
     withCaching[ProcedureCodesData](None, formId)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }

--- a/test/services/cache/ExportsCacheModelRepositorySpec.scala
+++ b/test/services/cache/ExportsCacheModelRepositorySpec.scala
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+import java.time.LocalDateTime
+
+import org.scalatest.concurrent.ScalaFutures
+import org.scalatest.{BeforeAndAfterEach, FunSuite, MustMatchers, OptionValues, WordSpec}
+import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
+import play.api.inject.guice.GuiceApplicationBuilder
+
+import scala.concurrent.ExecutionContext
+import scala.concurrent.ExecutionContext.global
+
+class ExportsCacheModelRepositorySpec
+    extends WordSpec with GuiceOneAppPerSuite with BeforeAndAfterEach with ScalaFutures with MustMatchers
+    with OptionValues {
+
+  val sessionId = "12345"
+  override lazy val app: Application = GuiceApplicationBuilder().build()
+  private val repo = app.injector.instanceOf[ExportsCacheModelRepository]
+
+  implicit val ec: ExecutionContext = global
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    repo.removeAll().futureValue
+  }
+
+  override def afterEach(): Unit = {
+    super.afterEach()
+    repo.removeAll().futureValue
+  }
+
+  "ExportsCacheModelRepository" when {
+
+    "on update" should {
+      "return model " in {
+        val model = createModel(sessionId)
+        val result = repo.upsert(sessionId, model).futureValue
+        result must be(Some(model))
+      }
+
+    }
+
+    "on get" should {
+      "return Right with model when exists" in {
+        val model = createModel(sessionId)
+        repo.upsert(sessionId, model).futureValue
+        val result = repo.get(sessionId).futureValue
+        result must be(Right(model))
+      }
+
+      "return left when cache entry does not exist" in {
+        val result = repo.get("UNKNOWNID").futureValue
+        result must be(Left("Unable to find model with sessionID: UNKNOWNID"))
+      }
+    }
+  }
+
+  def createModel(existingSessionId: String): ExportsCacheModel =
+    ExportsCacheModel(
+      sessionId = existingSessionId,
+      draftId = "",
+      createdDateTime = LocalDateTime.now(),
+      updatedDateTime = LocalDateTime.now(),
+      choice = "SMP"
+    )
+}

--- a/test/services/cache/ExportsCacheServiceSpec.scala
+++ b/test/services/cache/ExportsCacheServiceSpec.scala
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.cache
+
+
+import java.time.LocalDateTime
+
+import base.CustomExportsBaseSpec
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+
+import scala.concurrent.Future
+
+class ExportsCacheServiceSpec extends CustomExportsBaseSpec with BeforeAndAfterEach {
+
+  val mockRepo = mock[ExportsCacheModelRepository]
+  val service = new ExportsCacheService(mockRepo)
+
+  override def beforeEach(): Unit = {
+    reset(mockRepo)
+  }
+
+  "ExportsCacheService" should {
+
+    val model = ExportsCacheModel("SessionId", "draftId", LocalDateTime.now(), LocalDateTime.now(), "choice")
+
+    "return a Left with error message when repository throws exception" in {
+      val errorMessage = "some error message"
+      when(mockRepo.save(any())).thenReturn(Future.failed(new RuntimeException(errorMessage)))
+
+      service.save(model).futureValue must be(Left(errorMessage))
+    }
+
+    "return a Right Unit when repository successfully saves model" in {
+      when(mockRepo.save(any())).thenReturn(Future.successful(true))
+
+      service.save(model).futureValue must be(Right(()))
+    }
+
+    "return a Left with error message when repository fails to save model" in {
+      when(mockRepo.save(any())).thenReturn(Future.successful(false))
+
+      service.save(model).futureValue must be(Left("Failed saving cacheModel"))
+    }
+  }
+}


### PR DESCRIPTION
Added test for cache service and reverted auth code changes
Added cache to submit on initial 5 controllers