### PR TITLE
CEDS-1511 Remove deprecated cache service method

### DIFF
--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -61,7 +61,8 @@ class AdditionalInformationController @Inject()(
       val actionTypeOpt = FormAction.bindFromRequest()
 
       val cachedData = exportsCacheService
-        .getItemByIdAndSession(itemId, journeySessionId)
+        .get(journeySessionId)
+        .map(_.flatMap(_.itemBy(itemId)))
         .map(_.flatMap(_.additionalInformation).getOrElse(AdditionalInformationData(Seq())))
 
       cachedData.flatMap { cache =>

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -58,7 +58,8 @@ class DocumentsProducedController @Inject()(
     val boundForm = form().bindFromRequest()
     val actionTypeOpt = FormAction.bindFromRequest()
     val cachedData: Future[DocumentsProducedData] = exportsCacheService
-      .getItemByIdAndSession(itemId, journeySessionId)
+      .get(journeySessionId)
+      .map(_.flatMap(_.itemBy(itemId)))
       .map(_.flatMap(_.documentsProducedData).getOrElse(DocumentsProducedData(Seq())))
 
     cachedData.flatMap { cache: DocumentsProducedData =>

--- a/app/controllers/declaration/PackageInformationController.scala
+++ b/app/controllers/declaration/PackageInformationController.scala
@@ -54,7 +54,8 @@ class PackageInformationController @Inject()(
     implicit authRequest =>
       val actionTypeOpt = FormAction.bindFromRequest()
       val boundForm = form().bindFromRequest()
-      exportsCacheService.getItemByIdAndSession(itemId, journeySessionId).map(_.map(_.packageInformation)).flatMap {
+      exportsCacheService.get(journeySessionId)
+        .map(_.flatMap(_.itemBy(itemId))).map(_.map(_.packageInformation)).flatMap {
         data =>
           val packagings = data.getOrElse(Seq.empty)
 

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -71,7 +71,8 @@ class ProcedureCodesController @Inject()(
       val actionTypeOpt = FormAction.bindFromRequest()
 
       val cachedData = exportsCacheService
-        .getItemByIdAndSession(itemId, journeySessionId)
+        .get(journeySessionId)
+        .map(_.flatMap(_.itemBy(itemId)))
         .map(_.flatMap(_.procedureCodes))
         .map(_.getOrElse(ProcedureCodesData(None, Seq())))
 

--- a/app/services/cache/ExportsCacheService.scala
+++ b/app/services/cache/ExportsCacheService.scala
@@ -34,14 +34,7 @@ class ExportsCacheService @Inject()(journeyCacheModelRepo: ExportsDeclarationRep
   def update(sessionId: String, model: ExportsDeclaration): Future[Option[ExportsDeclaration]] =
     journeyCacheModelRepo.upsert(sessionId, model.copy(updatedDateTime = Instant.now()))
 
-  @deprecated("Please use `get` and `ExportCacheModel#itemBy` methods", since = "2019-08-08")
-  def getItemByIdAndSession(itemId: String, sessionId: String): Future[Option[ExportItem]] =
-    get(sessionId).map {
-      case Some(model) => model.itemBy(itemId)
-      case _           => None
-    }
-
-  def remove(sessionId: String): Future[FindAndModifyCommand.FindAndModifyResult] =
-    journeyCacheModelRepo.remove(sessionId)
+  def remove(sessionId: String): Future[Unit] =
+    journeyCacheModelRepo.remove(sessionId).map(_ => (): Unit)
 
 }

--- a/test/base/CustomExportsBaseSpec.scala
+++ b/test/base/CustomExportsBaseSpec.scala
@@ -167,9 +167,6 @@ trait CustomExportsBaseSpec
 
   // FIXME should be promoted to MockExportsCacheService trait
   override def withNewCaching(dataToReturn: ExportsDeclaration) {
-    when(mockExportsCacheService.getItemByIdAndSession(any[String], eqRef(dataToReturn.sessionId)))
-      .thenReturn(Future.successful(dataToReturn.items.headOption))
-
     when(
       mockExportsCacheService
         .update(eqRef(dataToReturn.sessionId), any[ExportsDeclaration])
@@ -182,9 +179,6 @@ trait CustomExportsBaseSpec
   }
 
   def withNewCaching() {
-    when(mockExportsCacheService.getItemByIdAndSession(any[String], any[String]))
-      .thenReturn(Future.successful(None))
-
     when(
       mockExportsCacheService
         .update(any[String], any[ExportsDeclaration])

--- a/test/base/MockExportCacheService.scala
+++ b/test/base/MockExportCacheService.scala
@@ -32,9 +32,6 @@ trait MockExportCacheService extends MockitoSugar with ExportsDeclarationBuilder
   val mockExportsCacheService: ExportsCacheService = mock[ExportsCacheService]
 
   def withNewCaching(dataToReturn: ExportsDeclaration): Unit = {
-    when(mockExportsCacheService.getItemByIdAndSession(anyString, anyString))
-      .thenReturn(Future.successful(dataToReturn.items.headOption))
-
     when(mockExportsCacheService.update(anyString, any[ExportsDeclaration]))
       .thenReturn(Future.successful(Some(dataToReturn)))
 

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -41,9 +41,7 @@ class SubmissionServiceSpec extends CustomExportsBaseSpec with OptionValues with
     reset(mockExportsCacheService, mockCustomsDeclareExportsConnector, mockAuditService)
     successfulCustomsDeclareExportsResponse()
 
-    val mockResult = mock[JSONBatchCommands.FindAndModifyCommand.FindAndModifyResult]
-
-    when(mockExportsCacheService.remove(any[String])).thenReturn(Future.successful(mockResult))
+    when(mockExportsCacheService.remove(any[String])).thenReturn(Future.successful((): Unit))
   }
 
   implicit val request = TestHelper.journeyRequest(FakeRequest("", ""), AllowedChoiceValues.SupplementaryDec)


### PR DESCRIPTION
I expect as part of Save & Resume that this service will be converted to use the back end rather than Mongo.

This PR preps the service a little by removing some methods that wont be available via the backend