### PR TITLE
Model in request on journey action

### DIFF
--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -41,8 +41,8 @@ case class JourneyAction @Inject()(cacheService: ExportsCacheService, mcc: Messa
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    cacheService.get(request.session.data("sessionId")).map(_.map(_.choice)).map {
-      case Some(journeyType) => Right(JourneyRequest(request, Choice(journeyType)))
+    cacheService.get(request.session.data("sessionId")).map {
+      case Some(cacheModel) => Right(JourneyRequest(request, cacheModel))
       case _ =>
         logger.error(s"Could not obtain journey type for ${eoriCacheId()(request)}")
         Left(Conflict("Could not obtain information about journey type"))

--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -19,7 +19,6 @@ package controllers.actions
 import com.google.inject.Inject
 import controllers.declaration.SessionIdAware
 import controllers.util.CacheIdGenerator.eoriCacheId
-import forms.Choice
 import models.requests.{AuthenticatedRequest, JourneyRequest}
 import play.api.Logger
 import play.api.mvc.Results.Conflict
@@ -41,7 +40,7 @@ case class JourneyAction @Inject()(cacheService: ExportsCacheService, mcc: Messa
     implicit val hc: HeaderCarrier =
       HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
 
-    cacheService.get(request.session.data("sessionId")).map {
+    cacheService.get(request.sessionId).map {
       case Some(cacheModel) => Right(JourneyRequest(request, cacheModel))
       case _ =>
         logger.error(s"Could not obtain journey type for ${eoriCacheId()(request)}")

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -42,9 +42,9 @@ class AdditionalDeclarationTypeController @Inject()(
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val decType = extractFormType(request)
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.additionalDeclarationType)).map {
+    request.cacheModel.additionalDeclarationType match {
       case Some(data) => Ok(declarationTypePage(decType.form().fill(data)))
       case _          => Ok(declarationTypePage(decType.form()))
     }

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -72,8 +72,9 @@ class AdditionalDeclarationTypeController @Inject()(
       case StandardDec      => AdditionalDeclarationTypeStandardDec
     }
 
-  private def updateCache(sessionId: String, formData: AdditionalDeclarationType): Future[Option[ExportsCacheModel]] =
-    getAndUpdateExportCacheModel(sessionId, model => {
+  private def updateCache(sessionId: String, formData: AdditionalDeclarationType)
+                         (implicit request: JourneyRequest[_]): Future[Option[ExportsCacheModel]] =
+    updateExportCacheModel(model => {
       exportsCacheService.update(sessionId, model.copy(additionalDeclarationType = Some(formData)))
     })
 

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -47,8 +47,8 @@ class AdditionalFiscalReferencesController @Inject()(
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId) match {
       case Some(model) => {
         model.additionalFiscalReferencesData.fold(Ok(additionalFiscalReferencesPage(itemId, form()))) { data =>
           Ok(additionalFiscalReferencesPage(itemId, form(), data.references))

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -50,8 +50,8 @@ class AdditionalInformationController @Inject()(
 
   val elementLimit = 99
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map(_.flatMap(_.additionalInformation)).map {
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId).flatMap(_.additionalInformation) match {
       case Some(data) => Ok(additionalInformationPage(itemId, appConfig, form(), data.items))
       case _          => Ok(additionalInformationPage(itemId, appConfig, form(), Seq()))
     }

--- a/app/controllers/declaration/BorderTransportController.scala
+++ b/app/controllers/declaration/BorderTransportController.scala
@@ -44,8 +44,8 @@ class BorderTransportController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.borderTransport)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.borderTransport match {
       case Some(data) => Ok(borderTransportPage(form.fill(data)))
       case _          => Ok(borderTransportPage(form))
     }

--- a/app/controllers/declaration/CarrierDetailsController.scala
+++ b/app/controllers/declaration/CarrierDetailsController.scala
@@ -45,8 +45,8 @@ class CarrierDetailsController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.carrierDetails)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.carrierDetails match {
       case Some(data) => Ok(carrierDetailsPage(CarrierDetails.form().fill(data)))
       case _          => Ok(carrierDetailsPage(CarrierDetails.form()))
     }

--- a/app/controllers/declaration/CommodityMeasureController.scala
+++ b/app/controllers/declaration/CommodityMeasureController.scala
@@ -44,16 +44,15 @@ class CommodityMeasureController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map { item =>
-      val packageInformation = item.map(_.packageInformation)
-      val commodityMeasure = item.flatMap(_.commodityMeasure)
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    val item = request.cacheModel.itemBy(itemId)
+    val packageInformation = item.map(_.packageInformation)
+    val commodityMeasure = item.flatMap(_.commodityMeasure)
 
-      (packageInformation, commodityMeasure) match {
-        case (Some(p), Some(data)) if p.nonEmpty => Ok(goodsMeasurePage(itemId, form().fill(data)))
-        case (Some(p), _) if p.nonEmpty          => Ok(goodsMeasurePage(itemId, form()))
-        case _                                   => BadRequest(goodsMeasurePage(itemId, form().withGlobalError(ADD_ONE)))
-      }
+    (packageInformation, commodityMeasure) match {
+      case (Some(p), Some(data)) if p.nonEmpty => Ok(goodsMeasurePage(itemId, form().fill(data)))
+      case (Some(p), _) if p.nonEmpty          => Ok(goodsMeasurePage(itemId, form()))
+      case _                                   => BadRequest(goodsMeasurePage(itemId, form().withGlobalError(ADD_ONE)))
     }
   }
 

--- a/app/controllers/declaration/ConfirmationController.scala
+++ b/app/controllers/declaration/ConfirmationController.scala
@@ -34,7 +34,7 @@ class ConfirmationController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    Future.successful(Ok(confirmationPage()))
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    Ok(confirmationPage())
   }
 }

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -21,6 +21,7 @@ import controllers.actions.{AuthAction, JourneyAction}
 import controllers.util.CacheIdGenerator.cacheId
 import forms.declaration.ConsigneeDetails
 import javax.inject.Inject
+import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -64,9 +65,10 @@ class ConsigneeDetailsController @Inject()(
       )
   }
 
-  private def updateCache(sessionId: String, formData: ConsigneeDetails): Future[Option[ExportsCacheModel]] =
-    getAndUpdateExportCacheModel(sessionId, model => {
+  private def updateCache(sessionId: String, formData: ConsigneeDetails)
+                         (implicit request: JourneyRequest[_]): Future[Option[ExportsCacheModel]] =
+    updateExportCacheModel { model =>
       val updatedParties = model.parties.copy(consigneeDetails = Some(formData))
       exportsCacheService.update(sessionId, model.copy(parties = updatedParties))
-    })
+    }
 }

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -44,8 +44,8 @@ class ConsigneeDetailsController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.consigneeDetails)).map {
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.consigneeDetails match {
       case Some(data) => Ok(consigneeDetailsPage(ConsigneeDetails.form().fill(data)))
       case _          => Ok(consigneeDetailsPage(ConsigneeDetails.form()))
     }

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -44,8 +44,8 @@ class ConsignmentReferencesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.consignmentReferences)).map {
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.consignmentReferences match {
       case Some(data) => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form().fill(data)))
       case _          => Ok(consignmentReferencesPage(appConfig, ConsignmentReferences.form()))
     }

--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -42,8 +42,8 @@ class DeclarantDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarantDetails)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.declarantDetails match {
       case Some(data) => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form().fill(data)))
       case _          => Ok(declarantDetailsPage(appConfig, DeclarantDetails.form()))
     }

--- a/app/controllers/declaration/DeclarationAdditionalActorsController.scala
+++ b/app/controllers/declaration/DeclarationAdditionalActorsController.scala
@@ -53,8 +53,8 @@ class DeclarationAdditionalActorsController @Inject()(
   private val exceedMaximumNumberError = "supplementary.additionalActors.maximumAmount.error"
   private val duplicateActorError = "supplementary.additionalActors.duplicated.error"
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarationAdditionalActorsData)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.declarationAdditionalActorsData match {
       case Some(data) => Ok(declarationAdditionalActorsPage(appConfig, form(), data.actors))
       case _          => Ok(declarationAdditionalActorsPage(appConfig, form(), Seq()))
     }

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -51,8 +51,8 @@ class DeclarationHolderController @Inject()(
 
   import forms.declaration.DeclarationHolder.form
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.declarationHoldersData)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.declarationHoldersData match {
       case Some(data) => Ok(declarationHolderPage(appConfig, form(), data.holders))
       case _          => Ok(declarationHolderPage(appConfig, form(), Seq()))
     }

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -53,24 +53,21 @@ class DestinationCountriesController @Inject()(
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.choice.value match {
       case SupplementaryDec => displayFormSupplementary()
       case StandardDec      => displayFormStandard()
     }
   }
 
-  private def displayFormSupplementary()(
-    implicit request: JourneyRequest[AnyContent],
-    hc: HeaderCarrier
-  ): Future[Result] =
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
+  private def displayFormSupplementary()(implicit request: JourneyRequest[AnyContent]): Result =
+    request.cacheModel.locations.destinationCountries match {
       case Some(data) => Ok(destinationCountriesSupplementaryPage(Supplementary.form.fill(data)))
       case _          => Ok(destinationCountriesSupplementaryPage(Supplementary.form))
     }
 
-  private def displayFormStandard()(implicit request: JourneyRequest[AnyContent], hc: HeaderCarrier): Future[Result] =
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.destinationCountries)).map {
+  private def displayFormStandard()(implicit request: JourneyRequest[AnyContent]): Result =
+    request.cacheModel.locations.destinationCountries match {
       case Some(data) => Ok(destinationCountriesStandardPage(Standard.form.fill(data), data.countriesOfRouting))
       case _          => Ok(destinationCountriesStandardPage(Standard.form, Seq.empty))
     }

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -42,8 +42,8 @@ class DispatchLocationController @Inject()(
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.dispatchLocation)).map {
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.dispatchLocation match {
       case Some(data) => Ok(dispatchLocationPage(DispatchLocation.form().fill(data)))
       case _          => Ok(dispatchLocationPage(DispatchLocation.form()))
     }

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -22,6 +22,7 @@ import controllers.util.CacheIdGenerator.cacheId
 import forms.declaration.DispatchLocation
 import forms.declaration.DispatchLocation.AllowedDispatchLocations
 import javax.inject.Inject
+import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
@@ -72,9 +73,10 @@ class DispatchLocationController @Inject()(
         controllers.declaration.routes.NotEligibleController.displayPage()
     }
 
-  private def updateCache(sessionId: String, formData: DispatchLocation): Future[Option[ExportsCacheModel]] =
-    getAndUpdateExportCacheModel(sessionId, model => {
+  private def updateCache(sessionId: String, formData: DispatchLocation)
+                         (implicit request: JourneyRequest[_]): Future[Option[ExportsCacheModel]] =
+    updateExportCacheModel(model =>
       exportsCacheService.update(sessionId, model.copy(dispatchLocation = Some(formData)))
-    })
+    )
 
 }

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -51,9 +51,8 @@ class DocumentsProducedController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId) map (_.flatMap(_.documentsProducedData)
-      .map(_.documents)) map {
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId).flatMap(_.documentsProducedData).map(_.documents) match {
       case Some(data) => Ok(documentProducedPage(itemId, appConfig, form(), data))
       case _          => Ok(documentProducedPage(itemId, appConfig, form(), Seq()))
     }

--- a/app/controllers/declaration/ExporterDetailsController.scala
+++ b/app/controllers/declaration/ExporterDetailsController.scala
@@ -42,8 +42,8 @@ class ExporterDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.exporterDetails)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.exporterDetails match {
       case Some(data) => Ok(exporterDetailsPage(appConfig, ExporterDetails.form().fill(data)))
       case _          => Ok(exporterDetailsPage(appConfig, ExporterDetails.form()))
     }

--- a/app/controllers/declaration/FiscalInformationController.scala
+++ b/app/controllers/declaration/FiscalInformationController.scala
@@ -44,8 +44,8 @@ class FiscalInformationController @Inject()(
 )(implicit appConfig: AppConfig, ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId) match {
       case Some(data) =>
         data.fiscalInformation.fold(Ok(fiscalInformationPage(itemId, form()))) { fiscalInformation =>
           Ok(fiscalInformationPage(itemId, form().fill(fiscalInformation)))

--- a/app/controllers/declaration/ItemTypeController.scala
+++ b/app/controllers/declaration/ItemTypeController.scala
@@ -51,12 +51,9 @@ class ItemTypeController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService
-      .getItemByIdAndSession(itemId, journeySessionId)
-      .map(_.flatMap(_.itemType))
-      .zip(hasAdditionalFiscalReferencesFor(itemId))
-      .map {
-        case (Some(itemType), hasFiscalReferences) =>
+    hasAdditionalFiscalReferencesFor(itemId).map { hasFiscalReferences =>
+      request.cacheModel.itemBy(itemId).flatMap(_.itemType) match {
+        case Some(itemType) =>
           Ok(
             itemTypePage(
               itemId,
@@ -66,9 +63,10 @@ class ItemTypeController @Inject()(
               itemType.nationalAdditionalCodes
             )
           )
-        case (_, hasFiscalReferences) =>
+        case None =>
           Ok(itemTypePage(itemId, ItemType.form(), hasFiscalReferences))
       }
+    }
   }
 
   def submitItemType(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async {

--- a/app/controllers/declaration/ItemsSummaryController.scala
+++ b/app/controllers/declaration/ItemsSummaryController.scala
@@ -39,13 +39,8 @@ class ItemsSummaryController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService
-      .get(journeySessionId)
-      .map {
-        case Some(cacheModel) => Ok(itemsSummaryPage(cacheModel.items.toList))
-        case None             => Ok(itemsSummaryPage(List.empty))
-      }
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    Ok(itemsSummaryPage(request.cacheModel.items.toList))
   }
 
   def addItem(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/LocationController.scala
+++ b/app/controllers/declaration/LocationController.scala
@@ -44,8 +44,8 @@ class LocationController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.GoodsLocation._
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.goodsLocation)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.locations.goodsLocation match  {
       case Some(data) => Ok(goodsLocationPage(appConfig, form.fill(data)))
       case _          => Ok(goodsLocationPage(appConfig, form))
     }

--- a/app/controllers/declaration/ModelCacheable.scala
+++ b/app/controllers/declaration/ModelCacheable.scala
@@ -33,12 +33,18 @@ trait ModelCacheable {
       case Some(model) => update(model)
       case _           => Future.successful(None)
     }
+
+  protected def updateExportCacheModel(
+    update: ExportsCacheModel => Future[Option[ExportsCacheModel]]
+  )(implicit ec: ExecutionContext, request: JourneyRequest[_]): Future[Option[ExportsCacheModel]] = {
+    update(request.cacheModel)
+  }
 }
 
 trait SessionIdAware {
   def journeySessionId(implicit request: JourneyRequest[_]) =
-    request.authenticatedRequest.session.data("sessionId")
+    request.journeySessionId
 
   def authenticatedSessionId(implicit request: AuthenticatedRequest[AnyContent]) =
-    request.session.data("sessionId")
+    request.sessionId
 }

--- a/app/controllers/declaration/NatureOfTransactionController.scala
+++ b/app/controllers/declaration/NatureOfTransactionController.scala
@@ -42,8 +42,8 @@ class NatureOfTransactionController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.natureOfTransaction)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.natureOfTransaction match {
       case Some(data) => Ok(natureOfTransactionPage(form.fill(data)))
       case _          => Ok(natureOfTransactionPage(form))
     }

--- a/app/controllers/declaration/NotEligibleController.scala
+++ b/app/controllers/declaration/NotEligibleController.scala
@@ -35,7 +35,7 @@ class NotEligibleController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    Future.successful(Ok(notEligiblePage(appConfig)))
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    Ok(notEligiblePage(appConfig))
   }
 }

--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -46,21 +46,21 @@ class OfficeOfExitController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.officeOfExit.OfficeOfExitForms._
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.choice.value match {
-      case SupplementaryDec => supplementaryPage.map(Ok(_))
-      case StandardDec      => standardPage.map(Ok(_))
+      case SupplementaryDec => Ok(supplementaryPage())
+      case StandardDec      => Ok(standardPage())
     }
   }
 
-  private def supplementaryPage()(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Html] =
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
+  private def supplementaryPage()(implicit request: JourneyRequest[_]): Html =
+    request.cacheModel.locations.officeOfExit match {
       case Some(data) => officeOfExitSupplementaryPage(supplementaryForm.fill(OfficeOfExitSupplementary(data)))
       case _          => officeOfExitSupplementaryPage(supplementaryForm)
     }
 
-  private def standardPage()(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Html] =
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.officeOfExit)).map {
+  private def standardPage()(implicit request: JourneyRequest[_], hc: HeaderCarrier): Html =
+    request.cacheModel.locations.officeOfExit match {
       case Some(data) => officeOfExitStandardPage(standardForm.fill(OfficeOfExitStandard(data)))
       case _          => officeOfExitStandardPage(standardForm)
     }

--- a/app/controllers/declaration/PackageInformationController.scala
+++ b/app/controllers/declaration/PackageInformationController.scala
@@ -48,11 +48,9 @@ class PackageInformationController @Inject()(
 
   val packagesMaxElements = 99
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService
-      .getItemByIdAndSession(itemId, journeySessionId)
-      .map(_.map(_.packageInformation))
-      .map(items => Ok(packageInformationPage(itemId, form(), items.getOrElse(Seq.empty))))
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    val items = request.cacheModel.itemBy(itemId).map(_.packageInformation).getOrElse(Nil)
+    Ok(packageInformationPage(itemId, form(), items))
   }
 
   def submitForm(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async {

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -46,8 +46,8 @@ class PreviousDocumentsController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.previousDocuments)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.previousDocuments match {
       case Some(data) => Ok(previousDocumentsPage(form(), data.documents))
       case _          => Ok(previousDocumentsPage(form(), Seq.empty))
     }

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -50,8 +50,8 @@ class ProcedureCodesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map {
+  def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId) match {
       case Some(exportItem) =>
         exportItem.procedureCodes.fold({ Ok(procedureCodesPage(appConfig, itemId, form(), Seq())) }) {
           procedureCodesData =>

--- a/app/controllers/declaration/RepresentativeDetailsController.scala
+++ b/app/controllers/declaration/RepresentativeDetailsController.scala
@@ -46,12 +46,11 @@ class RepresentativeDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayRepresentativeDetailsPage(): Action[AnyContent] = (authenticate andThen journeyType).async {
-    implicit request =>
-      exportsCacheService.get(journeySessionId).map(_.flatMap(_.parties.representativeDetails)).map {
-        case Some(data) => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form().fill(data)))
-        case _          => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form()))
-      }
+  def displayRepresentativeDetailsPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.parties.representativeDetails match {
+      case Some(data) => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form().fill(data)))
+      case _          => Ok(representativeDetailsPage(appConfig, RepresentativeDetails.form()))
+    }
   }
 
   def submitRepresentativeDetails(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -47,13 +47,9 @@ class SealController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val declaration = exportsCacheService.get(journeySessionId)
-    declaration.map(_.flatMap(_.transportDetails)).flatMap { data =>
-      declaration.map(_.map(_.seals)).map { seals =>
-        Ok(sealPage(form, seals.getOrElse(Seq.empty), data.fold(false)(_.container)))
-      }
-    }
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    val declaration = request.cacheModel
+    Ok(sealPage(form, declaration.seals, declaration.transportDetails.exists(_.container)))
   }
 
   def submitForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/SummaryController.scala
+++ b/app/controllers/declaration/SummaryController.scala
@@ -52,10 +52,11 @@ class SummaryController @Inject()(
   implicit val appConfigImpl: AppConfig = appConfig
   private val logger = Logger(this.getClass())
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map {
-      case Some(data) if containsMandatoryData(data) => Ok(summaryPage(SupplementaryDeclarationData(data)))
-      case _                                         => Ok(summaryPageNoData())
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    if(containsMandatoryData(request.cacheModel)){
+      Ok(summaryPage(SupplementaryDeclarationData(request.cacheModel)))
+    } else {
+      Ok(summaryPageNoData())
     }
   }
 

--- a/app/controllers/declaration/TotalNumberOfItemsController.scala
+++ b/app/controllers/declaration/TotalNumberOfItemsController.scala
@@ -44,8 +44,8 @@ class TotalNumberOfItemsController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
   import forms.declaration.TotalNumberOfItems._
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.totalNumberOfItems)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.totalNumberOfItems match {
       case Some(data) => Ok(totalNumberOfItemsPage(appConfig, form.fill(data)))
       case _          => Ok(totalNumberOfItemsPage(appConfig, form))
     }

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -50,8 +50,8 @@ class TransportContainerController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.containerData)).map {
+  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.containerData match {
       case Some(data) => Ok(transportContainersPage(form, data.containers))
       case _          => Ok(transportContainersPage(form, Seq()))
     }

--- a/app/controllers/declaration/TransportDetailsController.scala
+++ b/app/controllers/declaration/TransportDetailsController.scala
@@ -47,8 +47,8 @@ class TransportDetailsController @Inject()(
 )(implicit ec: ExecutionContext, appConfig: AppConfig)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SessionIdAware {
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.transportDetails)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.transportDetails match {
       case Some(data) => Ok(transportDetailsPage(form.fill(data)))
       case _          => Ok(transportDetailsPage(form))
     }

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -44,8 +44,8 @@ class WarehouseIdentificationController @Inject()(
 
   import forms.declaration.WarehouseIdentification._
 
-  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    exportsCacheService.get(journeySessionId).map(_.flatMap(_.locations.warehouseIdentification)).map {
+  def displayForm(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.locations.warehouseIdentification match {
       case Some(data) => Ok(warehouseIdentificationPage(appConfig, form.fill(data)))
       case _          => Ok(warehouseIdentificationPage(appConfig, form))
     }

--- a/app/models/requests/AuthenticatedRequest.scala
+++ b/app/models/requests/AuthenticatedRequest.scala
@@ -19,4 +19,6 @@ package models.requests
 import models.SignedInUser
 import play.api.mvc.{Request, WrappedRequest}
 
-case class AuthenticatedRequest[A](request: Request[A], user: SignedInUser) extends WrappedRequest[A](request)
+case class AuthenticatedRequest[A](request: Request[A], user: SignedInUser) extends WrappedRequest[A](request) {
+  def sessionId: String = request.session.data("sessionId")
+}

--- a/app/models/requests/JourneyRequest.scala
+++ b/app/models/requests/JourneyRequest.scala
@@ -18,6 +18,11 @@ package models.requests
 
 import forms.Choice
 import play.api.mvc.WrappedRequest
+import services.cache.ExportsCacheModel
 
-case class JourneyRequest[A](authenticatedRequest: AuthenticatedRequest[A], choice: Choice)
-    extends WrappedRequest[A](authenticatedRequest)
+case class JourneyRequest[A](authenticatedRequest: AuthenticatedRequest[A], cacheModel: ExportsCacheModel)
+    extends WrappedRequest[A](authenticatedRequest) {
+  val choice: Choice = Choice(cacheModel.choice)
+
+  def journeySessionId: String= authenticatedRequest.sessionId
+}

--- a/app/services/cache/ExportsCacheModelRepository.scala
+++ b/app/services/cache/ExportsCacheModelRepository.scala
@@ -96,7 +96,9 @@ case class ExportsCacheModel(
   previousDocuments: Option[PreviousDocumentsData] = None,
   natureOfTransaction: Option[NatureOfTransaction] = None,
   seals: Seq[Seal] = Seq.empty
-)
+) {
+  def itemBy(itemId: String): Option[ExportItem] = items.find(_.id.equalsIgnoreCase(itemId))
+}
 
 object ExportsCacheModel {
   implicit val formatInstant: OFormat[LocalDateTime] = new OFormat[LocalDateTime] {

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -32,7 +32,7 @@ class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsCacheModelRepo
 
   def getItemByIdAndSession(itemId: String, sessionId: String): Future[Option[ExportItem]] =
     get(sessionId).map {
-      case Some(model) => model.items.find(_.id.equalsIgnoreCase(itemId))
+      case Some(model) => model.itemBy(itemId)
       case _           => None
     }
 

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -30,7 +30,7 @@ class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsCacheModelRepo
   def update(sessionId: String, model: ExportsCacheModel): Future[Option[ExportsCacheModel]] =
     journeyCacheModelRepo.upsert(sessionId, model.copy(updatedDateTime = now()))
 
-  @deprecated
+  @deprecated("Please use `get` and `ExportCacheModel#itemBy` methods")
   def getItemByIdAndSession(itemId: String, sessionId: String): Future[Option[ExportItem]] =
     get(sessionId).map {
       case Some(model) => model.itemBy(itemId)

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -30,6 +30,7 @@ class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsCacheModelRepo
   def update(sessionId: String, model: ExportsCacheModel): Future[Option[ExportsCacheModel]] =
     journeyCacheModelRepo.upsert(sessionId, model.copy(updatedDateTime = now()))
 
+  @deprecated
   def getItemByIdAndSession(itemId: String, sessionId: String): Future[Option[ExportItem]] =
     get(sessionId).map {
       case Some(model) => model.itemBy(itemId)

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -214,9 +214,6 @@ trait CustomExportsBaseSpec
     when(mockExportsCacheService.getItemByIdAndSession(any[String], any[String]))
       .thenReturn(Future.successful(None))
 
-    when(mockExportsCacheService.get(any[String]))
-      .thenReturn(Future.successful(None))
-
     when(
       mockExportsCacheService
         .update(any[String], any[ExportsCacheModel])

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -19,10 +19,14 @@ package base
 import base.ExportsTestData._
 import controllers.actions.AuthActionImpl
 import models.SignedInUser
+import models.requests.AuthenticatedRequest
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
 import org.scalatest.mockito.MockitoSugar
+import play.api.mvc.{AnyContentAsEmpty, Request}
+import play.api.test.FakeRequest
+import services.cache.ExportsCacheModel
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
@@ -33,9 +37,12 @@ import scala.concurrent.Future
 trait MockAuthAction extends MockitoSugar with Stubs {
 
   lazy val mockAuthConnector: AuthConnector = mock[AuthConnector]
-  val mockAuthAction = new AuthActionImpl(mockAuthConnector, stubMessagesControllerComponents())
 
-  def authorizedUser(user: SignedInUser = newUser("12345", "external1")): Unit =
+  lazy val mockAuthAction = new AuthActionImpl(mockAuthConnector, stubMessagesControllerComponents())
+
+  lazy val exampleUser = newUser("12345", "external1")
+
+  def authorizedUser(user: SignedInUser = exampleUser): Unit =
     when(
       mockAuthConnector.authorise(
         any(),
@@ -253,5 +260,15 @@ trait MockAuthAction extends MockitoSugar with Stubs {
         )
       )
     )
+
+  def getAuthenticatedRequest(sessionId: String = "sessionId"): AuthenticatedRequest[AnyContentAsEmpty.type] = {
+    import utils.FakeRequestCSRFSupport._
+    AuthenticatedRequest(FakeRequest("GET", "").withSession(("sessionId", sessionId)).withCSRFToken, exampleUser)
+  }
+
+  def getRequest(): Request[AnyContentAsEmpty.type] = {
+    import utils.FakeRequestCSRFSupport._
+    FakeRequest("GET", "").withSession(("sessionId", "sessionId")).withCSRFToken
+  }
 
 }

--- a/test/base/TestHelper.scala
+++ b/test/base/TestHelper.scala
@@ -16,6 +16,8 @@
 
 package base
 
+import java.time.LocalDateTime
+
 import controllers.util.{Add, Remove, SaveAndContinue}
 import forms.Choice
 import forms.Choice.AllowedChoiceValues
@@ -23,6 +25,7 @@ import models.requests.{AuthenticatedRequest, JourneyRequest}
 import play.api.libs.json.{Json, Writes}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
+import services.cache.ExportsCacheModel
 import uk.gov.hmrc.http.cache.client.CacheMap
 
 import scala.util.Random
@@ -45,15 +48,21 @@ object TestHelper {
   val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
   def removeActionUrlEncoded(value: String) = (Remove.toString, value)
 
-  def journeyRequest(fakeRequest: FakeRequest[_], choice: String): JourneyRequest[_] =
+  def journeyRequest(fakeRequest: FakeRequest[_], choice: String): JourneyRequest[_] ={
+    val cache = ExportsCacheModel.apply("sessionId","draftId",LocalDateTime.now(), LocalDateTime.now(), choice)
     JourneyRequest(
       AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
-      Choice(choice)
+      cache
     )
+  }
 
-  def journeyRequest(fakeRequest: Request[_], choice: String): JourneyRequest[_] =
+
+  def journeyRequest(fakeRequest: Request[_], choice: String): JourneyRequest[_] = {
+    val cache = ExportsCacheModel.apply("sessionId","draftId",LocalDateTime.now(), LocalDateTime.now(), choice)
     JourneyRequest(
       AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
-      Choice(choice)
+      cache
     )
+  }
+
 }

--- a/test/controllers/declaration/DispatchLocationControllerSpec.scala
+++ b/test/controllers/declaration/DispatchLocationControllerSpec.scala
@@ -45,13 +45,13 @@ class DispatchLocationControllerSpec extends CustomExportsBaseSpec {
     reset(mockCustomsCacheService, mockExportsCacheService)
   }
 
-  "Declaration Type Controller on GET" should {
+  "Dispatch Location Controller on GET" should {
 
     "return 200 code" in {
 
       val result = route(app, getRequest(dispatchLocationUri)).get
       status(result) must be(OK)
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
 
     "populate the form fields with data from cache" in {
@@ -59,11 +59,11 @@ class DispatchLocationControllerSpec extends CustomExportsBaseSpec {
 
       val result = route(app, getRequest(dispatchLocationUri)).get
       contentAsString(result) must include("checked=\"checked\"")
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
   }
 
-  "Declaration Type Controller on POST" should {
+  "Dispatch Location Controller on POST" should {
 
     "save the data to the cache" in {
 
@@ -74,7 +74,7 @@ class DispatchLocationControllerSpec extends CustomExportsBaseSpec {
         .cache[DispatchLocation](any(), ArgumentMatchers.eq(DispatchLocation.formId), any())(any(), any(), any())
 
       verify(mockExportsCacheService).update(any(), any[ExportsCacheModel])
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
 
     "return 303 code" in {

--- a/test/controllers/declaration/DocumentsProducedControllerSpec.scala
+++ b/test/controllers/declaration/DocumentsProducedControllerSpec.scala
@@ -74,9 +74,11 @@ class DocumentsProducedControllerSpec
 
       val document = DocumentsProducedSpec.correctDocumentsProduced
       val cachedData = ExportItem(id = "id", documentsProducedData = Some(DocumentsProducedData(Seq(document))))
-      withNewCaching(aCacheModel(withItem(cachedData), withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))
+      val cacheModel = aCacheModel(withItem(cachedData), withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
 
-      val result = route(app, getRequest(uri)).get
+      withNewCaching(cacheModel)
+
+      val result = route(app, getRequest(uri, sessionId = cacheModel.sessionId)).get
       val view = contentAsString(result)
 
       status(result) must be(OK)

--- a/test/controllers/declaration/ItemTypeControllerSpec.scala
+++ b/test/controllers/declaration/ItemTypeControllerSpec.scala
@@ -62,9 +62,12 @@ class ItemTypeControllerSpec
     "read item from cache and display it" in {
 
       val cachedData = ItemType("5555", Seq("6666"), Seq("7777"), "FaultyGoods", Some("CusCus"), Some("12CD"), "900")
-      withNewCaching(aCacheModel(withItem(ExportItem("id", itemType = Some(cachedData))), withChoice("SMP")))
 
-      val result = route(app, getRequest(uri)).get
+      val model = aCacheModel(withItem(ExportItem("id", itemType = Some(cachedData))), withChoice("SMP"))
+
+      withNewCaching(model)
+
+      val result = route(app, getRequest(uri, sessionId = model.sessionId)).get
       val page = contentAsString(result)
 
       status(result) must be(OK)

--- a/test/controllers/declaration/PackageInformationControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationControllerSpec.scala
@@ -78,16 +78,17 @@ class PackageInformationControllerSpec
     "read data from cache" in {
 
       authorizedUser()
+      val model = aCacheModel(
+        withItem(
+          ExportItem("id", packageInformation = List(PackageInformation(Some("XX"), Some(101), Some("Secret Mark"))))
+        ),
+        withChoice(Choice.AllowedChoiceValues.SupplementaryDec)
+      )
       withNewCaching(
-        aCacheModel(
-          withItem(
-            ExportItem("id", packageInformation = List(PackageInformation(Some("XX"), Some(101), Some("Secret Mark"))))
-          ),
-          withChoice(Choice.AllowedChoiceValues.SupplementaryDec)
-        )
+        model
       )
 
-      val result = route(app, getRequest(uri)).get
+      val result = route(app, getRequest(uri, sessionId = model.sessionId)).get
       val page = contentAsString(result)
 
       page must include("XX")
@@ -98,22 +99,23 @@ class PackageInformationControllerSpec
     "read two items from cache and display it" in {
 
       authorizedUser()
-      withNewCaching(
-        aCacheModel(
-          withItem(
-            ExportItem(
-              "id",
-              packageInformation = List(
-                PackageInformation(Some("XX"), Some(101), Some("Secret Mark")),
-                PackageInformation(Some("YX"), Some(102), Some("Even More Secret Mark"))
-              )
+      val model = aCacheModel(
+        withItem(
+          ExportItem(
+            "id",
+            packageInformation = List(
+              PackageInformation(Some("XX"), Some(101), Some("Secret Mark")),
+              PackageInformation(Some("YX"), Some(102), Some("Even More Secret Mark"))
             )
-          ),
-          withChoice(Choice.AllowedChoiceValues.SupplementaryDec)
-        )
+          )
+        ),
+        withChoice(Choice.AllowedChoiceValues.SupplementaryDec)
+      )
+      withNewCaching(
+        model
       )
 
-      val result = route(app, getRequest(uri)).get
+      val result = route(app, getRequest(uri, sessionId = model.sessionId)).get
       val page = contentAsString(result)
 
       page must include("XX")

--- a/test/controllers/declaration/ProcedureCodesControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodesControllerSpec.scala
@@ -59,14 +59,14 @@ class ProcedureCodesControllerSpec
 
       status(result) must be(OK)
 
-      verify(mockExportsCacheService).getItemByIdAndSession(any[String], any[String])
+      verify(mockExportsCacheService).get(any[String])
     }
 
     "read item from cache and display it" in {
       val Some(result) = route(app, getRequest(uri))
 
       status(result) must be(OK)
-      verify(mockExportsCacheService).getItemByIdAndSession(any[String], any[String])
+      verify(mockExportsCacheService).get(any[String])
     }
   }
 

--- a/test/controllers/declaration/SummaryControllerSpec.scala
+++ b/test/controllers/declaration/SummaryControllerSpec.scala
@@ -65,7 +65,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
       "return 200 code" in {
         val result = route(app, getRequest(summaryPageUri)).get
         status(result) must be(OK)
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display 'Back' button that links to 'Export-items' page" in {
@@ -75,7 +75,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
 
         resultAsString must include(messages("site.back"))
         resultAsString must include("/declaration/transport-details")
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display 'Accept and submit declaration' button" in {
@@ -83,7 +83,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
 
         resultAsString must include(messages("site.acceptAndSubmitDeclaration"))
         resultAsString must include("button id=\"submit\" class=\"button\"")
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display content for Declaration Type module" in {
@@ -92,7 +92,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.declarationType.header"))
         resultAsString must include(messages("supplementary.summary.declarationType.dispatchLocation"))
         resultAsString must include(messages("supplementary.summary.declarationType.supplementaryDeclarationType"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display content for Your References module" in {
@@ -101,7 +101,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.yourReferences.header"))
         resultAsString must include(messages("supplementary.summary.yourReferences.ducr"))
         resultAsString must include(messages("supplementary.summary.yourReferences.lrn"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display content for Parties module" in {
@@ -121,7 +121,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.parties.additionalParties.type"))
         resultAsString must include(messages("supplementary.summary.parties.idStatusNumberAuthorisationCode"))
         resultAsString must include(messages("supplementary.summary.parties.authorizedPartyEori"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display content for Locations module" in {
@@ -138,7 +138,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.locations.warehouseId"))
         resultAsString must include(messages("supplementary.summary.locations.supervisingCustomsOffice"))
         resultAsString must include(messages("supplementary.summary.locations.officeOfExit"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display content for Item module" in {
@@ -148,7 +148,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.summary.items.amountInvoiced"))
         resultAsString must include(messages("supplementary.summary.items.exchangeRate"))
         resultAsString must include(messages("supplementary.summary.items.transactionType"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "display containers content with cache available" in {
@@ -157,13 +157,13 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
         resultAsString must include(messages("supplementary.transportInfo.containers.title"))
         resultAsString must include(messages("supplementary.transportInfo.containerId.title"))
         resultAsString must include(messages("M1l3s"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
 
       "get the whole supplementary declaration data from cache" in {
         route(app, getRequest(summaryPageUri)).get.futureValue
         verify(mockCustomsCacheService, never()).fetch(any())(any(), any())
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 
@@ -174,7 +174,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
 
         resultAsString must include(messages("supplementary.summary.noData.header"))
         resultAsString must include(messages("supplementary.summary.noData.header.secondary"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 
@@ -186,7 +186,7 @@ class SummaryControllerSpec extends CustomExportsBaseSpec {
 
         resultAsString must include(messages("supplementary.summary.noData.header"))
         resultAsString must include(messages("supplementary.summary.noData.header.secondary"))
-        verify(mockExportsCacheService, times(2)).get(anyString)
+        verify(mockExportsCacheService).get(anyString)
       }
     }
 

--- a/test/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -62,7 +62,7 @@ class TransportDetailsControllerSpec extends CustomExportsBaseSpec with Generato
 
       val result = route(app, getRequest(uri)).value
       status(result) must be(OK)
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
 
     "populate the form fields with data from cache" in {

--- a/test/controllers/declaration/TransportInformationContainersControllerSpec.scala
+++ b/test/controllers/declaration/TransportInformationContainersControllerSpec.scala
@@ -59,18 +59,19 @@ class TransportInformationContainersControllerSpec
 
       status(result) must be(OK)
       verifyTheCacheIsUnchanged()
-      verify(mockExportsCacheService, times(2)).get(anyString)
+      verify(mockExportsCacheService).get(anyString)
     }
 
     "read item from cache and display it" in {
+      val model = aCacheModel(
+        withChoice(SupplementaryDec),
+        withContainerData(TransportInformationContainer("DeliveredBestGoods"))
+      )
       withNewCaching(
-        aCacheModel(
-          withChoice(SupplementaryDec),
-          withContainerData(TransportInformationContainer("DeliveredBestGoods"))
-        )
+        model
       )
 
-      val result = route(app, getRequest(uri)).get
+      val result = route(app, getRequest(uri, sessionId = model.sessionId)).get
       val page = contentAsString(result)
 
       status(result) must be(OK)

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -49,7 +49,7 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
       val result = route(app, getRequest(uri)).get
 
       status(result) must be(OK)
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
 
     "read item from cache and display it" in {
@@ -68,7 +68,7 @@ class WarehouseIdentificationControllerSpec extends CustomExportsBaseSpec with W
       page must include(messages("supplementary.warehouse.identificationType.r"))
       page must include("SecretStash")
       page must include("Sea transport")
-      verify(mockExportsCacheService, times(2)).get(any())
+      verify(mockExportsCacheService).get(any())
     }
   }
 

--- a/test/unit/base/ControllerSpec.scala
+++ b/test/unit/base/ControllerSpec.scala
@@ -22,6 +22,7 @@ import controllers.actions.JourneyAction
 import controllers.util.{Add, SaveAndContinue}
 import handlers.ErrorHandler
 import metrics.ExportsMetrics
+import models.requests.JourneyRequest
 import org.mockito.ArgumentMatchers.{any, anyString}
 import org.mockito.Mockito.when
 import play.api.inject.DefaultApplicationLifecycle
@@ -30,6 +31,7 @@ import play.api.mvc.Results.BadRequest
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAsJson, Request}
 import play.api.test.FakeRequest
 import play.twirl.api.Html
+import services.cache.ExportsCacheModel
 import unit.tools.Stubs
 import utils.FakeRequestCSRFSupport._
 
@@ -54,8 +56,8 @@ trait ControllerSpec
   val addActionUrlEncoded = (Add.toString, "")
   val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
 
-  def getRequest(): Request[AnyContentAsEmpty.type] =
-    FakeRequest("GET", "").withSession(("sessionId", "sessionId")).withCSRFToken
+  def getRequest(cacheModel: ExportsCacheModel): JourneyRequest[AnyContentAsEmpty.type] =
+    JourneyRequest(getAuthenticatedRequest(sessionId = cacheModel.sessionId), cacheModel)
 
   def postRequest(body: JsValue): Request[AnyContentAsJson] =
     FakeRequest("POST", "").withSession(("sessionId", "sessionId")).withJsonBody(body).withCSRFToken

--- a/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -21,6 +21,7 @@ import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.{ConsigneeDetails, EntityDetails}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 import unit.base.ControllerSpec
 import views.html.declaration.consignee_details
 
@@ -38,8 +39,9 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
       consigneeDetailsPage
     )(ec, minimalAppConfig)
 
+    val model: ExportsCacheModel = aCacheModel(withChoice(SupplementaryDec))
     authorizedUser()
-    withNewCaching(aCacheModel(withChoice(SupplementaryDec)))
+    withNewCaching(model)
     withCaching(None)
   }
 
@@ -48,16 +50,18 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
     "return 200 (OK)" when {
 
       "display page method is invoked and cache is empty" in new SetUp {
-        val result = controller.displayPage()(getRequest())
+        val result = controller.displayPage()(getRequest(model))
 
         status(result) must be(OK)
       }
 
       "display page method is invoked and cache contrains data" in new SetUp {
 
-        withNewCaching(aCacheModel(withConsigneeDetails(Some("123"), None)))
+        val modelWithDetails = aCacheModel(withConsigneeDetails(Some("123"), None))
 
-        val result = controller.displayPage()(getRequest())
+        withNewCaching(modelWithDetails)
+
+        val result = controller.displayPage()(getRequest(modelWithDetails))
 
         status(result) must be(OK)
       }

--- a/test/views/declaration/spec/ViewSpec.scala
+++ b/test/views/declaration/spec/ViewSpec.scala
@@ -16,6 +16,8 @@
 
 package views.declaration.spec
 
+import java.time.LocalDateTime
+
 import base.{ExportsTestData, ViewValidator}
 import com.codahale.metrics.SharedMetricRegistries
 import config.AppConfig
@@ -31,8 +33,8 @@ import play.api.mvc.{AnyContentAsEmpty, Flash, Request, Result}
 import play.api.test.FakeRequest
 import play.twirl.api.Html
 import utils.FakeRequestCSRFSupport._
-
 import play.api.test.Helpers._
+import services.cache.ExportsCacheModel
 
 import scala.concurrent.Future
 
@@ -55,8 +57,10 @@ trait ViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with
 
   def assertMessage(key: String, expected: String): Unit = messages(key) must be(expected)
 
-  def fakeJourneyRequest(choice: String): JourneyRequest[AnyContentAsEmpty.type] =
-    JourneyRequest(AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), new Choice(choice))
+  def fakeJourneyRequest(choice: String): JourneyRequest[AnyContentAsEmpty.type] = {
+    val cache = ExportsCacheModel.apply("sessionId","draftId",LocalDateTime.now(), LocalDateTime.now(), choice)
+    JourneyRequest(AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), cache)
+  }
 
   SharedMetricRegistries.clear()
 }


### PR DESCRIPTION
Add `ExportCacheModel` allow us to reduce number of database lookups. We are quering for same data multiple times:
1. In JourneyAction
2. In constroller it self

This change has intention to attached to request `ExportCacheModel` which was fetched in JourneyAction.

Also it fix stubbing for specific `sessionId` in cache mocks. It is still work in progress - i'm working on fixing tests.
