### PR TITLE
CEDS 1433 remove and refresh

### DIFF
--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -112,9 +112,9 @@ class AdditionalFiscalReferencesController @Inject()(
     form: Form[AdditionalFiscalReference],
     cachedData: AdditionalFiscalReferencesData
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = MultipleItemsHelper.remove(values.headOption, cachedData.references)
+    val updatedCache = cachedData.references.filterNot(ref => s"${ref.country}${ref.reference}" == values.head)
     updateExportsCache(itemId, journeySessionId, AdditionalFiscalReferencesData(updatedCache))
-      .map(_ => Ok(additionalFiscalReferencesPage(itemId, form.discardingErrors)))
+      .map(_ => Ok(additionalFiscalReferencesPage(itemId, form.discardingErrors, updatedCache)))
   }
 
   private def badRequest(

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.util.MultipleItemsHelper.remove
 import controllers.util.{MultipleItemsHelper, _}
 import forms.declaration.AdditionalFiscalReference.form
 import forms.declaration.AdditionalFiscalReferencesData._
@@ -112,7 +113,7 @@ class AdditionalFiscalReferencesController @Inject()(
     form: Form[AdditionalFiscalReference],
     cachedData: AdditionalFiscalReferencesData
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = cachedData.references.filterNot(ref => s"${ref.country}${ref.reference}" == values.head)
+    val updatedCache = remove(cachedData.references, (ref: AdditionalFiscalReference) => s"${ref.country}${ref.reference}" == values.head)
     updateExportsCache(itemId, journeySessionId, AdditionalFiscalReferencesData(updatedCache))
       .map(_ => Ok(additionalFiscalReferencesPage(itemId, form.discardingErrors, updatedCache)))
   }

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.util.MultipleItemsHelper.remove
 import controllers.util._
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
@@ -108,7 +109,7 @@ class AdditionalInformationController @Inject()(
     boundForm: Form[AdditionalInformation],
     items: Seq[AdditionalInformation]
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = items.filterNot(addItem => addItem.toString == ids.head)
+    val updatedCache = remove(items, (addItem: AdditionalInformation) => addItem.toString == ids.head)
     updateCache(itemId, journeySessionId, AdditionalInformationData(updatedCache))
       .map(_ => Ok(additionalInformationPage(itemId, boundForm.discardingErrors, updatedCache)))
   }

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -108,7 +108,7 @@ class AdditionalInformationController @Inject()(
     boundForm: Form[AdditionalInformation],
     items: Seq[AdditionalInformation]
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = MultipleItemsHelper.remove(ids.headOption, items)
+    val updatedCache = items.filterNot(addItem => addItem.toString == ids.head)
     updateCache(itemId, journeySessionId, AdditionalInformationData(updatedCache))
       .map(_ => Ok(additionalInformationPage(itemId, boundForm.discardingErrors, updatedCache)))
   }

--- a/app/controllers/declaration/DeclarationAdditionalActorsController.scala
+++ b/app/controllers/declaration/DeclarationAdditionalActorsController.scala
@@ -158,14 +158,9 @@ class DeclarationAdditionalActorsController @Inject()(
     actorToRemove: Option[DeclarationAdditionalActors],
     formData: Form[DeclarationAdditionalActors],
     cachedData: DeclarationAdditionalActorsData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
-    actorToRemove match {
-      case Some(actorToRemove) =>
-        if (cachedData.containsItem(actorToRemove)) {
-          val updatedCache = cachedData.copy(actors = cachedData.actors.filterNot(_ == actorToRemove))
-          updateCache(journeySessionId, updatedCache)
-            .map(_ => Ok(declarationAdditionalActorsPage(formData.discardingErrors, updatedCache.actors)))
-        } else errorHandler.displayErrorPage()
-      case _ => errorHandler.displayErrorPage()
-    }
+  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
+    val updatedCache = cachedData.copy(actors = cachedData.actors.filterNot(actorToRemove.contains(_)))
+    updateCache(journeySessionId, updatedCache)
+      .map(_ => Ok(declarationAdditionalActorsPage(formData.discardingErrors, updatedCache.actors)))
+  }
 }

--- a/app/controllers/declaration/DeclarationAdditionalActorsController.scala
+++ b/app/controllers/declaration/DeclarationAdditionalActorsController.scala
@@ -17,7 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.remove
+import controllers.util._
 import forms.declaration.DeclarationAdditionalActors
 import forms.declaration.DeclarationAdditionalActors.form
 import handlers.ErrorHandler
@@ -159,7 +160,7 @@ class DeclarationAdditionalActorsController @Inject()(
     formData: Form[DeclarationAdditionalActors],
     cachedData: DeclarationAdditionalActorsData
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
-    val updatedCache = cachedData.copy(actors = cachedData.actors.filterNot(actorToRemove.contains(_)))
+    val updatedCache = cachedData.copy(actors = remove(cachedData.actors, actorToRemove.contains(_: DeclarationAdditionalActors)))
     updateCache(journeySessionId, updatedCache)
       .map(_ => Ok(declarationAdditionalActorsPage(formData.discardingErrors, updatedCache.actors)))
   }

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -17,7 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.remove
+import controllers.util._
 import forms.declaration.DeclarationHolder
 import handlers.ErrorHandler
 import javax.inject.Inject
@@ -177,7 +178,7 @@ class DeclarationHolderController @Inject()(
     userInput: Form[DeclarationHolder],
     cachedData: DeclarationHoldersData
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
-    val updatedCache = cachedData.copy(holders = cachedData.holders.filterNot(_ == holderToRemove))
+    val updatedCache = cachedData.copy(holders = remove(cachedData.holders, (_: DeclarationHolder) == holderToRemove))
     updateCache(journeySessionId, updatedCache)
       .map(_ => Ok(declarationHolderPage(userInput.discardingErrors, updatedCache.holders)))
   }

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -174,24 +174,14 @@ class DestinationCountriesController @Inject()(
     userInput: Form[DestinationCountries],
     cachedData: DestinationCountries
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val key =
-      parseRemoval(keys).getOrElse(throw new IllegalArgumentException("Data format for removal request is incorrect"))
-    val updatedCountries = removeElement(cachedData.countriesOfRouting, key)
+
+    val updatedCountries = cachedData.countriesOfRouting.filterNot(keys.contains(_))
 
     val updatedCache = cachedData.copy(countriesOfRouting = updatedCountries)
 
     updateCache(journeySessionId, updatedCache)
       .map(_ => Ok(destinationCountriesStandardPage(userInput.discardingErrors, updatedCache.countriesOfRouting)))
   }
-
-  private def parseRemoval(keys: Seq[String]): Try[Int] =
-    Try(keys)
-      .filter(_.size == 1)
-      .map(_.head.split("_"))
-      .filter(_.length == 2)
-      .map(_(1).toInt)
-
-  private def removeElement[A](collection: Seq[A], indexToRemove: Int): Seq[A] = collection.removeByIdx(indexToRemove)
 
   private def refreshPage(
     inputDestinationCountries: DestinationCountries

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -17,7 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.remove
+import controllers.util._
 import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.destinationCountries.DestinationCountries.{Standard, Supplementary}
 import forms.declaration.destinationCountries._
@@ -31,13 +32,11 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import utils.collections.Removable.RemovableSeq
 import utils.validators.forms.supplementary.DestinationCountriesValidator
 import utils.validators.forms.{Invalid, Valid}
 import views.html.declaration.{destination_countries_standard, destination_countries_supplementary}
 
 import scala.concurrent.{ExecutionContext, Future}
-import scala.util.Try
 
 class DestinationCountriesController @Inject()(
   authenticate: AuthAction,
@@ -175,8 +174,7 @@ class DestinationCountriesController @Inject()(
     cachedData: DestinationCountries
   )(implicit request: JourneyRequest[_]): Future[Result] = {
 
-    val updatedCountries = cachedData.countriesOfRouting.filterNot(keys.contains(_))
-
+    val updatedCountries = remove(cachedData.countriesOfRouting, keys.contains(_: String))
     val updatedCache = cachedData.copy(countriesOfRouting = updatedCountries)
 
     updateCache(journeySessionId, updatedCache)

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -17,7 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.remove
+import controllers.util._
 import forms.declaration.additionaldocuments.DocumentsProduced
 import forms.declaration.additionaldocuments.DocumentsProduced.form
 import handlers.ErrorHandler
@@ -149,7 +150,7 @@ class DocumentsProducedController @Inject()(
     cachedData: DocumentsProducedData
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
     val itemToRemove = DocumentsProduced.fromJsonString(values.head)
-    val updatedCache = cachedData.copy(documents = cachedData.documents.filterNot(itemToRemove.contains(_)))
+    val updatedCache = cachedData.copy(documents = remove(cachedData.documents, itemToRemove.contains(_: DocumentsProduced)))
     updateCache(itemId, journeySessionId, updatedCache).map(
       _ => Ok(documentProducedPage(itemId, boundForm.discardingErrors, updatedCache.documents))
     )

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -144,16 +144,16 @@ class DocumentsProducedController @Inject()(
 
   private def removeItem(
     itemId: String,
-    keys: Seq[String],
+    values: Seq[String],
     boundForm: Form[DocumentsProduced],
     cachedData: DocumentsProducedData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
-    keys.headOption.fold(errorHandler.displayErrorPage()) { index =>
-      val updatedCache = cachedData.copy(documents = cachedData.documents.patch(index.toInt, Nil, 1))
-      updateCache(itemId, journeySessionId, updatedCache).map(
-        _ => Ok(documentProducedPage(itemId, boundForm.discardingErrors, updatedCache.documents))
-      )
-    }
+  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
+    val itemToRemove = DocumentsProduced.fromJsonString(values.head)
+    val updatedCache = cachedData.copy(documents = cachedData.documents.filterNot(itemToRemove.contains(_)))
+    updateCache(itemId, journeySessionId, updatedCache).map(
+      _ => Ok(documentProducedPage(itemId, boundForm.discardingErrors, updatedCache.documents))
+    )
+  }
 
   private def handleErrorPage(
     itemId: String,

--- a/app/controllers/declaration/ItemTypeController.scala
+++ b/app/controllers/declaration/ItemTypeController.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util._
 import forms.declaration.ItemType
 import forms.declaration.ItemType._
 import handlers.ErrorHandler
@@ -207,7 +207,7 @@ class ItemTypeController @Inject()(
   }
 
   private def removeElement(collection: Seq[String], valueToRemove: String): Seq[String] =
-    collection.filterNot(_ == valueToRemove)
+    MultipleItemsHelper.remove(collection, (_: String) == valueToRemove)
 
   private def refreshPage(itemId: String, itemTypeInput: ItemType, model: ExportsDeclaration)(
     implicit request: JourneyRequest[AnyContent]

--- a/app/controllers/declaration/PackageInformationController.scala
+++ b/app/controllers/declaration/PackageInformationController.scala
@@ -59,7 +59,7 @@ class PackageInformationController @Inject()(
 
           actionTypeOpt match {
             case Some(Add)             => addItem(itemId, boundForm, packagings)
-            case Some(Remove(ids))     => removeItem(itemId, ids, boundForm, packagings)
+            case Some(Remove(values))     => removeItem(itemId, values, boundForm, packagings)
             case Some(SaveAndContinue) => saveAndContinue(itemId, boundForm, packagings)
             case _                     => errorHandler.displayErrorPage()
           }
@@ -68,11 +68,12 @@ class PackageInformationController @Inject()(
 
   private def removeItem(
     itemId: String,
-    ids: Seq[String],
+    values: Seq[String],
     boundForm: Form[PackageInformation],
     items: Seq[PackageInformation]
   )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = MultipleItemsHelper.remove(ids.headOption, items)
+    val itemToRemove = PackageInformation.fromJsonString(values.head)
+    val updatedCache = items.filterNot(itemToRemove.contains(_))
     updateExportsCache(itemId, journeySessionId, updatedCache)
       .map(_ => Ok(packageInformationPage(itemId, boundForm.discardingErrors, updatedCache)))
   }

--- a/app/controllers/declaration/PackageInformationController.scala
+++ b/app/controllers/declaration/PackageInformationController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.util.MultipleItemsHelper.remove
 import controllers.util._
 import forms.declaration.PackageInformation
 import forms.declaration.PackageInformation._
@@ -59,7 +60,7 @@ class PackageInformationController @Inject()(
 
           actionTypeOpt match {
             case Some(Add)             => addItem(itemId, boundForm, packagings)
-            case Some(Remove(values))     => removeItem(itemId, values, boundForm, packagings)
+            case Some(Remove(values))  => removeItem(itemId, values, boundForm, packagings)
             case Some(SaveAndContinue) => saveAndContinue(itemId, boundForm, packagings)
             case _                     => errorHandler.displayErrorPage()
           }
@@ -73,7 +74,7 @@ class PackageInformationController @Inject()(
     items: Seq[PackageInformation]
   )(implicit request: JourneyRequest[_]): Future[Result] = {
     val itemToRemove = PackageInformation.fromJsonString(values.head)
-    val updatedCache = items.filterNot(itemToRemove.contains(_))
+    val updatedCache = remove(items, itemToRemove.contains(_: PackageInformation))
     updateExportsCache(itemId, journeySessionId, updatedCache)
       .map(_ => Ok(packageInformationPage(itemId, boundForm.discardingErrors, updatedCache)))
   }

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -83,7 +83,7 @@ class PreviousDocumentsController @Inject()(
 
         case Some(Remove(ids)) =>
           val itemToRemove = Document.fromJsonString(ids.head)
-          val updatedDocuments = cache.documents.filterNot(itemToRemove.contains(_))
+          val updatedDocuments = MultipleItemsHelper.remove(cache.documents, itemToRemove.contains(_: Document))
           updateCache(PreviousDocumentsData(updatedDocuments))
             .map(_ => Ok(previousDocumentsPage(boundForm.discardingErrors, updatedDocuments)))
 

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -19,8 +19,8 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.util._
 import forms.declaration.Document._
-import forms.declaration.PreviousDocumentsData
 import forms.declaration.PreviousDocumentsData._
+import forms.declaration.{Document, PreviousDocumentsData}
 import handlers.ErrorHandler
 import javax.inject.Inject
 import models.requests.JourneyRequest
@@ -81,11 +81,11 @@ class PreviousDocumentsController @Inject()(
                 .map(_ => Redirect(controllers.declaration.routes.PreviousDocumentsController.displayForm()))
           )
 
-        case Some(Remove(ids)) => {
-          val updatedDocuments = remove(ids.headOption, cache.documents)
+        case Some(Remove(ids)) =>
+          val itemToRemove = Document.fromJsonString(ids.head)
+          val updatedDocuments = cache.documents.filterNot(itemToRemove.contains(_))
           updateCache(PreviousDocumentsData(updatedDocuments))
             .map(_ => Ok(previousDocumentsPage(boundForm.discardingErrors, updatedDocuments)))
-        }
 
         case _ => Future.successful(BadRequest(previousDocumentsPage(boundForm, cache.documents)))
       }

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -141,13 +141,12 @@ class ProcedureCodesController @Inject()(
     code: String,
     userInput: Form[ProcedureCodes],
     cachedData: ProcedureCodesData
-  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] =
-    if (cachedData.containsAdditionalCode(code)) {
-      val updatedCache =
-        cachedData.copy(additionalProcedureCodes = cachedData.additionalProcedureCodes.filterNot(_ == code))
-      updateCache(itemId, journeySessionId, updatedCache)
-        .map(_ => Ok(procedureCodesPage(itemId, userInput.discardingErrors, updatedCache.additionalProcedureCodes)))
-    } else errorHandler.displayErrorPage()
+  )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
+    val updatedCache =
+      cachedData.copy(additionalProcedureCodes = cachedData.additionalProcedureCodes.filterNot(_ == code))
+    updateCache(itemId, journeySessionId, updatedCache)
+      .map(_ => Ok(procedureCodesPage(itemId, userInput.discardingErrors, updatedCache.additionalProcedureCodes)))
+  }
 
   //scalastyle:off method.length
   private def saveAndContinueHandler(itemId: String, userInput: ProcedureCodes, cachedData: ProcedureCodesData)(

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.util.MultipleItemsHelper.remove
 import controllers.util._
 import forms.declaration.ProcedureCodes
 import forms.declaration.ProcedureCodes.form
@@ -143,7 +144,7 @@ class ProcedureCodesController @Inject()(
     cachedData: ProcedureCodesData
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier): Future[Result] = {
     val updatedCache =
-      cachedData.copy(additionalProcedureCodes = cachedData.additionalProcedureCodes.filterNot(_ == code))
+      cachedData.copy(additionalProcedureCodes = remove(cachedData.additionalProcedureCodes, (_: String) == code))
     updateCache(itemId, journeySessionId, updatedCache)
       .map(_ => Ok(procedureCodesPage(itemId, userInput.discardingErrors, updatedCache.additionalProcedureCodes)))
   }

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -17,8 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.MultipleItemsHelper.{add, saveAndContinue}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.{add, remove, saveAndContinue}
+import controllers.util._
 import forms.declaration.Seal
 import forms.declaration.Seal._
 import handlers.ErrorHandler
@@ -92,7 +92,7 @@ class SealController @Inject()(
   private def removeSeal(userInput: Form[Seal], cachedSeals: Seq[Seal], hasContainers: Boolean, ids: Seq[String])(
     implicit request: JourneyRequest[_]
   ): Future[Result] = {
-    val updatedSeals = cachedSeals.filterNot(_.id == ids.head)
+    val updatedSeals = remove(cachedSeals, {seal: Seal => ids.contains(seal.id)})
     updateCache(journeySessionId, updatedSeals).map { _ =>
       Ok(sealPage(userInput.discardingErrors, updatedSeals, hasContainers))
     }

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.MultipleItemsHelper.{add, remove, saveAndContinue}
+import controllers.util.MultipleItemsHelper.{add, saveAndContinue}
 import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
 import forms.declaration.Seal
 import forms.declaration.Seal._
@@ -92,7 +92,7 @@ class SealController @Inject()(
   private def removeSeal(userInput: Form[Seal], cachedSeals: Seq[Seal], hasContainers: Boolean, ids: Seq[String])(
     implicit request: JourneyRequest[_]
   ): Future[Result] = {
-    val updatedSeals = remove(ids.headOption, cachedSeals)
+    val updatedSeals = cachedSeals.filterNot(_.id == ids.head)
     updateCache(journeySessionId, updatedSeals).map { _ =>
       Ok(sealPage(userInput.discardingErrors, updatedSeals, hasContainers))
     }

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -17,8 +17,8 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.MultipleItemsHelper.{add, saveAndContinue}
-import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
+import controllers.util.MultipleItemsHelper.{add, remove, saveAndContinue}
+import controllers.util._
 import forms.Choice.AllowedChoiceValues
 import forms.declaration.TransportInformationContainer
 import forms.declaration.TransportInformationContainer.form
@@ -96,7 +96,7 @@ class TransportContainerController @Inject()(
     cache: TransportInformationContainerData,
     ids: Seq[String]
   )(implicit request: JourneyRequest[_]) = {
-    val updatedCache = cache.containers.filterNot(_.id == ids.head)
+    val updatedCache = remove(cache.containers, {container: TransportInformationContainer => ids.contains(container.id)})
     updateCache(journeySessionId, TransportInformationContainerData(updatedCache)).map { _ =>
       Ok(transportContainersPage(userInput.discardingErrors, updatedCache))
     }

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.util.MultipleItemsHelper.{add, remove, saveAndContinue}
+import controllers.util.MultipleItemsHelper.{add, saveAndContinue}
 import controllers.util.{Add, FormAction, Remove, SaveAndContinue}
 import forms.Choice.AllowedChoiceValues
 import forms.declaration.TransportInformationContainer
@@ -96,7 +96,7 @@ class TransportContainerController @Inject()(
     cache: TransportInformationContainerData,
     ids: Seq[String]
   )(implicit request: JourneyRequest[_]) = {
-    val updatedCache = remove(ids.headOption, cache.containers)
+    val updatedCache = cache.containers.filterNot(_.id == ids.head)
     updateCache(journeySessionId, TransportInformationContainerData(updatedCache)).map { _ =>
       Ok(transportContainersPage(userInput.discardingErrors, updatedCache))
     }

--- a/app/controllers/util/MultipleItemsHelper.scala
+++ b/app/controllers/util/MultipleItemsHelper.scala
@@ -67,7 +67,7 @@ object MultipleItemsHelper {
     */
   def remove[A](idOpt: Option[String], cachedData: Seq[A]): Seq[A] = idOpt match {
     case Some(id) if validateId(id) && cachedData.length - 1 >= id.toInt => removeItem(id, cachedData)
-    case _                                                               => throw new InternalServerException("Incorrect id")
+    case _                                                               => cachedData // nothing to do
   }
 
   private def validateId(id: String): Boolean = id.nonEmpty && id.forall(_.isDigit)

--- a/app/controllers/util/MultipleItemsHelper.scala
+++ b/app/controllers/util/MultipleItemsHelper.scala
@@ -56,24 +56,9 @@ object MultipleItemsHelper {
 
   private def addElement[A](document: A, cachedData: Seq[A]): Seq[A] = cachedData :+ document
 
-  /**
-    * Method to handle removing item. This method will throw an exception when user try to remove
-    * non-existing item
-    *
-    * @param idOpt - optional item id based on the request
-    * @param cachedData - cached data which contains sequence of added items
-    * @tparam A - type of case class represents form
-    * @return Updated sequence ready to update to db
-    */
-  def remove[A](idOpt: Option[String], cachedData: Seq[A]): Seq[A] = idOpt match {
-    case Some(id) if validateId(id) && cachedData.length - 1 >= id.toInt => removeItem(id, cachedData)
-    case _                                                               => cachedData // nothing to do
+  def remove[A](cachedData: Seq[A], filterNot: A => Boolean): Seq[A] = {
+    cachedData.filterNot(filterNot)
   }
-
-  private def validateId(id: String): Boolean = id.nonEmpty && id.forall(_.isDigit)
-
-  private def removeItem[A](id: String, cachedData: Seq[A]): Seq[A] =
-    cachedData.zipWithIndex.filter(_._2 != id.toInt).map(_._1)
 
   /**
     * Method to handle continue with items.

--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -18,7 +18,7 @@ package forms.declaration
 
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import services.DocumentType
 import utils.validators.forms.FieldValidator._
 
@@ -27,9 +27,13 @@ case class Document(
   documentType: String,
   documentReference: String,
   goodsItemIdentifier: Option[String]
-)
+) {
+  def toJson: JsValue = Json.toJson(this)(Document.format)
+}
 
 object Document {
+  def fromJsonString(value: String): Option[Document] = Json.fromJson(Json.parse(value)).asOpt
+
   implicit val format = Json.format[Document]
 
   val formId = "PreviousDocuments"

--- a/app/forms/declaration/PackageInformation.scala
+++ b/app/forms/declaration/PackageInformation.scala
@@ -18,7 +18,7 @@ package forms.declaration
 
 import play.api.data.Forms.{number, optional, text}
 import play.api.data.{Form, Forms}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import services.PackageTypes
 import utils.validators.forms.FieldValidator._
 
@@ -26,9 +26,13 @@ case class PackageInformation(
   typesOfPackages: String,
   numberOfPackages: Int,
   shippingMarks: String
-)
+) {
+  def toJson: JsValue = Json.toJson(this)(PackageInformation.format)
+}
 
 object PackageInformation {
+
+  def fromJsonString(value: String): Option[PackageInformation] = Json.fromJson(Json.parse(value)).asOpt
 
   def require1Field[T](fs: (T => Option[_])*): T => Boolean =
     t => fs.exists(f => f(t).nonEmpty)

--- a/app/forms/declaration/additionaldocuments/DocumentsProduced.scala
+++ b/app/forms/declaration/additionaldocuments/DocumentsProduced.scala
@@ -19,7 +19,7 @@ package forms.declaration.additionaldocuments
 import forms.common.Date
 import play.api.data.Forms._
 import play.api.data.{Form, Forms}
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 import utils.validators.forms.FieldValidator._
 
 case class DocumentsProduced(
@@ -31,6 +31,8 @@ case class DocumentsProduced(
   dateOfValidity: Option[Date],
   documentWriteOff: Option[DocumentWriteOff]
 ) {
+  def toJson: JsValue = Json.toJson(this)(DocumentsProduced.format)
+
   implicit val writes = Json.writes[DocumentsProduced]
 
   def isDefined: Boolean =
@@ -46,6 +48,8 @@ case class DocumentsProduced(
 }
 
 object DocumentsProduced {
+
+  def fromJsonString(value: String): Option[DocumentsProduced] = Json.fromJson(Json.parse(value)).asOpt
 
   implicit val format = Json.format[DocumentsProduced]
 

--- a/app/views/components/fields/field_multiple_values.scala.html
+++ b/app/views/components/fields/field_multiple_values.scala.html
@@ -26,7 +26,8 @@
     elements: Seq[String] = Seq.empty,
     labelClass: Option[String] = None,
     input: Html,
-    includeAddButton: Boolean = true
+    includeAddButton: Boolean = true,
+    valuePrefix: Option[String] = None
 )(implicit messages: Messages)
 
 <div class="form-field @if(field.hasErrors){form-field--error}">
@@ -42,19 +43,12 @@
     </label>
 
     @if(elements.nonEmpty) {
-      @if(field.name.endsWith("[]")) {
-        @removable_elements_table(
-            id = field.id + "-table",
-            elements = elements.zipWithIndex.map {
-                case (element, index) => LabelledValue(element, field.id + index)
-            }
-        )
-      } else {
+
         @removable_elements_table(
               id = field.id + "-table",
-              elements = elements.map(LabelledValue(_))
+              elements = elements.map(elm => LabelledValue(elm, valuePrefix.getOrElse("") + elm))
           )
-      }
+
     }
 
     <div class="form-control-wrapper">

--- a/app/views/components/fields/field_text_multiple_values.scala.html
+++ b/app/views/components/fields/field_text_multiple_values.scala.html
@@ -24,7 +24,8 @@
     elements: Seq[String] = Seq.empty,
     inputClass: Option[String] = None,
     labelClass: Option[String] = None,
-    includeAddButton: Boolean = true
+    includeAddButton: Boolean = true,
+    valuePrefix: Option[String] = None
 )(implicit messages: Messages)
 
 @field_multiple_values(
@@ -34,5 +35,6 @@
     elements = elements,
     labelClass = labelClass,
     input = input_text(field, inputClass),
-    includeAddButton = includeAddButton
+    includeAddButton = includeAddButton,
+    valuePrefix = valuePrefix
 )

--- a/app/views/declaration/add_transport_containers.scala.html
+++ b/app/views/declaration/add_transport_containers.scala.html
@@ -40,9 +40,7 @@
         @if(containers.nonEmpty) {
             @components.fields.removable_elements_table(
                 title = Some(messages("supplementary.transportInfo.containerId.title")),
-                elements = containers.zipWithIndex.map {
-                    case (container, index) => LabelledValue(container.id, index.toString)
-                }
+                elements = containers.map(container => LabelledValue(container.id))
             )
         }
 

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -45,9 +45,7 @@
         <h3>@messages("declaration.additionalFiscalReferences.numbers.header")</h3>
 
         @components.fields.removable_elements_table(
-            elements = additionalReferences.map(elem => elem.country + elem.reference).zipWithIndex.map {
-                case (label, index) => LabelledValue(label, index.toString)
-            }
+            elements = additionalReferences.map(elem => elem.country + elem.reference).map(ref => LabelledValue(ref))
         )
 
         <div id="country-of-dispatch-field" class="inline-block form-group">

--- a/app/views/declaration/additional_information.scala.html
+++ b/app/views/declaration/additional_information.scala.html
@@ -43,9 +43,7 @@
 
         @if(items.nonEmpty){
           @components.fields.removable_elements_table(
-              elements = items.zipWithIndex.map {
-                  case (item, index) => LabelledValue(item.toString, index.toString)
-              }
+              elements = items.map(item => LabelledValue(item.toString))
             )
         }
 

--- a/app/views/declaration/destination_countries_standard.scala.html
+++ b/app/views/declaration/destination_countries_standard.scala.html
@@ -50,7 +50,7 @@
         <h2>Countries of routing</h2>
         <div id="country-of-routing-field" class="inline-block form-group">
             @components.fields.field_multiple_values(
-                field = form("countriesOfRouting[]"),
+                field = form("countriesOfRouting"),
                 label = messages("declaration.itemType.nationalAdditionalCode.header"),
                 hint = None,
                 elements = routingCountries,

--- a/app/views/declaration/documents_produced.scala.html
+++ b/app/views/declaration/documents_produced.scala.html
@@ -69,7 +69,7 @@
                         <td>@item.dateOfValidity</td>
                         <td>@item.documentWriteOff.map(_.measurementUnit)</td>
                         <td>@item.documentWriteOff.map(_.documentQuantity)</td>
-                        <td>@components.buttons.remove_button(value = Some(index))</td>
+                        <td>@components.buttons.remove_button(value = Some(item.toJson))</td>
                     </tr>
                 }
                 </tbody>

--- a/app/views/declaration/item_type.scala.html
+++ b/app/views/declaration/item_type.scala.html
@@ -61,15 +61,16 @@
         )
 
         @components.fields.field_text_multiple_values(
-            field = form(taricAdditionalCodesKey + "[]"),
+            field = form(taricAdditionalCodesKey),
             label = messages("declaration.itemType.taricAdditionalCodes.header"),
             hint = Some(messages("declaration.itemType.taricAdditionalCodes.header.hint")),
             elements = taricAdditionalCodes,
-            labelClass = Some("bold-small")
+            labelClass = Some("bold-small"),
+            valuePrefix = Some(taricAdditionalCodesKey+"_")
         )
 
         @components.fields.field_multiple_values(
-            field = form(nationalAdditionalCodesKey + "[]"),
+            field = form(nationalAdditionalCodesKey),
             label = messages("declaration.itemType.nationalAdditionalCode.header"),
             hint = Some(messages("declaration.itemType.nationalAdditionalCode.header.hint")),
             elements = nationalAdditionalCodes,
@@ -78,7 +79,8 @@
                 field = form(nationalAdditionalCodesKey + "[]"),
                 emptySelectValue = messages("declaration.itemType.nationalAdditionalCode.error.empty"),
                 items = AutoCompleteItem.fromNationalAdditionalCode(NationalAdditionalCode.all)
-            )
+            ),
+            valuePrefix = Some(nationalAdditionalCodesKey+"_")
         )
 
         @components.fields.field_text(

--- a/app/views/declaration/item_type.scala.html
+++ b/app/views/declaration/item_type.scala.html
@@ -61,7 +61,7 @@
         )
 
         @components.fields.field_text_multiple_values(
-            field = form(taricAdditionalCodesKey),
+            field = form(taricAdditionalCodesKey + "[]"),
             label = messages("declaration.itemType.taricAdditionalCodes.header"),
             hint = Some(messages("declaration.itemType.taricAdditionalCodes.header.hint")),
             elements = taricAdditionalCodes,
@@ -70,7 +70,7 @@
         )
 
         @components.fields.field_multiple_values(
-            field = form(nationalAdditionalCodesKey),
+            field = form(nationalAdditionalCodesKey + "[]"),
             label = messages("declaration.itemType.nationalAdditionalCode.header"),
             hint = Some(messages("declaration.itemType.nationalAdditionalCode.header.hint")),
             elements = nationalAdditionalCodes,

--- a/app/views/declaration/package_information.scala.html
+++ b/app/views/declaration/package_information.scala.html
@@ -67,7 +67,7 @@
                     <td>@item.numberOfPackages</td>
                     <td>@item.shippingMarks</td>
                     <td>
-                        <button class="button--secondary" name=@messages("site.remove") value=@index>
+                        <button class="button--secondary" name=@messages("site.remove") value=@item.toJson>
                         @messages("site.remove")
                 </button>
                 </td>

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -59,7 +59,7 @@
                     <td>@document.documentReference</td>
                     <td>@document.goodsItemIdentifier.getOrElse("")</td>
                     <td>
-                        <button class="button--secondary" name=@messages("site.remove") value=@index>
+                        <button class="button--secondary" name=@messages("site.remove") value=@document.toJson>
                         @messages("site.remove")
                 </button>
                 </td>

--- a/app/views/declaration/seal.scala.html
+++ b/app/views/declaration/seal.scala.html
@@ -43,9 +43,7 @@
         @if(seals.nonEmpty) {
             @components.fields.removable_elements_table(
                 title = Some(messages("standard.seal.id")),
-                elements = seals.zipWithIndex.map {
-                    case (seal, index) => LabelledValue(seal.id, index.toString)
-                }
+                elements = seals.map(seal => LabelledValue(seal.id))
             )
         }
 

--- a/test/controllers/declaration/ItemTypeControllerSpec.scala
+++ b/test/controllers/declaration/ItemTypeControllerSpec.scala
@@ -25,7 +25,6 @@ import helpers.views.declaration.{CommonMessages, ItemTypeMessages}
 import models.ExportsDeclaration
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify}
-import org.scalatest.concurrent.ScalaFutures
 import play.api.test.Helpers._
 import services.cache.{ExportItem, ExportsItemBuilder}
 
@@ -662,41 +661,6 @@ class ItemTypeControllerSpec
     }
 
     "form action is 'Remove'" should {
-
-      "display error page" when {
-
-        "provided with no index" in {
-
-          val cachedItemType =
-            ItemType("100", fourDigitsSequence(10), Seq.empty, "Description", None, None, "100")
-          val userInput = addActionTypeToFormData(Remove(Seq(taricAdditionalCodesKey + "_")), Map.empty)
-          val item = ExportItem("id", itemType = Some(cachedItemType))
-          val model = aDeclaration(withItem(item), withChoice("SMP"))
-          withNewCaching(model)
-
-          val result = route(app, postRequestFormUrlEncoded(uri(item), model.sessionId)(userInput.toSeq: _*)).get
-          ScalaFutures.whenReady(result.failed) { exc =>
-            exc.getMessage must equal(messages("error.removeAction.incorrectFormat"))
-            exc mustBe an[IllegalArgumentException]
-          }
-        }
-
-        "provided with incorrect index value" in {
-
-          val cachedItemType =
-            ItemType("100", fourDigitsSequence(10), Seq.empty, "Description", None, None, "100")
-          val userInput = addActionTypeToFormData(Remove(Seq(taricAdditionalCodesKey + "_incorrectIndex")), Map.empty)
-          val item = ExportItem("id", itemType = Some(cachedItemType))
-          val model = aDeclaration(withItem(item), withChoice("SMP"))
-          withNewCaching(model)
-
-          val result = route(app, postRequestFormUrlEncoded(uri(item), model.sessionId)(userInput.toSeq: _*)).get
-          ScalaFutures.whenReady(result.failed) { exc =>
-            exc.getMessage must equal(messages("error.removeAction.incorrectFormat"))
-            exc mustBe an[IllegalArgumentException]
-          }
-        }
-      }
 
       "save data without removed element to the cache" when {
 

--- a/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
@@ -118,7 +118,7 @@ class PreviousDocumentsControllerSpec
 
         withNewCaching(modelWithPreviousDocuments)
 
-        val body = correctDocument :+ removeActionURLEncoded("0")
+        val body = correctDocument :+ removeActionURLEncoded(s"${document.toJson}")
 
         val result = route(app, postRequestFormUrlEncoded(uri, modelWithPreviousDocuments.sessionId)(body: _*)).get
 

--- a/test/controllers/util/MultipleItemsHelperSpec.scala
+++ b/test/controllers/util/MultipleItemsHelperSpec.scala
@@ -52,10 +52,12 @@ class MultipleItemsHelperSpec extends WordSpec with MustMatchers {
   }
 
   "MultipleItemsHelper on remove method" should {
-    "throw InternalServerError when id is not defined" in {
-      assertThrows[InternalServerException] {
-        MultipleItemsHelper.remove(None, Seq())
-      }
+
+    "return cache when item not defined" in {
+      val idToRemove = Some("99")
+      val cachedData = Seq(TestForm("ABC"), TestForm("DEF"))
+
+      MultipleItemsHelper.remove(idToRemove, cachedData) must be(cachedData)
     }
 
     "return updated sequence without selected item" in {

--- a/test/controllers/util/MultipleItemsHelperSpec.scala
+++ b/test/controllers/util/MultipleItemsHelperSpec.scala
@@ -54,18 +54,17 @@ class MultipleItemsHelperSpec extends WordSpec with MustMatchers {
   "MultipleItemsHelper on remove method" should {
 
     "return cache when item not defined" in {
-      val idToRemove = Some("99")
       val cachedData = Seq(TestForm("ABC"), TestForm("DEF"))
-
-      MultipleItemsHelper.remove(idToRemove, cachedData) must be(cachedData)
+      val filter: TestForm => Boolean = _.value == "99"
+      MultipleItemsHelper.remove(cachedData, filter) must be(cachedData)
     }
 
     "return updated sequence without selected item" in {
-      val idToRemove = Some("1")
+      val filter: TestForm => Boolean = _.value == "DEF"
       val cachedData = Seq(TestForm("ABC"), TestForm("DEF"))
       val expectedOutput = Seq(TestForm("ABC"))
 
-      MultipleItemsHelper.remove(idToRemove, cachedData) must be(expectedOutput)
+      MultipleItemsHelper.remove(cachedData, filter) must be(expectedOutput)
     }
   }
 

--- a/test/unit/controllers/declaration/SealControllerSpec.scala
+++ b/test/unit/controllers/declaration/SealControllerSpec.scala
@@ -122,20 +122,6 @@ class SealControllerSpec extends ControllerSpec with ScalaFutures with ErrorHand
       }
     }
 
-    "throw an exception" when {
-
-      "id is incorrect" in new SetUp {
-
-        val body = (Remove.toString, "")
-
-        val caught = intercept[InternalServerException] {
-          Await.result(controller.submitForm()(postRequestAsFormUrlEncoded(body)), patienceConfig.timeout)
-        }
-
-        assert(caught.getMessage == "Incorrect id")
-      }
-    }
-
     "return 303 (SEE_OTHER)" when {
 
       "user added correct item" in new SetUp {

--- a/test/views/declaration/DocumentsProducedViewSpec.scala
+++ b/test/views/declaration/DocumentsProducedViewSpec.scala
@@ -596,7 +596,7 @@ class DocumentsProducedViewSpec extends ViewSpec with DocumentsProducedMessages 
       val firstItemIndex = "0"
 
       removeButton.text() must be("Remove")
-      removeButton.attr("value") must be(firstItemIndex)
+      removeButton.attr("value") must be(correctDocumentsProduced.toJson.toString())
     }
   }
 }


### PR DESCRIPTION
Changes to fix the removal of list items, following by refreshing the page.  This re-submits the remove request and should not fail if the item to be removed is no longer there.

Also stopped referencing list items by index as refreshing the page would cause another item to be removed (or an index out of bounds).