### PR TITLE
CEDS-1249 Warehouse identification unit tests

### DIFF
--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -30,10 +30,9 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class JourneyAction @Inject()(cacheService: ExportsCacheService, mcc: MessagesControllerComponents)
+case class JourneyAction @Inject()(cacheService: ExportsCacheService)
+                                  (implicit override val executionContext: ExecutionContext)
     extends ActionRefiner[AuthenticatedRequest, JourneyRequest] with SessionIdAware {
-
-  implicit override val executionContext: ExecutionContext = mcc.executionContext
 
   private val logger = Logger(this.getClass())
 

--- a/test/base/MockCustomsCacheService.scala
+++ b/test/base/MockCustomsCacheService.scala
@@ -17,10 +17,11 @@
 package base
 
 import forms.Choice
-import org.mockito.ArgumentMatchers
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.mockito.stubbing.OngoingStubbing
+import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatest.mockito.MockitoSugar
 import play.api.data.Form
 import services.CustomsCacheService
@@ -28,7 +29,7 @@ import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.concurrent.Future
 
-trait MockCustomsCacheService extends MockitoSugar {
+trait MockCustomsCacheService extends MockitoSugar with BeforeAndAfterEach { self: Suite =>
 
   val mockCustomsCacheService = mock[CustomsCacheService]
 
@@ -53,4 +54,9 @@ trait MockCustomsCacheService extends MockitoSugar {
   def withJourneyType(choice: Choice): OngoingStubbing[Future[Option[Choice]]] =
     when(mockCustomsCacheService.fetchAndGetEntry[Choice](any(), any())(any(), any(), any()))
       .thenReturn(Future.successful(Some(choice)))
+
+  override protected def afterEach(): Unit = {
+    Mockito.reset(mockCustomsCacheService)
+    super.afterEach()
+  }
 }

--- a/test/base/MockExportsCacheService.scala
+++ b/test/base/MockExportsCacheService.scala
@@ -16,15 +16,16 @@
 
 package base
 
-import org.mockito.ArgumentCaptor
+import org.mockito.{ArgumentCaptor, Mockito}
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.{never, verify, when}
+import org.scalatest.{BeforeAndAfterEach, Suite}
 import org.scalatest.mockito.MockitoSugar
 import services.cache.{ExportsCacheModel, ExportsCacheModelBuilder, ExportsCacheService}
 
 import scala.concurrent.Future
 
-trait MockExportsCacheService extends MockitoSugar with ExportsCacheModelBuilder {
+trait MockExportsCacheService extends MockitoSugar with ExportsCacheModelBuilder with BeforeAndAfterEach { self: Suite =>
 
   val mockExportsCacheService = mock[ExportsCacheService]
 
@@ -33,15 +34,11 @@ trait MockExportsCacheService extends MockitoSugar with ExportsCacheModelBuilder
     when(mockExportsCacheService.getItemByIdAndSession(anyString, anyString))
       .thenReturn(Future.successful(dataToReturn.items.headOption))
 
-    when(
-      mockExportsCacheService
-        .update(anyString, any[ExportsCacheModel])
-    ).thenReturn(Future.successful(Some(dataToReturn)))
+    when(mockExportsCacheService.update(anyString, any[ExportsCacheModel]))
+      .thenReturn(Future.successful(Some(dataToReturn)))
 
-    when(
-      mockExportsCacheService
-        .get(anyString)
-    ).thenReturn(Future.successful(Some(dataToReturn)))
+    when(mockExportsCacheService.get(anyString))
+      .thenReturn(Future.successful(Some(dataToReturn)))
   }
 
   protected def theCacheModelUpdated: ExportsCacheModel = {
@@ -52,4 +49,9 @@ trait MockExportsCacheService extends MockitoSugar with ExportsCacheModelBuilder
 
   protected def verifyTheCacheIsUnchanged(): Unit =
     verify(mockExportsCacheService, never()).update(anyString, any[ExportsCacheModel])
+
+  override protected def afterEach(): Unit = {
+    Mockito.reset(mockExportsCacheService)
+    super.afterEach()
+  }
 }

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -60,17 +60,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
     }
 
 
-    "validate inland mode transport code - wrong choice" in {
-
-      val incorrectTransportCode: JsValue =
-        JsObject(Map("inlandModeOfTransportCode" -> JsString("Incorrect more")))
-
-      val result = route(app, postRequest(uri, incorrectTransportCode)).get
-
-      status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include(messages(inlandTransportModeError))
-      verifyTheCacheIsUnchanged()
-    }
 
     "validate request and redirect - no answers" in {
 

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -16,19 +16,14 @@
 
 package controllers.declaration
 
-import base.{CustomExportsBaseSpec, TestHelper}
+import base.CustomExportsBaseSpec
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
-import forms.declaration.TransportCodes._
 import forms.declaration.WarehouseIdentification
 import forms.declaration.WarehouseIdentificationSpec._
-import helpers.views.declaration.WarehouseIdentificationMessages
-import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{times, verify}
-import play.api.libs.json.{JsObject, JsString, JsValue}
 import play.api.test.Helpers._
 
-class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with WarehouseIdentificationMessages {
+class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec {
 
   private val uri = uriWithContextPath("/declaration/warehouse")
 
@@ -43,23 +38,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
   }
 
   "Warehouse Identification Controller on POST" should {
-
-    "validate identification type and number" in {
-
-      val incorrectWarehouseIdentification: JsValue =
-        JsObject(Map(
-          "identificationType" -> JsString(WarehouseIdentification.IdentifierType.PUBLIC_CUSTOMS_1),
-          "identificationNumber" -> JsString("")
-        ))
-
-      val result = route(app, postRequest(uri, incorrectWarehouseIdentification)).get
-
-      status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include(messages(identificationNumberError))
-      verifyTheCacheIsUnchanged()
-    }
-
-
 
     "validate request and redirect - no answers" in {
 

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -59,17 +59,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
       verifyTheCacheIsUnchanged()
     }
 
-    "validate supervising customs office - invalid" in {
-
-      val incorrectWarehouseOffice: JsValue =
-        JsObject(Map("supervisingCustomsOffice" -> JsString("SOMEWRONGCODE")))
-
-      val Some(result) = route(app, postRequest(uri, incorrectWarehouseOffice))
-
-      status(result) mustBe BAD_REQUEST
-      contentAsString(result) must include(messages(supervisingCustomsOfficeError))
-      verifyTheCacheIsUnchanged()
-    }
 
     "validate inland mode transport code - wrong choice" in {
 

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -44,18 +44,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
 
   "Warehouse Identification Controller on POST" should {
 
-    "validate identification type" in {
-
-      val incorrectWarehouseIdentification: JsValue =
-        JsObject(Map("identificationType" -> JsString(TestHelper.createRandomAlphanumericString(2))))
-
-      val result = route(app, postRequest(uri, incorrectWarehouseIdentification)).get
-
-      status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include(messages(identificationTypeError))
-      verifyTheCacheIsUnchanged()
-    }
-
     "validate identification type and number" in {
 
       val incorrectWarehouseIdentification: JsValue =
@@ -63,18 +51,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
           "identificationType" -> JsString(WarehouseIdentification.IdentifierType.PUBLIC_CUSTOMS_1),
           "identificationNumber" -> JsString("")
         ))
-
-      val result = route(app, postRequest(uri, incorrectWarehouseIdentification)).get
-
-      status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include(messages(identificationNumberError))
-      verifyTheCacheIsUnchanged()
-    }
-
-    "validate identification number - more than 35 characters" in {
-
-      val incorrectWarehouseIdentification: JsValue =
-        JsObject(Map("identificationNumber" -> JsString(TestHelper.createRandomAlphanumericString(36))))
 
       val result = route(app, postRequest(uri, incorrectWarehouseIdentification)).get
 

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -42,27 +42,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
     Mockito.reset(mockExportsCacheService)
   }
 
-  "Warehouse Identification Controller on GET" should {
-    "read item from cache and display it" in {
-      withNewCaching(
-        aCacheModel(
-          withChoice(SupplementaryDec),
-          withWarehouseIdentification(Some("Office"), Some("R"), Some("SecretStash"), Some(Maritime))
-        )
-      )
-
-      val Some(result) = route(app, getRequest(uri))
-      val page = contentAsString(result)
-
-      status(result) must be(OK)
-      page must include("Office")
-      page must include(messages("supplementary.warehouse.identificationType.r"))
-      page must include("SecretStash")
-      page must include("Sea transport")
-      verify(mockExportsCacheService, times(2)).get(any())
-    }
-  }
-
   "Warehouse Identification Controller on POST" should {
 
     "validate identification type" in {

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -43,15 +43,6 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
   }
 
   "Warehouse Identification Controller on GET" should {
-
-    "return 200 code" in {
-
-      val result = route(app, getRequest(uri)).get
-
-      status(result) must be(OK)
-      verify(mockExportsCacheService, times(2)).get(any())
-    }
-
     "read item from cache and display it" in {
       withNewCaching(
         aCacheModel(

--- a/test/services/cache/ExportsCacheModelBuilder.scala
+++ b/test/services/cache/ExportsCacheModelBuilder.scala
@@ -238,21 +238,6 @@ trait ExportsCacheModelBuilder {
       )
     )
 
-  def withWarehouseIdentification(
-     supervisingCustomsOffice: String,
-     identificationType: String,
-     identificationNumber: String,
-     inlandModeOfTransportCode: String
-  ): CacheModifier =
-    withWarehouseIdentification(
-      WarehouseIdentification(
-        Some(supervisingCustomsOffice),
-        Some(identificationType),
-        Some(identificationNumber),
-        Some(inlandModeOfTransportCode)
-      )
-    )
-
   def withoutOfficeOfExit(): CacheModifier = cache => cache.copy(locations = cache.locations.copy(officeOfExit = None))
 
   def withOfficeOfExit(

--- a/test/services/cache/ExportsCacheModelBuilder.scala
+++ b/test/services/cache/ExportsCacheModelBuilder.scala
@@ -238,6 +238,21 @@ trait ExportsCacheModelBuilder {
       )
     )
 
+  def withWarehouseIdentification(
+     supervisingCustomsOffice: String,
+     identificationType: String,
+     identificationNumber: String,
+     inlandModeOfTransportCode: String
+  ): CacheModifier =
+    withWarehouseIdentification(
+      WarehouseIdentification(
+        Some(supervisingCustomsOffice),
+        Some(identificationType),
+        Some(identificationNumber),
+        Some(inlandModeOfTransportCode)
+      )
+    )
+
   def withoutOfficeOfExit(): CacheModifier = cache => cache.copy(locations = cache.locations.copy(officeOfExit = None))
 
   def withOfficeOfExit(

--- a/test/unit/base/ControllerSpec.scala
+++ b/test/unit/base/ControllerSpec.scala
@@ -17,55 +17,15 @@
 package unit.base
 
 import base.{MockAuthAction, MockConnectors, MockCustomsCacheService, MockExportsCacheService}
-import controllers.actions.JourneyAction
 import controllers.util.{Add, SaveAndContinue}
-import handlers.ErrorHandler
-import metrics.ExportsMetrics
-import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito
-import org.mockito.Mockito.when
-import org.scalatest.mockito.MockitoSugar
-import org.scalatest.{BeforeAndAfterEach, Suite}
 import play.api.libs.json.JsValue
-import play.api.mvc.Results.BadRequest
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAsJson, Request}
 import play.api.test.FakeRequest
-import play.twirl.api.Html
+import unit.mock.JourneyActionMocks
 import unit.tools.Stubs
 import utils.FakeRequestCSRFSupport._
 
-import scala.concurrent.{ExecutionContext, Future}
-
-trait ErrorHandlerMocks extends BeforeAndAfterEach { self: MockitoSugar with Suite =>
-
-  val mockErrorHandler: ErrorHandler = mock[ErrorHandler]
-
-  def setupErrorHandler(): Unit = {
-    when(mockErrorHandler.standardErrorTemplate(anyString, anyString, anyString)(any()))
-      .thenReturn(Html.apply(""))
-
-    when(mockErrorHandler.displayErrorPage()(any())).thenReturn(Future.successful(BadRequest(Html.apply(""))))
-  }
-
-  override protected def afterEach(): Unit = {
-    Mockito.reset(mockErrorHandler)
-    super.afterEach()
-  }
-}
-
-trait ExportsMetricsMocks extends BeforeAndAfterEach { self: MockitoSugar with Suite =>
-  val mockExportsMetrics: ExportsMetrics = mock[ExportsMetrics]
-
-  override protected def afterEach(): Unit = {
-    Mockito.reset(mockExportsMetrics)
-    super.afterEach()
-  }
-}
-
-trait JourneyActionMocks extends MockExportsCacheService with BeforeAndAfterEach { self: MockitoSugar with Suite with Stubs =>
-
-  val mockJourneyAction: JourneyAction = JourneyAction(mockExportsCacheService)(ExecutionContext.global)
-}
+import scala.concurrent.ExecutionContext
 
 trait ControllerSpec extends UnitSpec with Stubs with MockAuthAction with MockConnectors with MockCustomsCacheService
     with MockExportsCacheService with JourneyActionMocks {

--- a/test/unit/controllers/CancelDeclarationControllerSpec.scala
+++ b/test/unit/controllers/CancelDeclarationControllerSpec.scala
@@ -16,16 +16,20 @@
 
 package unit.controllers
 
+import com.codahale.metrics.Timer
 import controllers.CancelDeclarationController
 import forms.CancelDeclaration
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito.{never, verify, when}
 import forms.cancellation.CancellationChangeReason.NoLongerRequired
 import models.requests.{CancellationRequestExists, CancellationRequested, MissingDeclaration}
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import unit.base.ControllerSpec
+import unit.base.{ControllerSpec, ErrorHandlerMocks, ExportsMetricsMocks}
 import views.html.{cancel_declaration, cancellation_confirmation_page}
 
-class CancelDeclarationControllerSpec extends ControllerSpec {
+class CancelDeclarationControllerSpec extends ControllerSpec with ErrorHandlerMocks with ExportsMetricsMocks {
   import CancelDeclarationControllerSpec._
 
   trait SetUp {
@@ -42,7 +46,10 @@ class CancelDeclarationControllerSpec extends ControllerSpec {
       cancelConfirmationPage
     )(ec, minimalAppConfig)
 
+    setupErrorHandler()
     authorizedUser()
+
+    when(mockExportsMetrics.startTimer(any())).thenReturn(mock[Timer.Context])
   }
 
   "Cancel declaration controller" should {

--- a/test/unit/controllers/CancelDeclarationControllerSpec.scala
+++ b/test/unit/controllers/CancelDeclarationControllerSpec.scala
@@ -19,14 +19,14 @@ package unit.controllers
 import com.codahale.metrics.Timer
 import controllers.CancelDeclarationController
 import forms.CancelDeclaration
-import org.mockito.ArgumentCaptor
-import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.{never, verify, when}
 import forms.cancellation.CancellationChangeReason.NoLongerRequired
 import models.requests.{CancellationRequestExists, CancellationRequested, MissingDeclaration}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.when
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import unit.base.{ControllerSpec, ErrorHandlerMocks, ExportsMetricsMocks}
+import unit.base.ControllerSpec
+import unit.mock.{ErrorHandlerMocks, ExportsMetricsMocks}
 import views.html.{cancel_declaration, cancellation_confirmation_page}
 
 class CancelDeclarationControllerSpec extends ControllerSpec with ErrorHandlerMocks with ExportsMetricsMocks {

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -22,7 +22,8 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import unit.base.{ControllerSpec, ErrorHandlerMocks}
+import unit.base.ControllerSpec
+import unit.mock.ErrorHandlerMocks
 import views.html.choice_page
 
 import scala.concurrent.Future

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -22,12 +22,12 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.libs.json.{JsValue, Json}
 import play.api.test.Helpers._
-import unit.base.ControllerSpec
+import unit.base.{ControllerSpec, ErrorHandlerMocks}
 import views.html.choice_page
 
 import scala.concurrent.Future
 
-class ChoiceControllerSpec extends ControllerSpec {
+class ChoiceControllerSpec extends ControllerSpec with ErrorHandlerMocks {
   import ChoiceControllerSpec._
 
   trait SetUp {
@@ -42,6 +42,7 @@ class ChoiceControllerSpec extends ControllerSpec {
       choicePage
     )(ec, minimalAppConfig)
 
+    setupErrorHandler()
     authorizedUser()
     withCaching(None)
     withNewCaching(aCacheModel(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -24,12 +24,12 @@ import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import services.cache.{ExportItem, ExportsCacheModel}
-import unit.base.ControllerSpec
+import unit.base.{ControllerSpec, ErrorHandlerMocks}
 import views.html.declaration.additional_fiscal_references
 
 import scala.concurrent.Future
 
-class AdditionalFiscalReferencesControllerSpec extends ControllerSpec {
+class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
   trait SetUp {
 
@@ -45,6 +45,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec {
       additionalFiscalReferencesPage
     )(minimalAppConfig, ec)
 
+    setupErrorHandler()
     authorizedUser()
     withCaching(None)
     withNewCaching(aCacheModel(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -20,14 +20,11 @@ import controllers.declaration.AdditionalFiscalReferencesController
 import controllers.util.Remove
 import forms.Choice
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
-import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import services.cache.{ExportItem, ExportsCacheModel}
-import unit.base.{ControllerSpec, ErrorHandlerMocks}
+import unit.base.ControllerSpec
+import unit.mock.ErrorHandlerMocks
 import views.html.declaration.additional_fiscal_references
-
-import scala.concurrent.Future
 
 class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 

--- a/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
@@ -21,12 +21,10 @@ import controllers.util.Remove
 import forms.Choice
 import forms.declaration.AdditionalInformation
 import models.declaration.AdditionalInformationData
-import org.mockito.ArgumentMatchers.{any, anyString}
-import org.mockito.Mockito.when
 import play.api.test.Helpers._
-import play.twirl.api.Html
 import services.cache.ExportItem
-import unit.base.{ControllerSpec, ErrorHandlerMocks}
+import unit.base.ControllerSpec
+import unit.mock.ErrorHandlerMocks
 import views.html.declaration.additional_information
 
 class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandlerMocks {

--- a/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
@@ -26,10 +26,10 @@ import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.twirl.api.Html
 import services.cache.ExportItem
-import unit.base.ControllerSpec
+import unit.base.{ControllerSpec, ErrorHandlerMocks}
 import views.html.declaration.additional_information
 
-class AdditionalInformationControllerSpec extends ControllerSpec {
+class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
   trait SetUp {
 
@@ -45,6 +45,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec {
       additionalInformationPage
     )(ec, minimalAppConfig)
 
+    setupErrorHandler()
     authorizedUser()
     withCaching(None)
     withNewCaching(aCacheModel(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))

--- a/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
@@ -22,10 +22,10 @@ import forms.declaration.BorderTransport
 import forms.declaration.TransportCodes.{Maritime, WagonNumber}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
-import unit.base.ControllerSpec
+import unit.base.{ControllerSpec, ErrorHandlerMocks}
 import views.html.declaration.border_transport
 
-class BorderTransportControllerSpec extends ControllerSpec {
+class BorderTransportControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
   trait SetUp {
     val borderTransportPage = new border_transport(mainTemplate)
@@ -40,6 +40,7 @@ class BorderTransportControllerSpec extends ControllerSpec {
       borderTransportPage
     )(ec, minimalAppConfig)
 
+    setupErrorHandler()
     authorizedUser()
     withCaching(None)
     withNewCaching(aCacheModel(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))

--- a/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
@@ -22,7 +22,8 @@ import forms.declaration.BorderTransport
 import forms.declaration.TransportCodes.{Maritime, WagonNumber}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
-import unit.base.{ControllerSpec, ErrorHandlerMocks}
+import unit.base.ControllerSpec
+import unit.mock.ErrorHandlerMocks
 import views.html.declaration.border_transport
 
 class BorderTransportControllerSpec extends ControllerSpec with ErrorHandlerMocks {

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -65,10 +65,10 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
         aCacheModel(
           withChoice(SupplementaryDec),
           withWarehouseIdentification(
-            customsOfficeIdentifier,
-            warehauseIdentificationType,
-            warehauseIdentificationNumber,
-            transportMode
+            Some(customsOfficeIdentifier),
+            Some(warehauseIdentificationType),
+            Some(warehauseIdentificationNumber),
+            Some(transportMode)
           )
         )
       )

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -100,6 +100,19 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       verifyTheCacheIsUnchanged()
     }
 
+    "validate supervising customs office - invalid" in {
+
+      val incorrectWarehouseOffice: JsValue =
+        JsObject(Map("supervisingCustomsOffice" -> JsString("SOMEWRONGCODE")))
+
+      val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseOffice))
+
+      status(result) mustBe BAD_REQUEST
+      contentAsString(result) must include("supplementary.warehouse.supervisingCustomsOffice.error")
+      verifyTheCacheIsUnchanged()
+    }
+
+
   }
 
   override protected def beforeEach(): Unit = {

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -18,6 +18,7 @@ package unit.controllers.declaration
 
 import controllers.declaration.WarehouseIdentificationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
+import forms.declaration.TransportCodes.Maritime
 import forms.declaration.WarehouseIdentification
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify}
@@ -38,15 +39,39 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
     warehouseIdentificationPage = new warehouse_identification(mainTemplate)
   )
 
+  "WerehouseIdentificationController on GET request" should {
+    "return 200 OK" in {
+      val response = controller.displayForm().apply(getRequest())
+      status(response) must be(OK)
+      verify(mockExportsCacheService, times(2)).get(any())
+    }
 
+    "read item from cache and display it" in {
+      val customsOfficeIdentifier = "Office"
+      val warehauseIdentificationType = "R"
+      val warehauseIdentificationNumber = "SecretStash"
+      val transportMode = Maritime
+      withNewCaching(
+        aCacheModel(
+          withChoice(SupplementaryDec),
+          withWarehouseIdentification(
+            customsOfficeIdentifier,
+            warehauseIdentificationType,
+            warehauseIdentificationNumber,
+            transportMode
+          )
+        )
+      )
 
-  "WerehouseIdentificationController" should {
-    "return 200 OK" when {
-      "request were made" in {
-        val response = controller.displayForm().apply(getRequest())
-        status(response) must be(OK)
-        verify(mockExportsCacheService, times(2)).get(any())
-      }
+      val result = controller.displayForm().apply(getRequest())
+      val page = contentAsString(result)
+
+      status(result) must be(OK)
+      page must include(customsOfficeIdentifier)
+      page must include("supplementary.warehouse.identificationType.r") // determinate by identification type
+      page must include(warehauseIdentificationNumber)
+      page must include("supplementary.transportInfo.transportMode.sea") // determinate by transportMode
+      verify(mockExportsCacheService, times(2)).get(any())
     }
   }
 

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -112,6 +112,19 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       verifyTheCacheIsUnchanged()
     }
 
+    "validate inland mode transport code - wrong choice" in {
+
+      val incorrectTransportCode: JsValue =
+        JsObject(Map("inlandModeOfTransportCode" -> JsString("Incorrect more")))
+
+      val result = controller.saveWarehouse().apply(postRequest(incorrectTransportCode))
+
+      status(result) must be(BAD_REQUEST)
+      contentAsString(result) must include("supplementary.warehouse.inlandTransportMode.error.incorrect")
+      verifyTheCacheIsUnchanged()
+    }
+
+
 
   }
 

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -20,6 +20,8 @@ import base.TestHelper
 import controllers.declaration.WarehouseIdentificationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.TransportCodes.Maritime
+import forms.declaration.WarehouseIdentification
+import helpers.views.declaration.WarehouseIdentificationMessages
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify}
 import org.scalatest.BeforeAndAfterEach
@@ -28,7 +30,8 @@ import play.api.test.Helpers._
 import unit.base.ControllerSpec
 import views.html.declaration.warehouse_identification
 
-class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAndAfterEach {
+class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAndAfterEach
+  with WarehouseIdentificationMessages {
 
   val controller = new WarehouseIdentificationController(
     appConfig = minimalAppConfig,
@@ -90,7 +93,22 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseIdentification))
 
       status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include("supplementary.warehouse.identificationType.error")
+      contentAsString(result) must include(identificationTypeError)
+      verifyTheCacheIsUnchanged()
+    }
+
+    "validate identification type and number" in {
+
+      val incorrectWarehouseIdentification: JsValue =
+        JsObject(Map(
+          "identificationType" -> JsString(WarehouseIdentification.IdentifierType.PUBLIC_CUSTOMS_1),
+          "identificationNumber" -> JsString("")
+        ))
+
+      val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseIdentification))
+
+      status(result) must be(BAD_REQUEST)
+      contentAsString(result) must include(identificationNumberError)
       verifyTheCacheIsUnchanged()
     }
 
@@ -101,7 +119,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseIdentification))
 
       status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include("supplementary.warehouse.identificationNumber.error")
+      contentAsString(result) must include(identificationNumberError)
       verifyTheCacheIsUnchanged()
     }
 
@@ -113,7 +131,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseOffice))
 
       status(result) mustBe BAD_REQUEST
-      contentAsString(result) must include("supplementary.warehouse.supervisingCustomsOffice.error")
+      contentAsString(result) must include(supervisingCustomsOfficeError)
       verifyTheCacheIsUnchanged()
     }
 
@@ -125,7 +143,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       val result = controller.saveWarehouse().apply(postRequest(incorrectTransportCode))
 
       status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include("supplementary.warehouse.inlandTransportMode.error.incorrect")
+      contentAsString(result) must include(inlandTransportModeError)
       verifyTheCacheIsUnchanged()
     }
   }

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -19,9 +19,12 @@ package unit.controllers.declaration
 import controllers.declaration.WarehouseIdentificationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.WarehouseIdentification
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{times, verify}
 import org.scalatest.BeforeAndAfterEach
 import unit.base.ControllerSpec
 import views.html.declaration.warehouse_identification
+import play.api.test.Helpers._
 
 class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAndAfterEach {
 
@@ -32,7 +35,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
     customsCacheService = mockCustomsCacheService,
     exportsCacheService = mockExportsCacheService,
     mcc = stubMessagesControllerComponents(),
-    warehouseIdentificationPage = mock[warehouse_identification]
+    warehouseIdentificationPage = new warehouse_identification(mainTemplate)
   )
 
 
@@ -40,7 +43,9 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
   "WerehouseIdentificationController" should {
     "return 200 OK" when {
       "request were made" in {
-        ???
+        val response = controller.displayForm().apply(getRequest())
+        status(response) must be(OK)
+        verify(mockExportsCacheService, times(2)).get(any())
       }
     }
   }
@@ -48,7 +53,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aCacheModel(withChoice(SupplementaryDec)))
-    withCaching[WarehouseIdentification](None)
+    withNewCaching(aCacheModel(withChoice(SupplementaryDec), withoutWarehouseIdentification()))
+//    withCaching[WarehouseIdentification](None)
   }
 }

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers.declaration
+
+import controllers.declaration.WarehouseIdentificationController
+import forms.Choice.AllowedChoiceValues.SupplementaryDec
+import forms.declaration.WarehouseIdentification
+import org.scalatest.BeforeAndAfterEach
+import unit.base.ControllerSpec
+import views.html.declaration.warehouse_identification
+
+class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAndAfterEach {
+
+  val controller = new WarehouseIdentificationController(
+    appConfig = minimalAppConfig,
+    authenticate = mockAuthAction,
+    journeyType = mockJourneyAction,
+    customsCacheService = mockCustomsCacheService,
+    exportsCacheService = mockExportsCacheService,
+    mcc = stubMessagesControllerComponents(),
+    warehouseIdentificationPage = mock[warehouse_identification]
+  )
+
+
+
+  "WerehouseIdentificationController" should {
+    "return 200 OK" when {
+      "request were made" in {
+        ???
+      }
+    }
+  }
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    authorizedUser()
+    withNewCaching(aCacheModel(withChoice(SupplementaryDec)))
+    withCaching[WarehouseIdentification](None)
+  }
+}

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -96,7 +96,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       val result = controller.saveWarehouse().apply(postRequest(incorrectWarehouseIdentification))
 
       status(result) must be(BAD_REQUEST)
-      contentAsString(result) must include("supplementary.warehouse.identificationType.error")
+      contentAsString(result) must include("supplementary.warehouse.identificationNumber.error")
       verifyTheCacheIsUnchanged()
     }
 

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -40,6 +40,12 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
     warehouseIdentificationPage = new warehouse_identification(mainTemplate)
   )
 
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    authorizedUser()
+    withNewCaching(aCacheModel(withChoice(SupplementaryDec), withoutWarehouseIdentification()))
+  }
+
   "WerehouseIdentificationController on GET request" should {
     "return 200 OK" in {
       val response = controller.displayForm().apply(getRequest())
@@ -122,11 +128,5 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       contentAsString(result) must include("supplementary.warehouse.inlandTransportMode.error.incorrect")
       verifyTheCacheIsUnchanged()
     }
-  }
-
-  override protected def beforeEach(): Unit = {
-    super.beforeEach()
-    authorizedUser()
-    withNewCaching(aCacheModel(withChoice(SupplementaryDec), withoutWarehouseIdentification()))
   }
 }

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -20,14 +20,13 @@ import base.TestHelper
 import controllers.declaration.WarehouseIdentificationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.TransportCodes.Maritime
-import forms.declaration.WarehouseIdentification
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{times, verify}
 import org.scalatest.BeforeAndAfterEach
 import play.api.libs.json.{JsObject, JsString, JsValue}
+import play.api.test.Helpers._
 import unit.base.ControllerSpec
 import views.html.declaration.warehouse_identification
-import play.api.test.Helpers._
 
 class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAndAfterEach {
 
@@ -123,9 +122,6 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
       contentAsString(result) must include("supplementary.warehouse.inlandTransportMode.error.incorrect")
       verifyTheCacheIsUnchanged()
     }
-
-
-
   }
 
   override protected def beforeEach(): Unit = {

--- a/test/unit/mock/ErrorHandlerMocks.scala
+++ b/test/unit/mock/ErrorHandlerMocks.scala
@@ -1,0 +1,29 @@
+package unit.mock
+
+import handlers.ErrorHandler
+import org.mockito.ArgumentMatchers.{any, anyString}
+import org.mockito.Mockito
+import org.mockito.Mockito.when
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.mockito.MockitoSugar
+import play.api.mvc.Results.BadRequest
+import play.twirl.api.Html
+
+import scala.concurrent.Future
+
+trait ErrorHandlerMocks extends BeforeAndAfterEach { self: MockitoSugar with Suite =>
+
+  val mockErrorHandler: ErrorHandler = mock[ErrorHandler]
+
+  def setupErrorHandler(): Unit = {
+    when(mockErrorHandler.standardErrorTemplate(anyString, anyString, anyString)(any()))
+      .thenReturn(Html.apply(""))
+
+    when(mockErrorHandler.displayErrorPage()(any())).thenReturn(Future.successful(BadRequest(Html.apply(""))))
+  }
+
+  override protected def afterEach(): Unit = {
+    Mockito.reset(mockErrorHandler)
+    super.afterEach()
+  }
+}

--- a/test/unit/mock/ErrorHandlerMocks.scala
+++ b/test/unit/mock/ErrorHandlerMocks.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.mock
 
 import handlers.ErrorHandler

--- a/test/unit/mock/ExportsMetricsMocks.scala
+++ b/test/unit/mock/ExportsMetricsMocks.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.mock
 
 import metrics.ExportsMetrics

--- a/test/unit/mock/ExportsMetricsMocks.scala
+++ b/test/unit/mock/ExportsMetricsMocks.scala
@@ -1,0 +1,15 @@
+package unit.mock
+
+import metrics.ExportsMetrics
+import org.mockito.Mockito
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.mockito.MockitoSugar
+
+trait ExportsMetricsMocks extends BeforeAndAfterEach { self: MockitoSugar with Suite =>
+  val mockExportsMetrics: ExportsMetrics = mock[ExportsMetrics]
+
+  override protected def afterEach(): Unit = {
+    Mockito.reset(mockExportsMetrics)
+    super.afterEach()
+  }
+}

--- a/test/unit/mock/JourneyActionMocks.scala
+++ b/test/unit/mock/JourneyActionMocks.scala
@@ -1,0 +1,14 @@
+package unit.mock
+
+import base.MockExportsCacheService
+import controllers.actions.JourneyAction
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.mockito.MockitoSugar
+import unit.tools.Stubs
+
+import scala.concurrent.ExecutionContext
+
+trait JourneyActionMocks extends MockExportsCacheService with BeforeAndAfterEach { self: MockitoSugar with Suite with Stubs =>
+
+  val mockJourneyAction: JourneyAction = JourneyAction(mockExportsCacheService)(ExecutionContext.global)
+}

--- a/test/unit/mock/JourneyActionMocks.scala
+++ b/test/unit/mock/JourneyActionMocks.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package unit.mock
 
 import base.MockExportsCacheService


### PR DESCRIPTION
Move some integration tests to unit tests if it does not require to have running application to perform assertion.

I have added some resets to `mock` traits in `afterEach` and little local refactoring.