### PR TITLE
CEDS-1410 Fix ProcedureCode form validation

### DIFF
--- a/app/controllers/declaration/ProcedureCodesPageController.scala
+++ b/app/controllers/declaration/ProcedureCodesPageController.scala
@@ -209,7 +209,7 @@ class ProcedureCodesPageController @Inject()(
 
       case (procedureCode, seq) =>
         procedureCode match {
-          case ProcedureCodes(None, _) if cachedData.procedureCode.isEmpty =>
+          case ProcedureCodes(None, _) =>
             handleErrorPage(
               itemId,
               Seq(("procedureCode", "supplementary.procedureCodes.procedureCode.error.empty")),

--- a/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodesPageControllerSpec.scala
@@ -101,6 +101,18 @@ class ProcedureCodesPageControllerSpec
         status(result) must be(BAD_REQUEST)
       }
 
+      "procedureCode is empty but has additional procedure codes in cache, it should return a bad request" in {
+
+        val cachedData = ProcedureCodesData(Some("1234"), Seq("123"))
+        withNewCaching(createModelWithItem("", Some(ExportItem("id", procedureCodes = Some(cachedData))), "SMP"))
+
+        val body = Seq(("procedureCode", ""), ("additionalProcedureCode", ""), saveAndContinueActionUrlEncoded)
+
+        val Some(result) = route(app, postRequestFormUrlEncoded(uri, body: _*))
+
+        status(result) must be(BAD_REQUEST)
+      }
+
       "maximum amount of codes are reached" in {
 
         withNewCaching(


### PR DESCRIPTION
If we had a list of additional procedure codes, but the form was empty
we would get a pattern matching error.
We should ensure the current form has the `procedureCode` sent on the
reuqest payload.