### PR TITLE
CEDS-1370 Apply new Cache to Parties and Summary pages

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -54,8 +54,8 @@ class ChoiceController @Inject()(
   val logger = Logger.apply(this.getClass)
 
   def displayChoiceForm(): Action[AnyContent] = authenticate.async { implicit request =>
-    customsCacheService.fetchAndGetEntry[Choice](eoriCacheId, choiceId).map {
-      case Some(data) => Ok(choicePage(Choice.form().fill(data)))
+    exportsCacheService.get(eoriCacheId).map(_.map(_.choice)).map {
+      case Some(data) => Ok(choicePage(Choice.form().fill(Choice(data))))
       case _          => Ok(choicePage(Choice.form()))
     }
   }

--- a/app/controllers/declaration/AdditionalDeclarationTypePageController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypePageController.scala
@@ -46,9 +46,9 @@ class AdditionalDeclarationTypePageController @Inject()(
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val decType = extractFormType(request)
-    customsCacheService.fetchAndGetEntry[AdditionalDeclarationType](cacheId, decType.formId).map {
-      case Some(data) => Ok(declarationTypePage(decType.form.fill(data)))
-      case _          => Ok(declarationTypePage(decType.form))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.additionalDeclarationType)).map {
+      case Some(data) => Ok(declarationTypePage(decType.form().fill(data)))
+      case _          => Ok(declarationTypePage(decType.form()))
     }
   }
 

--- a/app/controllers/declaration/BorderTransportController.scala
+++ b/app/controllers/declaration/BorderTransportController.scala
@@ -47,9 +47,10 @@ class BorderTransportController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService
-      .fetchAndGetEntry[BorderTransport](cacheId, BorderTransport.formId)
-      .map(data => Ok(borderTransportPage(data.fold(form)(form.fill(_)))))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.borderTransport)).map {
+      case Some(data) => Ok(borderTransportPage(form.fill(data)))
+      case _          => Ok(borderTransportPage(form))
+    }
   }
 
   def submitForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/CarrierDetailsPageController.scala
+++ b/app/controllers/declaration/CarrierDetailsPageController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import config.AppConfig
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.util.CacheIdGenerator.cacheId
-import forms.declaration.CarrierDetails
+import forms.declaration.{CarrierDetails, ConsigneeDetails}
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import play.api.data.Form
@@ -46,9 +46,9 @@ class CarrierDetailsPageController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService.fetchAndGetEntry[CarrierDetails](cacheId, CarrierDetails.id).map {
-      case Some(data) => Ok(carrierDetailsPage(CarrierDetails.form.fill(data)))
-      case _          => Ok(carrierDetailsPage(CarrierDetails.form))
+    cacheService.get(journeySessionId).map(_.flatMap(_.parties.carrierDetails)).map {
+      case Some(data) => Ok(carrierDetailsPage(CarrierDetails.form().fill(data)))
+      case _          => Ok(carrierDetailsPage(CarrierDetails.form()))
     }
   }
 

--- a/app/controllers/declaration/ConsigneeDetailsPageController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsPageController.scala
@@ -48,9 +48,9 @@ class ConsigneeDetailsPageController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService.fetchAndGetEntry[ConsigneeDetails](cacheId, ConsigneeDetails.id).map {
-      case Some(data) => Ok(consigneeDetailsPage(appConfig, ConsigneeDetails.form.fill(data)))
-      case _          => Ok(consigneeDetailsPage(appConfig, ConsigneeDetails.form))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.consigneeDetails)).map {
+      case Some(data) => Ok(consigneeDetailsPage(appConfig, ConsigneeDetails.form().fill(data)))
+      case _          => Ok(consigneeDetailsPage(appConfig, ConsigneeDetails.form()))
     }
   }
 

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -47,12 +47,10 @@ class ConsignmentReferencesController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService
-      .fetchAndGetEntry[ConsignmentReferences](cacheId, ConsignmentReferences.id)
-      .map {
-        case Some(data) => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form.fill(data)))
-        case _          => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form))
-      }
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.consignmentReferences)).map {
+      case Some(data) => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form().fill(data)))
+      case _          => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form()))
+    }
   }
 
   def submitConsignmentReferences(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/DeclarantDetailsPageController.scala
+++ b/app/controllers/declaration/DeclarantDetailsPageController.scala
@@ -45,9 +45,9 @@ class DeclarantDetailsPageController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService.fetchAndGetEntry[DeclarantDetails](cacheId, DeclarantDetails.id).map {
-      case Some(data) => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form.fill(data)))
-      case _          => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarantDetails)).map {
+      case Some(data) => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form().fill(data)))
+      case _          => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form()))
     }
   }
 

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -54,9 +54,9 @@ class DeclarationHolderController @Inject()(
   import forms.declaration.DeclarationHolder.form
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService.fetchAndGetEntry[DeclarationHoldersData](cacheId, formId).map {
-      case Some(data) => Ok(declarationHolderPage(appConfig, form, data.holders))
-      case _          => Ok(declarationHolderPage(appConfig, form, Seq()))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarationHoldersData)).map {
+      case Some(data) => Ok(declarationHolderPage(appConfig, form(), data.holders))
+      case _          => Ok(declarationHolderPage(appConfig, form(), Seq()))
     }
   }
 
@@ -66,9 +66,9 @@ class DeclarationHolderController @Inject()(
 
       val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded(_))
 
-      val cachedData = customsCacheService
-        .fetchAndGetEntry[DeclarationHoldersData](cacheId, formId)
-        .map(_.getOrElse(DeclarationHoldersData(Seq())))
+      val cachedData = exportsCacheService
+        .get(journeySessionId)
+        .map(_.flatMap(_.parties.declarationHoldersData).getOrElse(DeclarationHoldersData(Seq())))
 
       cachedData.flatMap { cache =>
         boundForm
@@ -118,6 +118,24 @@ class DeclarationHolderController @Inject()(
     }
 
   //scalastyle:off method.length
+  private def handleErrorPage(
+    fieldWithError: Seq[(String, String)],
+    userInput: DeclarationHolder,
+    holders: Seq[DeclarationHolder]
+  )(implicit request: Request[_]): Future[Result] = {
+    val updatedErrors = fieldWithError.map((FormError.apply(_: String, _: String)).tupled)
+
+    val formWithError = form.fill(userInput).copy(errors = updatedErrors)
+
+    Future.successful(BadRequest(declarationHolderPage(appConfig, formWithError, holders)))
+  }
+
+  private def updateCache(sessionId: String, formData: DeclarationHoldersData): Future[Option[ExportsCacheModel]] =
+    getAndUpdateExportCacheModel(sessionId, model => {
+      val updatedParties = model.parties.copy(declarationHoldersData = Some(formData))
+      exportsCacheService.update(sessionId, model.copy(parties = updatedParties))
+    })
+
   private def saveAndContinue(
     userInput: DeclarationHolder,
     cachedData: DeclarationHoldersData
@@ -173,18 +191,6 @@ class DeclarationHolderController @Inject()(
     }
   //scalastyle:on method.length
 
-  private def handleErrorPage(
-    fieldWithError: Seq[(String, String)],
-    userInput: DeclarationHolder,
-    holders: Seq[DeclarationHolder]
-  )(implicit request: Request[_]): Future[Result] = {
-    val updatedErrors = fieldWithError.map((FormError.apply(_: String, _: String)).tupled)
-
-    val formWithError = form.fill(userInput).copy(errors = updatedErrors)
-
-    Future.successful(BadRequest(declarationHolderPage(appConfig, formWithError, holders)))
-  }
-
   private def removeHolder(
     holderToRemove: DeclarationHolder,
     cachedData: DeclarationHoldersData
@@ -199,10 +205,4 @@ class DeclarationHolderController @Inject()(
 
   private def retrieveHolder(values: Seq[String]): DeclarationHolder =
     DeclarationHolder.buildFromString(values.headOption.getOrElse(""))
-
-  private def updateCache(sessionId: String, formData: DeclarationHoldersData): Future[Option[ExportsCacheModel]] =
-    getAndUpdateExportCacheModel(sessionId, model => {
-      val updatedParties = model.parties.copy(declarationHoldersData = Some(formData))
-      exportsCacheService.update(sessionId, model.copy(parties = updatedParties))
-    })
 }

--- a/app/controllers/declaration/ExporterDetailsPageController.scala
+++ b/app/controllers/declaration/ExporterDetailsPageController.scala
@@ -45,9 +45,9 @@ class ExporterDetailsPageController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    customsCacheService.fetchAndGetEntry[ExporterDetails](cacheId, ExporterDetails.id).map {
-      case Some(data) => Ok(exporterDetailsPage(appConfig, ExporterDetails.form.fill(data)))
-      case _          => Ok(exporterDetailsPage(appConfig, ExporterDetails.form))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.exporterDetails)).map {
+      case Some(data) => Ok(exporterDetailsPage(appConfig, ExporterDetails.form().fill(data)))
+      case _          => Ok(exporterDetailsPage(appConfig, ExporterDetails.form()))
     }
   }
 
@@ -67,6 +67,7 @@ class ExporterDetailsPageController @Inject()(
 
   private def updateCache(sessionId: String, formData: ExporterDetails): Future[Option[ExportsCacheModel]] =
     getAndUpdateExportCacheModel(sessionId, model => {
-      exportsCacheService.update(sessionId, model.copy(exporterDetails = Some(formData)))
+      val updatedParties = model.parties.copy(exporterDetails = Some(formData))
+      exportsCacheService.update(sessionId, model.copy(parties = updatedParties))
     })
 }

--- a/app/controllers/declaration/RepresentativeDetailsPageController.scala
+++ b/app/controllers/declaration/RepresentativeDetailsPageController.scala
@@ -50,12 +50,10 @@ class RepresentativeDetailsPageController @Inject()(
 
   def displayRepresentativeDetailsPage(): Action[AnyContent] = (authenticate andThen journeyType).async {
     implicit request =>
-      customsCacheService
-        .fetchAndGetEntry[RepresentativeDetails](cacheId, RepresentativeDetails.formId)
-        .map {
-          case Some(data) => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form.fill(data)))
-          case _          => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form))
-        }
+      exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.representativeDetails)).map {
+        case Some(data) => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form().fill(data)))
+        case _          => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form()))
+      }
   }
 
   def submitRepresentativeDetails(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -53,9 +53,9 @@ class TransportContainerController @Inject()(
 } with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.containerData)).map {
-      case Some(data) => Ok(transportContainersPage(form(), data.containers))
-      case _          => Ok(transportContainersPage(form(), Seq()))
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.containerData)).map {
+      case Some(data) => Ok(transportContainersPage(form, data.containers))
+      case _          => Ok(transportContainersPage(form, Seq()))
     }
   }
 

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -47,7 +47,7 @@ class WarehouseIdentificationController @Inject()(
   import forms.declaration.WarehouseIdentification._
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.warehouseIdentification)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.warehouseIdentification)).map {
       case Some(data) => Ok(warehouseIdentificationPage(appConfig, form.fill(data)))
       case _          => Ok(warehouseIdentificationPage(appConfig, form))
     }
@@ -68,8 +68,8 @@ class WarehouseIdentificationController @Inject()(
   }
 
   private def updateCache(sessionId: String, formData: WarehouseIdentification): Future[Option[ExportsCacheModel]] =
-    getAndUpdateExportCacheModel(
-      sessionId,
-      model => exportsCacheService.update(sessionId, model.copy(warehouseIdentification = Some(formData)))
-    )
+    getAndUpdateExportCacheModel(sessionId, model => {
+      val updatedLocations = model.locations.copy(warehouseIdentification = Some(formData))
+      cacheService.update(sessionId, model.copy(locations = updatedLocations))
+    })
 }

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -47,7 +47,7 @@ class WarehouseIdentificationController @Inject()(
   import forms.declaration.WarehouseIdentification._
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.warehouseIdentification)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.warehouseIdentification)).map {
       case Some(data) => Ok(warehouseIdentificationPage(appConfig, form.fill(data)))
       case _          => Ok(warehouseIdentificationPage(appConfig, form))
     }

--- a/app/models/declaration/Items.scala
+++ b/app/models/declaration/Items.scala
@@ -17,7 +17,7 @@
 package models.declaration
 
 import forms.declaration._
-import uk.gov.hmrc.http.cache.client.CacheMap
+import services.cache.ExportsCacheModel
 
 case class Items(
   totalNumberOfItems: Option[TotalNumberOfItems] = None,
@@ -30,9 +30,6 @@ case class Items(
 object Items {
   val id = "Items"
 
-  def apply(cacheMap: CacheMap): Items =
-    Items(
-      totalNumberOfItems = cacheMap.getEntry[TotalNumberOfItems](TotalNumberOfItems.formId),
-      natureOfTransaction = cacheMap.getEntry[NatureOfTransaction](NatureOfTransaction.formId)
-    )
+  def apply(cacheData: ExportsCacheModel): Items =
+    Items(totalNumberOfItems = cacheData.totalNumberOfItems, natureOfTransaction = cacheData.natureOfTransaction)
 }

--- a/app/models/declaration/Locations.scala
+++ b/app/models/declaration/Locations.scala
@@ -18,9 +18,9 @@ package models.declaration
 
 import forms.declaration._
 import forms.declaration.destinationCountries.DestinationCountries
-import forms.declaration.officeOfExit.{OfficeOfExit, OfficeOfExitForms}
+import forms.declaration.officeOfExit.OfficeOfExit
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.cache.client.CacheMap
+import services.cache.ExportsCacheModel
 
 case class Locations(
   destinationCountries: Option[DestinationCountries] = None,
@@ -41,10 +41,10 @@ object Locations {
 
   implicit val format = Json.format[Locations]
 
-  def apply(cacheMap: CacheMap): Locations = Locations(
-    destinationCountries = cacheMap.getEntry[DestinationCountries](DestinationCountries.formId),
-    goodsLocation = cacheMap.getEntry[GoodsLocation](GoodsLocation.formId),
-    warehouseIdentification = cacheMap.getEntry[WarehouseIdentification](WarehouseIdentification.formId),
-    officeOfExit = cacheMap.getEntry[OfficeOfExit](OfficeOfExitForms.formId)
+  def apply(cacheData: ExportsCacheModel): Locations = Locations(
+    destinationCountries = cacheData.locations.destinationCountries,
+    goodsLocation = cacheData.locations.goodsLocation,
+    warehouseIdentification = cacheData.locations.warehouseIdentification,
+    officeOfExit = cacheData.locations.officeOfExit
   )
 }

--- a/app/models/declaration/Parties.scala
+++ b/app/models/declaration/Parties.scala
@@ -18,7 +18,7 @@ package models.declaration
 
 import forms.declaration._
 import play.api.libs.json.Json
-import uk.gov.hmrc.http.cache.client.CacheMap
+import services.cache.ExportsCacheModel
 
 case class Parties(
   exporterDetails: Option[ExporterDetails] = None,
@@ -45,14 +45,13 @@ object Parties {
 
   implicit val format = Json.format[Parties]
 
-  def apply(cacheMap: CacheMap): Parties = Parties(
-    exporterDetails = cacheMap.getEntry[ExporterDetails](ExporterDetails.id),
-    consigneeDetails = cacheMap.getEntry[ConsigneeDetails](ConsigneeDetails.id),
-    declarantDetails = cacheMap.getEntry[DeclarantDetails](DeclarantDetails.id),
-    representativeDetails = cacheMap.getEntry[RepresentativeDetails](RepresentativeDetails.formId),
-    declarationAdditionalActorsData =
-      cacheMap.getEntry[DeclarationAdditionalActorsData](DeclarationAdditionalActorsData.formId),
-    declarationHoldersData = cacheMap.getEntry[DeclarationHoldersData](DeclarationHoldersData.formId),
-    carrierDetails = cacheMap.getEntry[CarrierDetails](CarrierDetails.id)
+  def apply(cacheData: ExportsCacheModel): Parties = Parties(
+    exporterDetails = cacheData.parties.exporterDetails,
+    consigneeDetails = cacheData.parties.consigneeDetails,
+    declarantDetails = cacheData.parties.declarantDetails,
+    representativeDetails = cacheData.parties.representativeDetails,
+    declarationAdditionalActorsData = cacheData.parties.declarationAdditionalActorsData,
+    declarationHoldersData = cacheData.parties.declarationHoldersData,
+    carrierDetails = cacheData.parties.carrierDetails
   )
 }

--- a/app/models/declaration/SupplementaryDeclarationData.scala
+++ b/app/models/declaration/SupplementaryDeclarationData.scala
@@ -18,7 +18,7 @@ package models.declaration
 
 import forms.declaration._
 import models.declaration.dectype.DeclarationTypeSupplementary
-import uk.gov.hmrc.http.cache.client.CacheMap
+import services.cache.ExportsCacheModel
 
 case class SupplementaryDeclarationData(
   declarationType: Option[DeclarationTypeSupplementary] = None,
@@ -28,27 +28,6 @@ case class SupplementaryDeclarationData(
   transportInformationContainerData: Option[TransportInformationContainerData] = None,
   items: Option[Items] = None
 ) extends SummaryContainer {
-
-  import SupplementaryDeclarationData.SchemaMandatoryValues._
-
-  private val schemaMandatoryFields: Map[String, String] = Map(
-    "declaration.functionCode" -> functionCode,
-    "wcoDataModelVersionCode" -> wcoDataModelVersionCode,
-    "wcoTypeName" -> wcoTypeName,
-    "responsibleCountryCode" -> responsibleCountryCode,
-    "responsibleAgencyName" -> responsibleAgencyName,
-    "agencyAssignedCustomizationVersionCode" -> agencyAssignedCustomizationVersionCode
-  )
-
-  def toMap: Map[String, Product with Serializable] =
-    Map(
-      DeclarationTypeSupplementary.id -> declarationType,
-      ConsignmentReferences.id -> consignmentReferences,
-      Parties.id -> parties,
-      Locations.id -> locations,
-      TransportInformationContainerData.id -> transportInformationContainerData,
-      Items.id -> items
-    ).collect { case (key, Some(data)) => (key, data) }
 
   override def isEmpty: Boolean =
     declarationType.isEmpty &&
@@ -61,15 +40,14 @@ case class SupplementaryDeclarationData(
 
 object SupplementaryDeclarationData {
 
-  def apply(cacheMap: CacheMap): SupplementaryDeclarationData =
+  def apply(cacheData: ExportsCacheModel): SupplementaryDeclarationData =
     SupplementaryDeclarationData(
-      declarationType = flattenIfEmpty(DeclarationTypeSupplementary(cacheMap)),
-      consignmentReferences = cacheMap.getEntry[ConsignmentReferences](ConsignmentReferences.id),
-      parties = flattenIfEmpty(Parties(cacheMap)),
-      locations = flattenIfEmpty(Locations(cacheMap)),
-      transportInformationContainerData =
-        cacheMap.getEntry[TransportInformationContainerData](TransportInformationContainerData.id),
-      items = flattenIfEmpty(Items(cacheMap))
+      declarationType = flattenIfEmpty(DeclarationTypeSupplementary(cacheData)),
+      consignmentReferences = cacheData.consignmentReferences,
+      parties = flattenIfEmpty(Parties(cacheData)),
+      locations = flattenIfEmpty(Locations(cacheData)),
+      transportInformationContainerData = cacheData.containerData,
+      items = flattenIfEmpty(Items(cacheData))
     )
 
   private def flattenIfEmpty[A <: SummaryContainer](container: A): Option[A] =

--- a/app/models/declaration/dectype/DeclarationTypeSupplementary.scala
+++ b/app/models/declaration/dectype/DeclarationTypeSupplementary.scala
@@ -17,12 +17,9 @@
 package models.declaration.dectype
 
 import forms.declaration.DispatchLocation
-import forms.declaration.additionaldeclarationtype.{
-  AdditionalDeclarationType,
-  AdditionalDeclarationTypeSupplementaryDec
-}
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
 import models.declaration.SummaryContainer
-import uk.gov.hmrc.http.cache.client.CacheMap
+import services.cache.ExportsCacheModel
 
 case class DeclarationTypeSupplementary(
   dispatchLocation: Option[DispatchLocation],
@@ -35,9 +32,8 @@ case class DeclarationTypeSupplementary(
 object DeclarationTypeSupplementary {
   val id = "DeclarationType"
 
-  def apply(cacheMap: CacheMap): DeclarationTypeSupplementary = DeclarationTypeSupplementary(
-    dispatchLocation = cacheMap.getEntry[DispatchLocation](DispatchLocation.formId),
-    additionalDeclarationType =
-      cacheMap.getEntry[AdditionalDeclarationType](AdditionalDeclarationTypeSupplementaryDec.formId)
+  def apply(cacheData: ExportsCacheModel): DeclarationTypeSupplementary = DeclarationTypeSupplementary(
+    dispatchLocation = cacheData.dispatchLocation,
+    additionalDeclarationType = cacheData.additionalDeclarationType
   )
 }

--- a/app/services/cache/ExportsCacheModelRepository.scala
+++ b/app/services/cache/ExportsCacheModelRepository.scala
@@ -75,8 +75,6 @@ case class ExportsCacheModel(
   dispatchLocation: Option[DispatchLocation] = None,
   additionalDeclarationType: Option[AdditionalDeclarationType] = None,
   consignmentReferences: Option[ConsignmentReferences] = None,
-  exporterDetails: Option[ExporterDetails] = None,
-  warehouseIdentification: Option[WarehouseIdentification] = None,
   borderTransport: Option[BorderTransport] = None,
   transportDetails: Option[TransportDetails] = None,
   containerData: Option[TransportInformationContainerData] = None,

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -222,7 +222,7 @@ trait CustomExportsBaseSpec
       choice = "SMP",
       items = items,
       parties = Parties()
-    )
+  )
 
   def createModelWithNoItems(): ExportsCacheModel = createModelWithItems("", Set.empty)
 

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -222,7 +222,7 @@ trait CustomExportsBaseSpec
       choice = "SMP",
       items = items,
       parties = Parties()
-  )
+    )
 
   def createModelWithNoItems(): ExportsCacheModel = createModelWithItems("", Set.empty)
 

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -39,8 +39,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "Choice Controller on GET" should {

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -49,6 +49,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
       val result = route(app, getRequest(choiceUri)).get
 
       status(result) must be(OK)
+      verify(mockExportsCacheService).get(any())
     }
 
     "read item from cache and display it" in {
@@ -61,6 +62,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       status(result) must be(OK)
       stringResult must include("value=\"SMP\" checked=\"checked\"")
+      verify(mockExportsCacheService).get(any())
     }
   }
 
@@ -75,6 +77,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
         status(result) must be(BAD_REQUEST)
         contentAsString(result) must include(messages(choiceEmpty))
+        verifyTheCacheIsUnchanged()
       }
 
       "wrong value provided for choice" in {
@@ -84,6 +87,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
         status(result) must be(BAD_REQUEST)
         contentAsString(result) must include(messages(choiceError))
+        verifyTheCacheIsUnchanged()
       }
     }
 
@@ -106,6 +110,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/dispatch-location"))
+      theCacheModelUpdated.choice must be("SMP")
     }
 
     "redirect to dispatch location page when 'Standard declaration' is selected" in {
@@ -116,6 +121,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/dispatch-location"))
+      theCacheModelUpdated.choice must be("STD")
     }
 
     "redirect to cancel declaration page when 'Cancel declaration' is selected" in {
@@ -126,6 +132,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/cancel-declaration"))
+      theCacheModelUpdated.choice must be("CAN")
     }
 
     "redirect to submissions page when 'View recent declarations' is selected" in {
@@ -136,6 +143,7 @@ class ChoiceControllerSpec extends CustomExportsBaseSpec with ChoiceMessages {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/submissions"))
+      theCacheModelUpdated.choice must be("SUB")
     }
   }
 }

--- a/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
@@ -21,10 +21,14 @@ import java.time.LocalDateTime
 import base.{CustomExportsBaseSpec, ExportsTestData}
 import controllers.util.CacheIdGenerator
 import forms.Choice
-import forms.Choice.{AllowedChoiceValues, choiceId}
+import forms.Choice.{choiceId, AllowedChoiceValues}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeStandardDec.AllowedAdditionalDeclarationTypes._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDec.AllowedAdditionalDeclarationTypes._
-import forms.declaration.additionaldeclarationtype.{AdditionalDeclarationType, AdditionalDeclarationTypeStandardDec, AdditionalDeclarationTypeSupplementaryDec}
+import forms.declaration.additionaldeclarationtype.{
+  AdditionalDeclarationType,
+  AdditionalDeclarationTypeStandardDec,
+  AdditionalDeclarationTypeSupplementaryDec
+}
 import models.SignedInUser
 import models.requests.{AuthenticatedRequest, JourneyRequest}
 import org.mockito.ArgumentMatchers
@@ -83,12 +87,13 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
   }
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    super.afterEach()
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "Additional Declaration Type Controller on GET" should {
@@ -120,7 +125,8 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           LocalDateTime.now(),
           LocalDateTime.now(),
           "SMP",
-           additionalDeclarationType = Some(AdditionalDeclarationType(PreLodged)))
+          additionalDeclarationType = Some(AdditionalDeclarationType(PreLodged))
+        )
         withNewCaching(cachedData)
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get
@@ -135,7 +141,8 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           LocalDateTime.now(),
           LocalDateTime.now(),
           "SMP",
-          additionalDeclarationType = Some(AdditionalDeclarationType(Simplified)))
+          additionalDeclarationType = Some(AdditionalDeclarationType(Simplified))
+        )
         withNewCaching(cachedData)
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get

--- a/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypePageControllerSpec.scala
@@ -16,17 +16,15 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.{CustomExportsBaseSpec, ExportsTestData}
 import controllers.util.CacheIdGenerator
 import forms.Choice
-import forms.Choice.{choiceId, AllowedChoiceValues}
+import forms.Choice.{AllowedChoiceValues, choiceId}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeStandardDec.AllowedAdditionalDeclarationTypes._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDec.AllowedAdditionalDeclarationTypes._
-import forms.declaration.additionaldeclarationtype.{
-  AdditionalDeclarationType,
-  AdditionalDeclarationTypeStandardDec,
-  AdditionalDeclarationTypeSupplementaryDec
-}
+import forms.declaration.additionaldeclarationtype.{AdditionalDeclarationType, AdditionalDeclarationTypeStandardDec, AdditionalDeclarationTypeSupplementaryDec}
 import models.SignedInUser
 import models.requests.{AuthenticatedRequest, JourneyRequest}
 import org.mockito.ArgumentMatchers
@@ -101,12 +99,14 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get
         status(result) must be(OK)
+        verify(mockExportsCacheService).get(any())
       }
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get
         status(result) must be(OK)
+        verify(mockExportsCacheService).get(any())
       }
     }
 
@@ -114,9 +114,14 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
 
       "used for Standard Declaration" in new TestStandardJourney {
 
-        mockCacheBehaviour(cacheId, AdditionalDeclarationTypeStandardDec.formId)(
-          Some(AdditionalDeclarationType(PreLodged))
-        )
+        val cachedData = ExportsCacheModel(
+          "SessionId",
+          "DraftId",
+          LocalDateTime.now(),
+          LocalDateTime.now(),
+          "SMP",
+           additionalDeclarationType = Some(AdditionalDeclarationType(PreLodged)))
+        withNewCaching(cachedData)
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get
         contentAsString(result) must include("checked=\"checked\"")
@@ -124,9 +129,14 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
 
-        mockCacheBehaviour(cacheId, AdditionalDeclarationTypeStandardDec.formId)(
-          Some(AdditionalDeclarationType(Simplified))
-        )
+        val cachedData = ExportsCacheModel(
+          "SessionId",
+          "DraftId",
+          LocalDateTime.now(),
+          LocalDateTime.now(),
+          "SMP",
+          additionalDeclarationType = Some(AdditionalDeclarationType(Simplified)))
+        withNewCaching(cachedData)
 
         val result = route(app, getRequest(additionalDeclarationTypeUri)).get
         contentAsString(result) must include("checked=\"checked\"")
@@ -150,8 +160,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           any()
         )(any(), any(), any())
 
-        verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
-        verify(mockExportsCacheService).get(any())
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(PreLodged)))
       }
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
@@ -165,8 +174,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
           any()
         )(any(), any(), any())
 
-        verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
-        verify(mockExportsCacheService).get(any())
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(Simplified)))
       }
     }
 
@@ -178,6 +186,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
         val result = route(app, postRequest(additionalDeclarationTypeUri, validForm)).get
 
         status(result) must be(SEE_OTHER)
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(PreLodged)))
       }
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
@@ -186,6 +195,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
         val result = route(app, postRequest(additionalDeclarationTypeUri, validForm)).get
 
         status(result) must be(SEE_OTHER)
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(Simplified)))
       }
     }
 
@@ -197,6 +207,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
         val header = route(app, postRequest(additionalDeclarationTypeUri, validForm)).get.futureValue.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignment-references"))
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(PreLodged)))
       }
 
       "used for Supplementary Declaration" in new TestSupplementaryJourney {
@@ -205,6 +216,7 @@ class AdditionalDeclarationTypePageControllerSpec extends CustomExportsBaseSpec 
         val header = route(app, postRequest(additionalDeclarationTypeUri, validForm)).get.futureValue.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignment-references"))
+        theCacheModelUpdated.additionalDeclarationType must be(Some(AdditionalDeclarationType(Simplified)))
       }
     }
   }

--- a/test/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/controllers/declaration/BorderTransportControllerSpec.scala
@@ -57,8 +57,7 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "GET" should {
@@ -79,7 +78,8 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
           LocalDateTime.now(),
           LocalDateTime.now(),
           "SMP",
-          borderTransport = Some(transport))
+          borderTransport = Some(transport)
+        )
         withNewCaching(cachedData)
 
         val result = route(app, request).value

--- a/test/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/controllers/declaration/BorderTransportControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.CSRFUtil._
 import base.CustomExportsBaseSpec
 import forms.Choice
@@ -64,17 +66,27 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
     "return 200 code" in {
       val result = route(app, getRequest(uri)).value
       status(result) must be(OK)
+      verify(mockExportsCacheService).get(any())
     }
 
     "populate the form fields with data from cache" in {
       val request = addCSRFToken(getRequest(uri))
 
       forAll(arbitrary[BorderTransport]) { transport =>
-        withCaching[BorderTransport](Some(transport), BorderTransport.formId)
+        val cachedData = ExportsCacheModel(
+          "SessionId",
+          "DraftId",
+          LocalDateTime.now(),
+          LocalDateTime.now(),
+          "SMP",
+          borderTransport = Some(transport))
+        withNewCaching(cachedData)
+
         val result = route(app, request).value
 
         contentAsString(result).replaceCSRF mustBe
           view(form.fill(transport), request).body.replaceCSRF()
+        reset(mockExportsCacheService)
       }
     }
   }
@@ -89,6 +101,7 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
         val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).value
 
         intercept[InsufficientEnrolments](status(result))
+        verifyTheCacheIsUnchanged()
       }
     }
 
@@ -106,6 +119,7 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
 
         status(result) must be(BAD_REQUEST)
         contentAsString(result).replaceCSRF mustBe view(form.bindFromRequest()(request), request).body.replaceCSRF
+        verifyTheCacheIsUnchanged()
       }
 
     }
@@ -154,6 +168,7 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
 
       "on click of continue when a record has already been added" in {
         forAll(arbitrary[BorderTransport]) { borderTransport =>
+          withNewCaching(createModelWithNoItems())
           withCaching[BorderTransport](Some(borderTransport), BorderTransport.formId)
           val payload = Seq(
             ("borderModeOfTransportCode", borderTransport.borderModeOfTransportCode),
@@ -165,6 +180,8 @@ class BorderTransportControllerSpec extends CustomExportsBaseSpec with Generator
           result.futureValue.header.headers.get("Location") must be(
             Some("/customs-declare-exports/declaration/transport-details")
           )
+          theCacheModelUpdated.borderTransport.get must be(borderTransport)
+          reset(mockExportsCacheService)
         }
       }
     }

--- a/test/controllers/declaration/CarrierDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/CarrierDetailsPageControllerSpec.scala
@@ -32,14 +32,17 @@ class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
   private val uri = uriWithContextPath("/declaration/carrier-details")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[CarrierDetails](None)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
-  override def afterEach() =
+  override def afterEach() = {
+    super.afterEach()
     Mockito.reset(mockExportsCacheService)
+  }
 
   "Carrier Details Page Controller on GET" should {
 

--- a/test/controllers/declaration/CarrierDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/CarrierDetailsPageControllerSpec.scala
@@ -21,8 +21,10 @@ import forms.Choice
 import forms.Choice.choiceId
 import forms.common.AddressSpec
 import forms.declaration.CarrierDetailsSpec._
-import forms.declaration.{CarrierDetails, EntityDetails}
+import forms.declaration.{CarrierDetails, EntityDetails, EntityDetailsSpec}
+import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
+import org.mockito.Mockito.verify
 import play.api.test.Helpers._
 
 class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
@@ -45,6 +47,7 @@ class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
       val result = route(app, getRequest(uri)).get
 
       status(result) must be(OK)
+      verify(mockExportsCacheService).get(any())
     }
   }
 
@@ -69,6 +72,9 @@ class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
       theCacheModelUpdated.parties.carrierDetails.get must be(
         CarrierDetails(EntityDetails(eori = Some("9GB1234567ABCDEF"), address = None))
       )
+      theCacheModelUpdated.parties.carrierDetails must be(
+        Some(CarrierDetails(EntityDetails(Some("9GB1234567ABCDEF"), None)))
+      )
     }
 
     "validate request and redirect - only address provided" in {
@@ -81,6 +87,9 @@ class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
       theCacheModelUpdated.parties.carrierDetails.get must be(
         CarrierDetails(EntityDetails(eori = None, address = Some(AddressSpec.correctAddress)))
       )
+      theCacheModelUpdated.parties.carrierDetails must be(
+        Some(CarrierDetails(EntityDetailsSpec.correctEntityDetailsAddressOnly))
+      )
     }
 
     "validate request and redirect - all values provided" in {
@@ -92,6 +101,9 @@ class CarrierDetailsPageControllerSpec extends CustomExportsBaseSpec {
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/additional-actors"))
       theCacheModelUpdated.parties.carrierDetails.get must be(
         CarrierDetails(EntityDetails(Some("9GB1234567ABCDEF"), Some(AddressSpec.correctAddress)))
+      )
+      theCacheModelUpdated.parties.carrierDetails must be(
+        Some(CarrierDetails(EntityDetails(Some("9GB1234567ABCDEF"), Some(AddressSpec.correctAddress))))
       )
     }
   }

--- a/test/controllers/declaration/ConsigneeDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/ConsigneeDetailsPageControllerSpec.scala
@@ -16,13 +16,19 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.CustomExportsBaseSpec
 import forms.Choice
 import forms.Choice.choiceId
 import forms.common.Address
 import forms.declaration.ConsigneeDetailsSpec._
+import forms.declaration.EntityDetailsSpec.correctEntityDetails
 import forms.declaration.{ConsigneeDetails, EntityDetails}
+import models.declaration.Parties
+import org.mockito.Mockito.reset
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
 
@@ -35,20 +41,35 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
+  override def afterEach() {
+    reset(mockExportsCacheService)
+  }
+
   "Consignee Details Controller on GET" should {
 
     "return 200 status code" in {
       val result = route(app, getRequest(uri)).get
 
       status(result) must be(OK)
+      verifyTheCacheIsUnchanged()
     }
 
     "read item from cache and display it" in {
-
-      val cachedData = ConsigneeDetails(
-        EntityDetails(Some("12345"), Some(Address("Spiderman", "Test Street", "Leeds", "LS18BN", "Germany")))
+      val cachedData = ExportsCacheModel(
+        "SessionId",
+        "DraftId",
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        "SMP",
+        parties = Parties(
+          consigneeDetails = Some(
+            ConsigneeDetails(
+              EntityDetails(Some("12345"), Some(Address("Spiderman", "Test Street", "Leeds", "LS18BN", "Germany")))
+            )
+          )
+        )
       )
-      withCaching[ConsigneeDetails](Some(cachedData), "ConsigneeDetails")
+      withNewCaching(cachedData)
 
       val result = route(app, getRequest(uri)).get
       val page = contentAsString(result)
@@ -70,6 +91,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
       val result = route(app, postRequest(uri, emptyConsigneeDetailsJSON)).get
 
       status(result) must be(BAD_REQUEST)
+      verifyTheCacheIsUnchanged()
     }
 
     "validate request and redirect - only EORI provided" in {
@@ -79,6 +101,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/declarant-details"))
+      theCacheModelUpdated.parties.consigneeDetails must be(Some(correctConsigneeDetailsEORIOnly))
     }
 
     "validate request and redirect - only address provided" in {
@@ -88,6 +111,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/declarant-details"))
+      theCacheModelUpdated.parties.consigneeDetails must be(Some(correctConsigneeDetailsAddressOnly))
     }
 
     "validate request and redirect - all values provided" in {
@@ -97,6 +121,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
 
       status(result) must be(SEE_OTHER)
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/declarant-details"))
+      theCacheModelUpdated.parties.consigneeDetails must be(Some(ConsigneeDetails(correctEntityDetails)))
     }
   }
 }

--- a/test/controllers/declaration/ConsigneeDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/ConsigneeDetailsPageControllerSpec.scala
@@ -35,6 +35,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
   private val uri = uriWithContextPath("/declaration/consignee-details")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[ConsigneeDetails](None)
@@ -42,6 +43,7 @@ class ConsigneeDetailsPageControllerSpec extends CustomExportsBaseSpec {
   }
 
   override def afterEach() {
+    super.afterEach()
     reset(mockExportsCacheService)
   }
 

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -39,6 +39,7 @@ class ConsignmentReferencesControllerSpec
   import ConsignmentReferencesControllerSpec._
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[ConsignmentReferences](None, ConsignmentReferences.id)
@@ -46,8 +47,8 @@ class ConsignmentReferencesControllerSpec
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    super.afterEach()
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "Consignment References Controller on GET" should {

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -16,17 +16,20 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.CustomExportsBaseSpec
-import forms.Choice
 import forms.Choice.choiceId
 import forms.declaration.ConsignmentReferences
 import forms.declaration.ConsignmentReferencesSpec._
+import forms.{Choice, Ducr}
 import helpers.views.declaration.{CommonMessages, ConsignmentReferencesMessages}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class ConsignmentReferencesControllerSpec
     extends CustomExportsBaseSpec with ConsignmentReferencesMessages with CommonMessages {
@@ -36,7 +39,6 @@ class ConsignmentReferencesControllerSpec
   import ConsignmentReferencesControllerSpec._
 
   override def beforeEach() {
-    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[ConsignmentReferences](None, ConsignmentReferences.id)
@@ -44,7 +46,6 @@ class ConsignmentReferencesControllerSpec
   }
 
   override def afterEach() {
-    super.afterEach()
     reset(mockCustomsCacheService)
     reset(mockExportsCacheService)
   }
@@ -55,6 +56,7 @@ class ConsignmentReferencesControllerSpec
 
       val result = route(app, getRequest(uri)).get
       status(result) must be(OK)
+      verifyTheCacheIsUnchanged()
     }
 
     "not populate the form fields if cache is empty" in {
@@ -64,11 +66,20 @@ class ConsignmentReferencesControllerSpec
 
       resultAsString.replaceAll(" ", "") must include("name=\"ducr.ducr\"\nvalue=\"\"")
       resultAsString.replaceAll(" ", "") must include("name=\"lrn\"\nvalue=\"\"")
+      verifyTheCacheIsUnchanged()
     }
 
     "populate the form fields with data from cache" in {
 
-      withCaching[ConsignmentReferences](Some(correctConsignmentReferences), ConsignmentReferences.id)
+      val cachedData = ExportsCacheModel(
+        "SessionId",
+        "DraftId",
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        "SMP",
+        consignmentReferences = Some((correctConsignmentReferences))
+      )
+      withNewCaching(cachedData)
 
       val result = route(app, getRequest(uri)).get
       val resultAsString = contentAsString(result)
@@ -117,6 +128,7 @@ class ConsignmentReferencesControllerSpec
       val header = result.futureValue.header
 
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/exporter-details"))
+      theCacheModelUpdated.consignmentReferences.get.ducr must be(Some(Ducr("8GB123456789012-1234567890QWERTYUIO")))
     }
   }
 }

--- a/test/controllers/declaration/DeclarantDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/DeclarantDetailsPageControllerSpec.scala
@@ -34,6 +34,7 @@ class DeclarantDetailsPageControllerSpec extends CustomExportsBaseSpec {
   private val uri = uriWithContextPath("/declaration/declarant-details")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[DeclarantDetails](None)
@@ -41,6 +42,7 @@ class DeclarantDetailsPageControllerSpec extends CustomExportsBaseSpec {
   }
 
   override def afterEach() {
+    super.afterEach()
     reset(mockExportsCacheService)
   }
 

--- a/test/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.{CustomExportsBaseSpec, ViewValidator}
 import controllers.declaration.DeclarationAdditionalActorsControllerSpec.cacheWithMaximumAmountOfActors
 import controllers.util.{Add, Remove, SaveAndContinue}
@@ -24,11 +26,12 @@ import forms.Choice.choiceId
 import forms.declaration.DeclarationAdditionalActors
 import forms.declaration.DeclarationAdditionalActorsSpec._
 import helpers.views.declaration.{CommonMessages, DeclarationAdditionalActorsMessages}
-import models.declaration.DeclarationAdditionalActorsData
 import models.declaration.DeclarationAdditionalActorsData.formId
 import models.declaration.DeclarationAdditionalActorsDataSpec._
+import models.declaration.{DeclarationAdditionalActorsData, Parties}
 import org.mockito.Mockito.reset
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class DeclarationAdditionalActorsControllerSpec
     extends CustomExportsBaseSpec with DeclarationAdditionalActorsMessages with CommonMessages with ViewValidator {
@@ -36,7 +39,6 @@ class DeclarationAdditionalActorsControllerSpec
   private val uri: String = uriWithContextPath("/declaration/additional-actors")
   private val addActionUrlEncoded = (Add.toString, "")
   private val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
-  private def removeActionUrlEncoded(value: String) = (Remove.toString, value)
 
   override def beforeEach() {
     authorizedUser()
@@ -50,18 +52,19 @@ class DeclarationAdditionalActorsControllerSpec
     reset(mockExportsCacheService)
   }
 
+  private def removeActionUrlEncoded(value: String) = (Remove.toString, value)
+
   "Declaration Additional Actors Controller on GET" should {
 
     "return 200 status code" in {
       val result = route(app, getRequest(uri)).get
 
       status(result) must be(OK)
+      verifyTheCacheIsUnchanged()
     }
 
     "read item from cache and display it" in {
-
-      val cachedData = DeclarationAdditionalActorsData(Seq(DeclarationAdditionalActors(Some("112233"), Some("CS"))))
-      withCaching[DeclarationAdditionalActorsData](Some(cachedData), "DeclarationAdditionalActorsData")
+      withCache(DeclarationAdditionalActorsData(Seq(DeclarationAdditionalActors(Some("112233"), Some("CS")))))
 
       val result = route(app, getRequest(uri)).get
       val page = contentAsString(result)
@@ -117,6 +120,7 @@ class DeclarationAdditionalActorsControllerSpec
           status(result) must be(BAD_REQUEST)
           page must include(messages(eoriError))
           page must include(messages(partyTypeEmpty))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding actor with correct EORI and party not selected" in {
@@ -127,6 +131,7 @@ class DeclarationAdditionalActorsControllerSpec
 
           status(result) must be(BAD_REQUEST)
           page must include(messages(partyTypeEmpty))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding actor with correct EORI and incorrect party" in {
@@ -137,10 +142,11 @@ class DeclarationAdditionalActorsControllerSpec
 
           status(result) must be(BAD_REQUEST)
           page must include(messages(partyTypeError))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding more than 99 items" in {
-          withCaching[DeclarationAdditionalActorsData](Some(cacheWithMaximumAmountOfActors), formId)
+          withCache(cacheWithMaximumAmountOfActors)
 
           val body = Map("eori" -> "eori1", "partyType" -> "CS").toSeq :+ saveAndContinueActionUrlEncoded
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -150,10 +156,11 @@ class DeclarationAdditionalActorsControllerSpec
 
           checkErrorsSummary(page)
           checkErrorLink(page, 1, maximumActorsError, "#")
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding duplicate item" in {
-          withCaching[DeclarationAdditionalActorsData](Some(correctAdditionalActorsData), formId)
+          withCache(correctAdditionalActorsData)
 
           val body = correctAdditionalActorsMap.toSeq :+ saveAndContinueActionUrlEncoded
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -163,6 +170,7 @@ class DeclarationAdditionalActorsControllerSpec
 
           checkErrorsSummary(page)
           checkErrorLink(page, 1, duplicatedActorsError, "#")
+          verifyTheCacheIsUnchanged()
         }
       }
     }
@@ -172,7 +180,7 @@ class DeclarationAdditionalActorsControllerSpec
       "remove an actor successfully " when {
 
         "exists in the cache" in {
-          withCaching[DeclarationAdditionalActorsData](Some(correctAdditionalActorsData), formId)
+          withCache(correctAdditionalActorsData)
 
           val body = removeActionUrlEncoded(correctAdditionalActorsData.actors.head.toJson.toString())
 
@@ -185,12 +193,12 @@ class DeclarationAdditionalActorsControllerSpec
       "return an error" when {
 
         "does not exists in the cache" in {
-
           val body = removeActionUrlEncoded(correctAdditionalActorsData.actors.head.toJson.toString())
 
           val result = route(app, postRequestFormUrlEncoded(uri, body)).get
 
           status(result) must be(BAD_REQUEST)
+          verifyTheCacheIsUnchanged()
         }
       }
     }
@@ -198,7 +206,6 @@ class DeclarationAdditionalActorsControllerSpec
     "handle add action" should {
 
       "when validate request - optional data allowed" in {
-
         val undefinedDocument: Map[String, String] = Map("eori" -> "", "partyType" -> "")
         testErrorScenario(
           addActionUrlEncoded,
@@ -208,7 +215,6 @@ class DeclarationAdditionalActorsControllerSpec
       }
 
       "when validate request - correct values" in {
-
         testHappyPathsScenarios(
           expectedPath = "/customs-declare-exports/declaration/additional-actors",
           actorsMap = correctAdditionalActorsMap,
@@ -228,6 +234,7 @@ class DeclarationAdditionalActorsControllerSpec
           status(result) must be(BAD_REQUEST)
           page must include(messages(eoriError))
           page must include(messages(partyTypeEmpty))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding actor with correct EORI and party not selected" in {
@@ -238,6 +245,7 @@ class DeclarationAdditionalActorsControllerSpec
 
           status(result) must be(BAD_REQUEST)
           page must include(messages(partyTypeEmpty))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding actor with correct EORI and incorrect party" in {
@@ -248,10 +256,11 @@ class DeclarationAdditionalActorsControllerSpec
 
           status(result) must be(BAD_REQUEST)
           page must include(messages(partyTypeError))
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding more than 99 items" in {
-          withCaching[DeclarationAdditionalActorsData](Some(cacheWithMaximumAmountOfActors), formId)
+          withCache(cacheWithMaximumAmountOfActors)
 
           val body = Map("eori" -> "eori1", "partyType" -> "CS").toSeq :+ addActionUrlEncoded
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -261,10 +270,11 @@ class DeclarationAdditionalActorsControllerSpec
 
           checkErrorsSummary(page)
           checkErrorLink(page, 1, maximumActorsError, "#")
+          verifyTheCacheIsUnchanged()
         }
 
         "when adding duplicate item" in {
-          withCaching[DeclarationAdditionalActorsData](Some(correctAdditionalActorsData), formId)
+          withCache(correctAdditionalActorsData)
 
           val body = correctAdditionalActorsMap.toSeq :+ addActionUrlEncoded
           val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).get
@@ -274,14 +284,13 @@ class DeclarationAdditionalActorsControllerSpec
 
           checkErrorsSummary(page)
           checkErrorLink(page, 1, duplicatedActorsError, "#")
+          verifyTheCacheIsUnchanged()
         }
       }
 
       "add an item successfully and return SEE_OTHER" when {
 
         "with an empty cache" in {
-          withCaching[DeclarationAdditionalActorsData](None, formId)
-
           testHappyPathsScenarios(
             expectedPath = "/customs-declare-exports/declaration/additional-actors",
             actorsMap = correctAdditionalActorsMap,
@@ -290,8 +299,6 @@ class DeclarationAdditionalActorsControllerSpec
         }
 
         "that does not exist in cache" in {
-          withCaching[DeclarationAdditionalActorsData](Some(correctAdditionalActorsData), formId)
-
           testHappyPathsScenarios(
             expectedPath = "/customs-declare-exports/declaration/additional-actors",
             actorsMap = Map("eori" -> "eori2", "partyType" -> "CS"),
@@ -301,6 +308,18 @@ class DeclarationAdditionalActorsControllerSpec
       }
     }
   }
+
+  private def withCache(data: DeclarationAdditionalActorsData) =
+    withNewCaching(
+      ExportsCacheModel(
+        "SessionId",
+        "DraftId",
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        "SMP",
+        parties = Parties(declarationAdditionalActorsData = Some(data))
+      )
+    )
 
   private def testHappyPathsScenarios(
     expectedPath: String,
@@ -331,6 +350,7 @@ class DeclarationAdditionalActorsControllerSpec
       val stringResult = contentAsString(result)
       stringResult must include(messages(expectedErrorMessagePath))
     }
+    verifyTheCacheIsUnchanged()
   }
 }
 

--- a/test/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
@@ -41,6 +41,7 @@ class DeclarationAdditionalActorsControllerSpec
   private val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[DeclarationAdditionalActorsData](None)
@@ -48,8 +49,8 @@ class DeclarationAdditionalActorsControllerSpec
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    super.afterEach()
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   private def removeActionUrlEncoded(value: String) = (Remove.toString, value)

--- a/test/controllers/declaration/DeclarationHolderControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderControllerSpec.scala
@@ -48,8 +48,7 @@ class DeclarationHolderControllerSpec
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   private def removeActionUrlEncoded(value: String) = (Remove.toString, value)

--- a/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
+++ b/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
@@ -44,8 +44,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "Declaration Type Controller on GET" should {
@@ -58,7 +57,6 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
     }
 
     "populate the form fields with data from cache" in {
-      withCaching[DispatchLocation](Some(DispatchLocation(AllowedDispatchLocations.OutsideEU)), DispatchLocation.formId)
       withNewCaching(
         ExportsCacheModel(
           "sessionId",
@@ -121,7 +119,9 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
         val header = result.futureValue.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/not-eligible"))
-        theCacheModelUpdated.dispatchLocation must be(Some(DispatchLocation(AllowedDispatchLocations.SpecialFiscalTerritory)))
+        theCacheModelUpdated.dispatchLocation must be(
+          Some(DispatchLocation(AllowedDispatchLocations.SpecialFiscalTerritory))
+        )
       }
     }
   }

--- a/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
+++ b/test/controllers/declaration/DispatchLocationPageControllerSpec.scala
@@ -23,7 +23,6 @@ import forms.Choice
 import forms.Choice.choiceId
 import forms.declaration.DispatchLocation
 import forms.declaration.DispatchLocation.AllowedDispatchLocations
-import models.declaration.{Locations, Parties}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
@@ -55,6 +54,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
 
       val result = route(app, getRequest(dispatchLocationUri)).get
       status(result) must be(OK)
+      verify(mockExportsCacheService).get(any())
     }
 
     "populate the form fields with data from cache" in {
@@ -72,6 +72,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
 
       val result = route(app, getRequest(dispatchLocationUri)).get
       contentAsString(result) must include("checked=\"checked\"")
+      verify(mockExportsCacheService).get(any())
     }
   }
 
@@ -95,6 +96,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
       val result = route(app, postRequest(dispatchLocationUri, validForm)).get
 
       status(result) must be(SEE_OTHER)
+      theCacheModelUpdated.dispatchLocation must be(Some(DispatchLocation(AllowedDispatchLocations.OutsideEU)))
     }
 
     "redirect to 'Additional Declaration Type' page" when {
@@ -106,6 +108,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
         val header = result.futureValue.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/type"))
+        theCacheModelUpdated.dispatchLocation must be(Some(DispatchLocation(AllowedDispatchLocations.OutsideEU)))
       }
     }
 
@@ -118,6 +121,7 @@ class DispatchLocationPageControllerSpec extends CustomExportsBaseSpec {
         val header = result.futureValue.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/not-eligible"))
+        theCacheModelUpdated.dispatchLocation must be(Some(DispatchLocation(AllowedDispatchLocations.SpecialFiscalTerritory)))
       }
     }
   }

--- a/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
@@ -35,13 +35,15 @@ class ExporterDetailsPageControllerSpec extends CustomExportsBaseSpec with Commo
   private val uri = uriWithContextPath("/declaration/exporter-details")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[ExporterDetails](None)
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
-  override def afterEach()= {
+  override def afterEach() = {
+    super.afterEach()
     Mockito.reset(mockExportsCacheService)
   }
 

--- a/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/ExporterDetailsPageControllerSpec.scala
@@ -16,6 +16,8 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.CustomExportsBaseSpec
 import forms.Choice
 import forms.Choice.choiceId
@@ -23,7 +25,10 @@ import forms.common.Address
 import forms.declaration.ExporterDetailsSpec._
 import forms.declaration.{EntityDetails, ExporterDetails}
 import helpers.views.declaration.CommonMessages
+import models.declaration.Parties
+import org.mockito.Mockito
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 class ExporterDetailsPageControllerSpec extends CustomExportsBaseSpec with CommonMessages {
 
@@ -36,21 +41,39 @@ class ExporterDetailsPageControllerSpec extends CustomExportsBaseSpec with Commo
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
+  override def afterEach()= {
+    Mockito.reset(mockExportsCacheService)
+  }
+
   "Exporter Details Controller on GET" should {
 
     "return 200 with a success" in {
-      withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
       val result = route(app, getRequest(uri)).get
 
       status(result) must be(OK)
+      verifyTheCacheIsUnchanged()
     }
 
     "read item from cache and display it" in {
 
-      val cachedData = ExporterDetails(
-        EntityDetails(Some("99980"), Some(Address("CaptainAmerica", "Test Street", "Leeds", "LS18BN", "Portugal")))
+      val cachedData = ExportsCacheModel(
+        "SessionId",
+        "DraftId",
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        "SMP",
+        parties = Parties(
+          exporterDetails = Some(
+            ExporterDetails(
+              EntityDetails(
+                Some("99980"),
+                Some(Address("CaptainAmerica", "Test Street", "Leeds", "LS18BN", "Portugal"))
+              )
+            )
+          )
+        )
       )
-      withCaching[ExporterDetails](Some(cachedData), "ExporterDetails")
+      withNewCaching(cachedData)
 
       val result = route(app, getRequest(uri)).get
       val page = contentAsString(result)
@@ -93,66 +116,61 @@ class ExporterDetailsPageControllerSpec extends CustomExportsBaseSpec with Commo
     "on the supplementary journey " should {
 
       "validate request and redirect to consignee-details page with only EORI provided" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsEORIOnlyJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetailsEORIOnly))
       }
 
       "validate request and redirect to consignee-details page with only address provided" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsAddressOnlyJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetailsAddressOnly))
       }
 
       "validate request and redirect to consignee-details page with correct values" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetails))
+
       }
     }
 
     "on the standard journey " should {
 
       "validate request and redirect to consignee-details page with only EORI provided" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.StandardDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsEORIOnlyJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetailsEORIOnly))
       }
 
       "validate request and redirect to consignee-details page with only address provided" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.StandardDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsAddressOnlyJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetailsAddressOnly))
       }
 
       "validate request and redirect to consignee-details page with correct values" in {
-        withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.StandardDec)), choiceId)
-
         val result = route(app, postRequest(uri, correctExporterDetailsJSON)).get
         val header = result.futureValue.header
 
         status(result) must be(SEE_OTHER)
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/consignee-details"))
+        theCacheModelUpdated.parties.exporterDetails must be(Some(correctExporterDetails))
       }
     }
   }

--- a/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
+++ b/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
@@ -30,6 +30,7 @@ class NatureOfTransactionControllerSpec extends CustomExportsBaseSpec with Natur
   private val uri = uriWithContextPath("/declaration/nature-of-transaction")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[NatureOfTransaction](None)
@@ -37,6 +38,7 @@ class NatureOfTransactionControllerSpec extends CustomExportsBaseSpec with Natur
   }
 
   override def afterEach() {
+    super.afterEach()
     reset(mockExportsCacheService)
   }
 

--- a/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
@@ -49,8 +49,7 @@ class ProcedureCodesPageControllerSpec
   override def afterEach(): Unit = {
     super.afterEach()
 
-    reset(mockExportsCacheService)
-    reset(mockCustomsCacheService)
+    reset(mockExportsCacheService, mockCustomsCacheService)
   }
 
   "Procedure Codes Controller on GET" should {

--- a/test/controllers/declaration/RepresentativeDetailsPageControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeDetailsPageControllerSpec.scala
@@ -43,6 +43,7 @@ class RepresentativeDetailsPageControllerSpec
   private val uri = uriWithContextPath("/declaration/representative-details")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[Choice](Some(Choice(SupplementaryDec)), choiceId)
@@ -50,8 +51,8 @@ class RepresentativeDetailsPageControllerSpec
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    super.afterEach()
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "Representative Address Controller on GET" should {
@@ -261,7 +262,7 @@ class RepresentativeDetailsPageControllerSpec
         val result = route(app, postRequest(uri, JsObject(Map[String, JsValue]().empty))).get
 
         status(result) must be(SEE_OTHER)
-        theCacheModelUpdated.parties.representativeDetails must be(Some(RepresentativeDetails(None,None)))
+        theCacheModelUpdated.parties.representativeDetails must be(Some(RepresentativeDetails(None, None)))
       }
     }
 

--- a/test/controllers/declaration/SealControllerSpec.scala
+++ b/test/controllers/declaration/SealControllerSpec.scala
@@ -46,6 +46,7 @@ class SealControllerSpec extends CustomExportsBaseSpec with Generators with Prop
   private val uri = uriWithContextPath("/declaration/add-seal")
 
   override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
     withNewCaching(createModelWithNoItems())
     withCaching[Seq[Seal]](None, Seal.formId)
@@ -54,6 +55,7 @@ class SealControllerSpec extends CustomExportsBaseSpec with Generators with Prop
   }
 
   override def afterEach() {
+    super.afterEach()
     reset(mockCustomsCacheService, mockExportsCacheService)
   }
 

--- a/test/controllers/declaration/SummaryPageControllerSpec.scala
+++ b/test/controllers/declaration/SummaryPageControllerSpec.scala
@@ -23,7 +23,7 @@ import forms.declaration.ConsignmentReferencesSpec.correctConsignmentReferencesJ
 import forms.declaration.{ConsignmentReferences, ConsignmentReferencesSpec}
 import models.declaration.SupplementaryDeclarationTestData
 import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{reset, times, verify, when}
+import org.mockito.Mockito._
 import org.mockito.verification.VerificationMode
 import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
@@ -35,67 +35,78 @@ import scala.concurrent.Future
 
 class SummaryPageControllerSpec extends CustomExportsBaseSpec {
 
-  private trait Test {
-    val summaryPageUri = uriWithContextPath("/declaration/summary")
-    val emptyForm: JsValue = JsObject(Map("" -> JsString("")))
-    val emptyMetadata: MetaData = MetaData(response = Seq.empty)
-    val onlyOnce: VerificationMode = times(1)
-    val minimumValidCacheData =
-      CacheMap(eoriForCache, Map(ConsignmentReferences.id -> correctConsignmentReferencesJSON))
+  val summaryPageUri = uriWithContextPath("/declaration/summary")
+  val emptyForm: JsValue = JsObject(Map("" -> JsString("")))
+  val emptyMetadata: MetaData = MetaData(response = Seq.empty)
+  val onlyOnce: VerificationMode = times(1)
+  val minimumValidCacheData =
+    CacheMap(eoriForCache, Map(ConsignmentReferences.id -> correctConsignmentReferencesJSON))
 
-    reset(mockCustomsCacheService)
-    reset(mockNrsService)
-    reset(mockCustomsDeclareExportsConnector)
-
+  override def beforeEach() {
+    super.beforeEach()
     authorizedUser()
-    withCaching(None, eoriForCache)
+    successfulCustomsDeclareExportsResponse()
+    withNewCaching(SupplementaryDeclarationTestData.allRecords)
+
+    //TODO: Below, these three mocks will have to be deleted as part of the mapping story
     when(mockCustomsCacheService.fetch(anyString())(any(), any()))
       .thenReturn(Future.successful(Some(minimumValidCacheData)))
     when(mockCustomsCacheService.remove(anyString())(any(), any()))
       .thenReturn(Future.successful(HttpResponse(OK)))
-    successfulCustomsDeclareExportsResponse()
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
+  }
+
+  override def afterEach() {
+    super.afterEach()
+    reset(mockCustomsCacheService, mockExportsCacheService, mockNrsService, mockCustomsDeclareExportsConnector)
   }
 
   "Summary Page Controller on display" when {
 
     "there is data in cache for supplementary declaration" should {
-      "return 200 code" in new Test {
+      "return 200 code" in {
         val result = route(app, getRequest(summaryPageUri)).get
         status(result) must be(OK)
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display 'Back' button that links to 'Export-items' page" in new Test {
+      "display 'Back' button that links to 'Export-items' page" in {
+
+        withNewCaching(SupplementaryDeclarationTestData.allRecords.copy(containerData = None))
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("site.back"))
         resultAsString must include("/declaration/transport-details")
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display 'Accept and submit declaration' button" in new Test {
+      "display 'Accept and submit declaration' button" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("site.acceptAndSubmitDeclaration"))
         resultAsString must include("button id=\"submit\" class=\"button\"")
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display content for Declaration Type module" in new Test {
+      "display content for Declaration Type module" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.declarationType.header"))
         resultAsString must include(messages("supplementary.summary.declarationType.dispatchLocation"))
         resultAsString must include(messages("supplementary.summary.declarationType.supplementaryDeclarationType"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display content for Your References module" in new Test {
+      "display content for Your References module" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.yourReferences.header"))
         resultAsString must include(messages("supplementary.summary.yourReferences.ducr"))
         resultAsString must include(messages("supplementary.summary.yourReferences.lrn"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display content for Parties module" in new Test {
+      "display content for Parties module" in {
         when(mockCustomsCacheService.fetch(anyString())(any(), any()))
           .thenReturn(Future.successful(Some(SupplementaryDeclarationTestData.cacheMapAllRecords)))
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
@@ -112,9 +123,10 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.parties.additionalParties.type"))
         resultAsString must include(messages("supplementary.summary.parties.idStatusNumberAuthorisationCode"))
         resultAsString must include(messages("supplementary.summary.parties.authorizedPartyEori"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display content for Locations module" in new Test {
+      "display content for Locations module" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("declaration.summary.locations.header"))
@@ -128,59 +140,55 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.locations.warehouseId"))
         resultAsString must include(messages("supplementary.summary.locations.supervisingCustomsOffice"))
         resultAsString must include(messages("supplementary.summary.locations.officeOfExit"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display content for Item module" in new Test {
+      "display content for Item module" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.items.header"))
         resultAsString must include(messages("supplementary.summary.items.amountInvoiced"))
         resultAsString must include(messages("supplementary.summary.items.exchangeRate"))
         resultAsString must include(messages("supplementary.summary.items.transactionType"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "display containers content with cache available" in new Test {
-        when(mockCustomsCacheService.fetch(anyString())(any(), any()))
-          .thenReturn(Future.successful(Some(SupplementaryDeclarationTestData.cacheMapAllRecords)))
-
+      "display containers content with cache available" in {
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.transportInfo.containers.title"))
         resultAsString must include(messages("supplementary.transportInfo.containerId.title"))
         resultAsString must include(messages("M1l3s"))
+        verify(mockExportsCacheService).get(anyString)
       }
 
-      "get the whole supplementary declaration data from cache" in new Test {
+      "get the whole supplementary declaration data from cache" in {
         route(app, getRequest(summaryPageUri)).get.futureValue
-        verify(mockCustomsCacheService, onlyOnce).fetch(any())(any(), any())
+        verify(mockCustomsCacheService, never()).fetch(any())(any(), any())
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 
     "there is no data in cache for supplementary declaration" should {
-      "display error page" in new Test {
-        when(mockCustomsCacheService.fetch(anyString())(any(), any()))
-          .thenReturn(Future.successful(None))
-
+      "display error page" in {
+        withNewCaching(createModelWithNoItems())
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.noData.header"))
         resultAsString must include(messages("supplementary.summary.noData.header.secondary"))
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 
     "there is data in cache, but without LRN" should {
-      "display error page" in new Test {
-        val cachedData = CacheMap(
-          id = eoriForCache,
-          data = SupplementaryDeclarationTestData.cacheMapAllRecords.data - ConsignmentReferences.id
-        )
-        when(mockCustomsCacheService.fetch(anyString())(any(), any()))
-          .thenReturn(Future.successful(Some(cachedData)))
+      "display error page" in {
+        withNewCaching(SupplementaryDeclarationTestData.allRecords.copy(consignmentReferences = None))
 
         val resultAsString = contentAsString(route(app, getRequest(summaryPageUri)).get)
 
         resultAsString must include(messages("supplementary.summary.noData.header"))
         resultAsString must include(messages("supplementary.summary.noData.header.secondary"))
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 
@@ -189,29 +197,29 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
   "Summary Page Controller on submit" when {
 
     "everything is correct" should {
-      "get the whole supplementary declaration data from cache" in new Test {
+      "get the whole supplementary declaration data from cache" in {
         route(app, postRequest(summaryPageUri, emptyForm)).get.futureValue
         verify(mockCustomsCacheService, onlyOnce).fetch(any())(any(), any())
       }
 
-      "remove supplementary declaration data from cache" in new Test {
+      "remove supplementary declaration data from cache" in {
         route(app, postRequest(summaryPageUri, emptyForm)).get.futureValue
         verify(mockCustomsCacheService, onlyOnce).remove(any())(any(), any())
       }
 
-      "return 303 code" in new Test {
+      "return 303 code" in {
         val result = route(app, postRequest(summaryPageUri, emptyForm)).get
         status(result) must be(SEE_OTHER)
       }
 
-      "redirect to confirmation page" in new Test {
+      "redirect to confirmation page" in {
         val result = route(app, postRequest(summaryPageUri, emptyForm)).get.futureValue
         val header = result.header
 
         header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/confirmation"))
       }
 
-      "add flash scope with lrn " in new Test {
+      "add flash scope with lrn " in {
         val cacheData = Map(ConsignmentReferences.id -> ConsignmentReferencesSpec.correctConsignmentReferencesJSON)
         when(mockCustomsCacheService.fetch(anyString())(any(), any()))
           .thenReturn(Future.successful(Some(CacheMap(eoriForCache, cacheData))))
@@ -225,7 +233,7 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
     }
 
     "got error from Customs Declarations" should {
-      "display error page" in new Test {
+      "display error page" in {
         when(mockCustomsDeclareExportsConnector.submitExportDeclaration(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(HttpResponse(BAD_REQUEST)))
 
@@ -237,13 +245,13 @@ class SummaryPageControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("global.error.message"))
       }
 
-      "not remove data from cache" in new Test {
+      "not remove data from cache" in {
         when(mockCustomsDeclareExportsConnector.submitExportDeclaration(any(), any(), any())(any(), any()))
           .thenReturn(Future.successful(HttpResponse(BAD_REQUEST)))
 
         route(app, postRequest(summaryPageUri, emptyForm)).get.futureValue
 
-        verify(mockCustomsCacheService, times(0)).remove(eoriForCache)
+        verify(mockCustomsCacheService, never()).remove(eoriForCache)
       }
     }
   }

--- a/test/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -21,7 +21,7 @@ import java.time.LocalDateTime
 import base.CSRFUtil._
 import base.{CustomExportsBaseSpec, TestHelper}
 import forms.Choice
-import forms.Choice.{AllowedChoiceValues, choiceId}
+import forms.Choice.{choiceId, AllowedChoiceValues}
 import forms.declaration.TransportCodes.Maritime
 import forms.declaration.{TransportDetails, WarehouseIdentification}
 import generators.Generators
@@ -56,8 +56,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
   }
 
   override def afterEach() {
-    reset(mockCustomsCacheService)
-    reset(mockExportsCacheService)
+    reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
   "GET" should {
@@ -75,14 +74,14 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
       val request = addCSRFToken(getRequest(uri))
 
       forAll(arbitrary[TransportDetails]) { transport =>
-
         val cachedData = ExportsCacheModel(
           "SessionId",
           "DraftId",
           LocalDateTime.now(),
           LocalDateTime.now(),
           "SMP",
-          transportDetails = Some(transport))
+          transportDetails = Some(transport)
+        )
 
         withNewCaching(cachedData)
         val result = route(app, request).value

--- a/test/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -16,11 +16,14 @@
 
 package controllers.declaration
 
+import java.time.LocalDateTime
+
 import base.CSRFUtil._
 import base.{CustomExportsBaseSpec, TestHelper}
 import forms.Choice
-import forms.Choice.{choiceId, AllowedChoiceValues}
-import forms.declaration.TransportDetails
+import forms.Choice.{AllowedChoiceValues, choiceId}
+import forms.declaration.TransportCodes.Maritime
+import forms.declaration.{TransportDetails, WarehouseIdentification}
 import generators.Generators
 import models.requests.JourneyRequest
 import org.mockito.ArgumentMatchers
@@ -32,6 +35,7 @@ import play.api.data.Form
 import play.api.test.CSRFTokenHelper.addCSRFToken
 import play.api.test.Helpers._
 import play.twirl.api.Html
+import services.cache.ExportsCacheModel
 import uk.gov.hmrc.auth.core.InsufficientEnrolments
 import views.html.declaration.transport_details
 
@@ -62,6 +66,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
 
       val result = route(app, getRequest(uri)).value
       status(result) must be(OK)
+      verify(mockExportsCacheService).get(any())
     }
 
     "populate the form fields with data from cache" in {
@@ -70,12 +75,22 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
       val request = addCSRFToken(getRequest(uri))
 
       forAll(arbitrary[TransportDetails]) { transport =>
-        withCaching[TransportDetails](Some(transport), TransportDetails.formId)
+
+        val cachedData = ExportsCacheModel(
+          "SessionId",
+          "DraftId",
+          LocalDateTime.now(),
+          LocalDateTime.now(),
+          "SMP",
+          transportDetails = Some(transport))
+
+        withNewCaching(cachedData)
         val result = route(app, request).value
 
         contentAsString(result).replaceCSRF mustBe
           view(form.fill(transport), TestHelper.journeyRequest(request, AllowedChoiceValues.SupplementaryDec)).body
             .replaceCSRF()
+        reset(mockExportsCacheService)
       }
     }
   }
@@ -92,6 +107,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
         val result = route(app, postRequestFormUrlEncoded(uri, body: _*)).value
 
         intercept[InsufficientEnrolments](status(result))
+        verifyTheCacheIsUnchanged()
       }
     }
 
@@ -113,6 +129,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
           form.bindFromRequest()(request),
           TestHelper.journeyRequest(request, AllowedChoiceValues.SupplementaryDec)
         ).body.replaceCSRF
+        verifyTheCacheIsUnchanged()
       }
     }
 
@@ -212,6 +229,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
         val result = route(app, postRequestFormUrlEncoded(uri, payload: _*)).value
         status(result) must be(SEE_OTHER)
         result.futureValue.header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/add-seal"))
+        theCacheModelUpdated.transportDetails must be(Some(transportDetails))
       }
     }
   }

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -25,6 +25,7 @@ import forms.declaration.TransportCodes._
 import forms.declaration.WarehouseIdentification
 import forms.declaration.WarehouseIdentificationSpec._
 import helpers.views.declaration.WarehouseIdentificationMessages
+import models.declaration.Locations
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.verify
@@ -43,7 +44,7 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
     withCaching[Choice](Some(Choice(Choice.AllowedChoiceValues.SupplementaryDec)), choiceId)
   }
 
-  override def afterEach()  {
+  override def afterEach() {
     Mockito.reset(mockExportsCacheService)
   }
 
@@ -58,9 +59,19 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
     }
 
     "read item from cache and display it" in {
+      val cachedData = ExportsCacheModel(
+        "SessionId",
+        "DraftId",
+        LocalDateTime.now(),
+        LocalDateTime.now(),
+        "SMP",
+        locations = Locations(
+          warehouseIdentification =
+            Some(WarehouseIdentification(Some("Office"), Some("R"), Some("SecretStash"), Some(Maritime)))
+        )
+      )
 
-      val cachedData = WarehouseIdentification(Some("Office"), Some("R"), Some("SecretStash"), Some(Maritime))
-      withNewCaching(createModelWithNoItems().copy(warehouseIdentification = Some(cachedData)))
+      withNewCaching(cachedData)
 
       val Some(result) = route(app, getRequest(uri))
       val page = contentAsString(result)
@@ -132,7 +143,7 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
       status(result) must be(SEE_OTHER)
 
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/border-transport"))
-      theCacheModelUpdated.warehouseIdentification must be(Some(emptyWarehouseIdentification))
+      theCacheModelUpdated.locations.warehouseIdentification must be(Some(emptyWarehouseIdentification))
     }
 
     "validate request and redirect - correct values" in {
@@ -143,7 +154,7 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
       status(result) must be(SEE_OTHER)
 
       header.headers.get("Location") must be(Some("/customs-declare-exports/declaration/border-transport"))
-      theCacheModelUpdated.warehouseIdentification.get.identificationNumber must be(Some("1234567GB"))
+      theCacheModelUpdated.locations.warehouseIdentification.get.identificationNumber must be(Some("1234567GB"))
     }
   }
 }

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -39,10 +39,7 @@ class SubmissionServiceSpec extends CustomExportsBaseSpec with OptionValues {
   val mapper = mock[WcoMetadataMapper]
 
   override def beforeEach() {
-    reset(mockCustomsCacheService)
-    reset(mockCustomsDeclareExportsConnector)
-    reset(mockAuditService)
-    reset(mapper)
+    reset(mockCustomsCacheService, mockCustomsDeclareExportsConnector, mockAuditService, mapper)
     successfulCustomsDeclareExportsResponse()
     when(mockCustomsCacheService.remove(anyString())(any(), any()))
       .thenReturn(Future.successful(HttpResponse(OK)))


### PR DESCRIPTION
We still have a few old cache mocks there, that are need because we still
need to map it to the DMS schema. A subsequent story will take care of
this.