### PR TITLE
Remove early initialization from controller

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -42,14 +42,12 @@ import scala.concurrent.{ExecutionContext, Future}
 class ChoiceController @Inject()(
   authenticate: AuthAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   errorHandler: ErrorHandler,
   mcc: MessagesControllerComponents,
   choicePage: choice_page
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   val logger = Logger.apply(this.getClass)
 

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -36,13 +36,11 @@ class AdditionalDeclarationTypeController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   declarationTypePage: declaration_type
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val decType = extractFormType(request)

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -41,13 +41,11 @@ class AdditionalFiscalReferencesController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   additionalFiscalReferencesPage: additional_fiscal_references
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -42,13 +42,11 @@ class AdditionalInformationController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCustomsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   additionalInformationPage: additional_information
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   val elementLimit = 99
 

--- a/app/controllers/declaration/BorderTransportController.scala
+++ b/app/controllers/declaration/BorderTransportController.scala
@@ -38,13 +38,11 @@ class BorderTransportController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   borderTransportPage: border_transport
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.borderTransport)).map {

--- a/app/controllers/declaration/CarrierDetailsController.scala
+++ b/app/controllers/declaration/CarrierDetailsController.scala
@@ -39,14 +39,14 @@ class CarrierDetailsController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  override val cacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   carrierDetailsPage: carrier_details
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.parties.carrierDetails)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.carrierDetails)).map {
       case Some(data) => Ok(carrierDetailsPage(CarrierDetails.form().fill(data)))
       case _          => Ok(carrierDetailsPage(CarrierDetails.form()))
     }
@@ -68,7 +68,7 @@ class CarrierDetailsController @Inject()(
     for {
       _ <- getAndUpdateExportCacheModel(sessionId, model => {
         val updatedParties = model.parties.copy(carrierDetails = Some(formData))
-        cacheService.update(sessionId, model.copy(parties = updatedParties))
+        exportsCacheService.update(sessionId, model.copy(parties = updatedParties))
       })
       _ <- customsCacheService.cache[CarrierDetails](cacheId, CarrierDetails.id, formData)
     } yield Unit

--- a/app/controllers/declaration/CommodityMeasureController.scala
+++ b/app/controllers/declaration/CommodityMeasureController.scala
@@ -38,13 +38,11 @@ class CommodityMeasureController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   goodsMeasurePage: goods_measure
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map { item =>

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -39,13 +39,11 @@ class ConsigneeDetailsController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   consigneeDetailsPage: consignee_details
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.consigneeDetails)).map {

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -38,13 +38,11 @@ class ConsignmentReferencesController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   consignmentReferencesPage: consignment_references
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.consignmentReferences)).map {

--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -36,13 +36,11 @@ class DeclarantDetailsController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   declarantDetailsPage: declarant_details
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarantDetails)).map {

--- a/app/controllers/declaration/DeclarationAdditionalActorsController.scala
+++ b/app/controllers/declaration/DeclarationAdditionalActorsController.scala
@@ -44,13 +44,11 @@ class DeclarationAdditionalActorsController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   declarationAdditionalActorsPage: declaration_additional_actors
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   private val exceedMaximumNumberError = "supplementary.additionalActors.maximumAmount.error"
   private val duplicateActorError = "supplementary.additionalActors.duplicated.error"

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -43,13 +43,11 @@ class DeclarationHolderController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   declarationHolderPage: declaration_holder
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   import forms.declaration.DeclarationHolder.form
 

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -46,7 +46,7 @@ class DestinationCountriesController @Inject()(
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
   errorHandler: ErrorHandler,
-  override val cacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   destinationCountriesSupplementaryPage: destination_countries_supplementary,
   destinationCountriesStandardPage: destination_countries_standard
@@ -64,13 +64,13 @@ class DestinationCountriesController @Inject()(
     implicit request: JourneyRequest[AnyContent],
     hc: HeaderCarrier
   ): Future[Result] =
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
       case Some(data) => Ok(destinationCountriesSupplementaryPage(Supplementary.form.fill(data)))
       case _          => Ok(destinationCountriesSupplementaryPage(Supplementary.form))
     }
 
   private def displayFormStandard()(implicit request: JourneyRequest[AnyContent], hc: HeaderCarrier): Future[Result] =
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
       case Some(data) => Ok(destinationCountriesStandardPage(Standard.form.fill(data), data.countriesOfRouting))
       case _          => Ok(destinationCountriesStandardPage(Standard.form, Seq.empty))
     }
@@ -101,7 +101,7 @@ class DestinationCountriesController @Inject()(
   private def handleSubmitStandard()(implicit request: JourneyRequest[AnyContent]): Future[Result] = {
     val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded)
 
-    val cachedData = cacheService
+    val cachedData = exportsCacheService
       .get(journeySessionId)
       .map(_.flatMap(_.locations.destinationCountries))
       .map(_.getOrElse(DestinationCountries.empty()))
@@ -207,7 +207,7 @@ class DestinationCountriesController @Inject()(
   private def refreshPage(
     inputDestinationCountries: DestinationCountries
   )(implicit request: JourneyRequest[_]): Future[Result] =
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
       case Some(cachedData) =>
         Ok(
           destinationCountriesStandardPage(Standard.form.fill(inputDestinationCountries), cachedData.countriesOfRouting)
@@ -220,7 +220,7 @@ class DestinationCountriesController @Inject()(
     getAndUpdateExportCacheModel(
       sessionId,
       model =>
-        cacheService
+        exportsCacheService
           .update(sessionId, model.copy(locations = model.locations.copy(destinationCountries = Some(formData))))
     )
 

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -36,13 +36,11 @@ class DispatchLocationController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   dispatchLocationPage: dispatch_location
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.dispatchLocation)).map {

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -44,14 +44,12 @@ class DocumentsProducedController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCustomsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   itemsCache: ItemsCachingService,
   mcc: MessagesControllerComponents,
   documentProducedPage: documents_produced
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.getItemByIdAndSession(itemId, journeySessionId) map (_.flatMap(_.documentsProducedData)

--- a/app/controllers/declaration/ExporterDetailsController.scala
+++ b/app/controllers/declaration/ExporterDetailsController.scala
@@ -36,13 +36,11 @@ class ExporterDetailsController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   exporterDetailsPage: exporter_details
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.exporterDetails)).map {

--- a/app/controllers/declaration/FiscalInformationController.scala
+++ b/app/controllers/declaration/FiscalInformationController.scala
@@ -38,13 +38,11 @@ class FiscalInformationController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   fiscalInformationPage: fiscal_information
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {

--- a/app/controllers/declaration/ItemTypeController.scala
+++ b/app/controllers/declaration/ItemTypeController.scala
@@ -44,13 +44,11 @@ class ItemTypeController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   itemTypePage: item_type
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService

--- a/app/controllers/declaration/LocationController.scala
+++ b/app/controllers/declaration/LocationController.scala
@@ -39,13 +39,13 @@ class LocationController @Inject()(
   customsCacheService: CustomsCacheService,
   mcc: MessagesControllerComponents,
   goodsLocationPage: goods_location,
-  override val cacheService: ExportsCacheService
+  override val exportsCacheService: ExportsCacheService
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.GoodsLocation._
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.goodsLocation)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.goodsLocation)).map {
       case Some(data) => Ok(goodsLocationPage(appConfig, form.fill(data)))
       case _          => Ok(goodsLocationPage(appConfig, form))
     }
@@ -69,7 +69,7 @@ class LocationController @Inject()(
       _ <- getAndUpdateExportCacheModel(
         sessionId,
         model =>
-          cacheService
+          exportsCacheService
             .update(sessionId, model.copy(locations = model.locations.copy(goodsLocation = Some(formData))))
       )
       _ <- customsCacheService.cache[GoodsLocation](cacheId, formId, formData)

--- a/app/controllers/declaration/ModelCacheable.scala
+++ b/app/controllers/declaration/ModelCacheable.scala
@@ -23,13 +23,13 @@ import services.cache.{ExportsCacheModel, ExportsCacheService}
 import scala.concurrent.{ExecutionContext, Future}
 
 trait ModelCacheable {
-  val cacheService: ExportsCacheService
+  def exportsCacheService: ExportsCacheService
 
   protected def getAndUpdateExportCacheModel(
     sessionId: String,
     update: ExportsCacheModel => Future[Option[ExportsCacheModel]]
   )(implicit ec: ExecutionContext): Future[Option[ExportsCacheModel]] =
-    cacheService.get(sessionId).flatMap {
+    exportsCacheService.get(sessionId).flatMap {
       case Some(model) => update(model)
       case _           => Future.successful(None)
     }

--- a/app/controllers/declaration/NatureOfTransactionController.scala
+++ b/app/controllers/declaration/NatureOfTransactionController.scala
@@ -38,12 +38,12 @@ class NatureOfTransactionController @Inject()(
   customsCacheService: CustomsCacheService,
   mcc: MessagesControllerComponents,
   natureOfTransactionPage: nature_of_transaction,
-  override val cacheService: ExportsCacheService
+  override val exportsCacheService: ExportsCacheService
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.natureOfTransaction)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.natureOfTransaction)).map {
       case Some(data) => Ok(natureOfTransactionPage(form.fill(data)))
       case _          => Ok(natureOfTransactionPage(form))
     }
@@ -65,6 +65,6 @@ class NatureOfTransactionController @Inject()(
   private def updateCache(sessionId: String, formData: NatureOfTransaction): Future[Option[ExportsCacheModel]] =
     getAndUpdateExportCacheModel(
       sessionId,
-      model => cacheService.update(sessionId, model.copy(natureOfTransaction = Some(formData)))
+      model => exportsCacheService.update(sessionId, model.copy(natureOfTransaction = Some(formData)))
     )
 }

--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -41,7 +41,7 @@ class OfficeOfExitController @Inject()(
   mcc: MessagesControllerComponents,
   officeOfExitSupplementaryPage: office_of_exit_supplementary,
   officeOfExitStandardPage: office_of_exit_standard,
-  override val cacheService: ExportsCacheService
+  override val exportsCacheService: ExportsCacheService
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.officeOfExit.OfficeOfExitForms._
@@ -54,13 +54,13 @@ class OfficeOfExitController @Inject()(
   }
 
   private def supplementaryPage()(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Html] =
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
       case Some(data) => officeOfExitSupplementaryPage(supplementaryForm.fill(OfficeOfExitSupplementary(data)))
       case _          => officeOfExitSupplementaryPage(supplementaryForm)
     }
 
   private def standardPage()(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Html] =
-    cacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
       case Some(data) => officeOfExitStandardPage(standardForm.fill(OfficeOfExitStandard(data)))
       case _          => officeOfExitStandardPage(standardForm)
     }
@@ -105,7 +105,7 @@ class OfficeOfExitController @Inject()(
     getAndUpdateExportCacheModel(
       sessionId,
       model =>
-        cacheService.update(
+        exportsCacheService.update(
           sessionId,
           model.copy(locations = model.locations.copy(officeOfExit = Some(OfficeOfExit.from(formData))))
       )
@@ -115,7 +115,7 @@ class OfficeOfExitController @Inject()(
     getAndUpdateExportCacheModel(
       sessionId,
       model =>
-        cacheService.update(
+        exportsCacheService.update(
           sessionId,
           model.copy(locations = model.locations.copy(officeOfExit = Some(OfficeOfExit.from(formData))))
       )

--- a/app/controllers/declaration/PackageInformationController.scala
+++ b/app/controllers/declaration/PackageInformationController.scala
@@ -40,13 +40,11 @@ class PackageInformationController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   packageInformationPage: package_information
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   val packagesMaxElements = 99
 

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -42,12 +42,12 @@ class PreviousDocumentsController @Inject()(
   customsCacheService: CustomsCacheService,
   mcc: MessagesControllerComponents,
   previousDocumentsPage: previous_documents,
-  override val cacheService: ExportsCacheService
+  override val exportsCacheService: ExportsCacheService
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.previousDocuments)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.previousDocuments)).map {
       case Some(data) => Ok(previousDocumentsPage(form(), data.documents))
       case _          => Ok(previousDocumentsPage(form(), Seq.empty))
     }
@@ -60,7 +60,7 @@ class PreviousDocumentsController @Inject()(
 
     val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded)
 
-    val cachedData = cacheService
+    val cachedData = exportsCacheService
       .get(journeySessionId)
       .map(_.flatMap(_.previousDocuments))
       .map(_.getOrElse(PreviousDocumentsData(Seq.empty)))
@@ -103,7 +103,7 @@ class PreviousDocumentsController @Inject()(
       _ <- getAndUpdateExportCacheModel(
         journeySessionId,
         model =>
-          cacheService
+          exportsCacheService
             .update(journeySessionId, model.copy(previousDocuments = Some(formData)))
       )
       _ <- customsCacheService.cache[PreviousDocumentsData](cacheId, formId, formData)

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -44,13 +44,11 @@ class ProcedureCodesController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   legacyCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   procedureCodesPage: procedure_codes
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {

--- a/app/controllers/declaration/RepresentativeDetailsController.scala
+++ b/app/controllers/declaration/RepresentativeDetailsController.scala
@@ -40,13 +40,11 @@ class RepresentativeDetailsController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   representativeDetailsPage: representative_details
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayRepresentativeDetailsPage(): Action[AnyContent] = (authenticate andThen journeyType).async {
     implicit request =>

--- a/app/controllers/declaration/SummaryController.scala
+++ b/app/controllers/declaration/SummaryController.scala
@@ -41,7 +41,7 @@ class SummaryController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  override val cacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   submissionService: SubmissionService,
   mcc: MessagesControllerComponents,
   summaryPage: summary_page,
@@ -53,7 +53,7 @@ class SummaryController @Inject()(
   private val logger = Logger(this.getClass())
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map {
+    exportsCacheService.get(journeySessionId).map {
       case Some(data) if containsMandatoryData(data) => Ok(summaryPage(SupplementaryDeclarationData(data)))
       case _                                         => Ok(summaryPageNoData())
     }

--- a/app/controllers/declaration/TotalNumberOfItemsController.scala
+++ b/app/controllers/declaration/TotalNumberOfItemsController.scala
@@ -39,13 +39,13 @@ class TotalNumberOfItemsController @Inject()(
   customsCacheService: CustomsCacheService,
   mcc: MessagesControllerComponents,
   totalNumberOfItemsPage: total_number_of_items,
-  override val cacheService: ExportsCacheService
+  override val exportsCacheService: ExportsCacheService
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.TotalNumberOfItems._
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    cacheService.get(journeySessionId).map(_.flatMap(_.totalNumberOfItems)).map {
+    exportsCacheService.get(journeySessionId).map(_.flatMap(_.totalNumberOfItems)).map {
       case Some(data) => Ok(totalNumberOfItemsPage(appConfig, form.fill(data)))
       case _          => Ok(totalNumberOfItemsPage(appConfig, form))
     }
@@ -71,7 +71,7 @@ class TotalNumberOfItemsController @Inject()(
       _ <- getAndUpdateExportCacheModel(
         sessionId,
         model =>
-          cacheService
+          exportsCacheService
             .update(sessionId, model.copy(totalNumberOfItems = Some(formData)))
       )
       _ <- customsCacheService.cache[TotalNumberOfItems](cacheId, formId, formData)

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -44,13 +44,11 @@ class TransportContainerController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   transportContainersPage: add_transport_containers
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.containerData)).map {
@@ -64,7 +62,7 @@ class TransportContainerController @Inject()(
 
     val actionTypeOpt = request.body.asFormUrlEncoded.map(FormAction.fromUrlEncoded)
 
-    val cachedData = cacheService
+    val cachedData = exportsCacheService
       .get(journeySessionId)
       .map(_.flatMap(_.containerData))
       .map(_.getOrElse(TransportInformationContainerData(Seq())))

--- a/app/controllers/declaration/TransportDetailsController.scala
+++ b/app/controllers/declaration/TransportDetailsController.scala
@@ -41,13 +41,11 @@ class TransportDetailsController @Inject()(
   journeyType: JourneyAction,
   errorHandler: ErrorHandler,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   transportDetailsPage: transport_details
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     exportsCacheService.get(journeySessionId).map(_.flatMap(_.transportDetails)).map {

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -36,13 +36,11 @@ class WarehouseIdentificationController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   customsCacheService: CustomsCacheService,
-  exportsCacheService: ExportsCacheService,
+  override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   warehouseIdentificationPage: warehouse_identification
 )(implicit ec: ExecutionContext)
-    extends {
-  val cacheService = exportsCacheService
-} with FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   import forms.declaration.WarehouseIdentification._
 
@@ -70,6 +68,6 @@ class WarehouseIdentificationController @Inject()(
   private def updateCache(sessionId: String, formData: WarehouseIdentification): Future[Option[ExportsCacheModel]] =
     getAndUpdateExportCacheModel(sessionId, model => {
       val updatedLocations = model.locations.copy(warehouseIdentification = Some(formData))
-      cacheService.update(sessionId, model.copy(locations = updatedLocations))
+      exportsCacheService.update(sessionId, model.copy(locations = updatedLocations))
     })
 }


### PR DESCRIPTION
In scala road map [early initializers are going to be deprecated][1].
We are able to make our code more robust by not using deprecated language feature.

This PR makes controllers code more consistent and increase readability.

[1]: https://github.com/scala/scala-dev/issues/513