### PR TITLE
CEDS-1475 Rename HTML ids to `Related document`

### DIFF
--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -69,7 +69,7 @@ object Document {
   object AllowedValues {
     val TemporaryStorage = "X"
     val SimplifiedDeclaration = "Y"
-    val PreviousDocument = "Z"
+    val RelatedDocument = "Z"
   }
 }
 

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -77,7 +77,7 @@
             inputs = Seq(
                 RadioOption("Temporary storage", TemporaryStorage, messages("supplementary.previousDocuments.X")),
                 RadioOption("Simplified declaration", SimplifiedDeclaration, messages("supplementary.previousDocuments.Y")),
-                RadioOption("Previous document", PreviousDocument, messages("supplementary.previousDocuments.Z"))
+                RadioOption("Related document", RelatedDocument, messages("supplementary.previousDocuments.Z"))
             )
         )
 

--- a/test/unit/controllers/SubmissionsControllerSpec.scala
+++ b/test/unit/controllers/SubmissionsControllerSpec.scala
@@ -64,8 +64,10 @@ class SubmissionsControllerSpec extends ControllerSpec {
   "Display Submissions" should {
     "return 200 (OK)" when {
       "display page method is invoked" in new SetUp {
-        when(mockCustomsDeclareExportsConnector.fetchSubmissions()(any(), any())).thenReturn(successful(Seq(submission)))
-        when(mockCustomsDeclareExportsConnector.fetchNotifications()(any(), any())).thenReturn(successful(Seq(notification)))
+        when(mockCustomsDeclareExportsConnector.fetchSubmissions()(any(), any()))
+          .thenReturn(successful(Seq(submission)))
+        when(mockCustomsDeclareExportsConnector.fetchNotifications()(any(), any()))
+          .thenReturn(successful(Seq(notification)))
 
         val result = controller.displayListOfSubmissions()(getRequest())
 
@@ -79,13 +81,17 @@ class SubmissionsControllerSpec extends ControllerSpec {
       "declaration found" in new SetUp {
         val rejectedDeclaration: ExportsDeclaration = aDeclaration(withId("id"), withStatus(DeclarationStatus.COMPLETE))
         val newDeclaration: ExportsDeclaration = aDeclaration(withId("new-id"), withStatus(DeclarationStatus.DRAFT))
-        when(mockCustomsDeclareExportsConnector.findDeclaration(refEq("id"))(any(), any())).thenReturn(successful(Some(rejectedDeclaration)))
-        when(mockCustomsDeclareExportsConnector.createDeclaration(any[ExportsDeclaration])(any(), any())).thenReturn(successful(newDeclaration))
+        when(mockCustomsDeclareExportsConnector.findDeclaration(refEq("id"))(any(), any()))
+          .thenReturn(successful(Some(rejectedDeclaration)))
+        when(mockCustomsDeclareExportsConnector.createDeclaration(any[ExportsDeclaration])(any(), any()))
+          .thenReturn(successful(newDeclaration))
 
         val result = controller.amend("id")(getRequest())
 
         status(result) must be(SEE_OTHER)
-        redirectLocation(result) must be(Some(controllers.declaration.routes.SummaryController.displayPage(Mode.AmendMode).url))
+        redirectLocation(result) must be(
+          Some(controllers.declaration.routes.SummaryController.displayPage(Mode.AmendMode).url)
+        )
         session(result).get(ExportsSessionKeys.declarationId) must be(Some("new-id"))
         theDeclarationCreated.status mustBe DeclarationStatus.DRAFT
       }

--- a/test/unit/controllers/declaration/SummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/SummaryControllerSpec.scala
@@ -121,11 +121,8 @@ class SummaryControllerSpec extends ControllerSpec with ErrorHandlerMocks with O
         val declaration = aDeclaration()
         withNewCaching(aDeclaration())
         when(
-          mockSubmissionService.submit(any[ExportsDeclaration])(
-            any[JourneyRequest[_]],
-            any[HeaderCarrier],
-            any[ExecutionContext]
-          )
+          mockSubmissionService
+            .submit(any[ExportsDeclaration])(any[JourneyRequest[_]], any[HeaderCarrier], any[ExecutionContext])
         ).thenReturn(Future.successful(Some("123LRN")))
 
         val result = controller.submitDeclaration()(postRequest(Json.toJson(declaration)))
@@ -134,7 +131,11 @@ class SummaryControllerSpec extends ControllerSpec with ErrorHandlerMocks with O
         session(result).get(ExportsSessionKeys.declarationId) must be(None)
         redirectLocation(result) must be(Some(controllers.declaration.routes.ConfirmationController.displayPage().url))
         flash(result).get("LRN") must be(Some("123LRN"))
-        verify(mockSubmissionService).submit(any[ExportsDeclaration])(any[JourneyRequest[_]], any[HeaderCarrier], any[ExecutionContext])
+        verify(mockSubmissionService).submit(any[ExportsDeclaration])(
+          any[JourneyRequest[_]],
+          any[HeaderCarrier],
+          any[ExecutionContext]
+        )
       }
     }
   }

--- a/test/views/declaration/ConsignmentReferencesViewSpec.scala
+++ b/test/views/declaration/ConsignmentReferencesViewSpec.scala
@@ -182,7 +182,8 @@ class ConsignmentReferencesViewSpec extends ViewSpec with ConsignmentReferencesM
 
     "display data in DUCR input" in {
 
-      val view = createView(ConsignmentReferences.form().fill(ConsignmentReferences(Ducr("9GB12345678901234-SHIP1234-1"), "")))
+      val view =
+        createView(ConsignmentReferences.form().fill(ConsignmentReferences(Ducr("9GB12345678901234-SHIP1234-1"), "")))
 
       getElementById(view, "ducr_ducr").attr("value") must be("9GB12345678901234-SHIP1234-1")
       getElementById(view, "lrn").attr("value") must be("")
@@ -199,7 +200,9 @@ class ConsignmentReferencesViewSpec extends ViewSpec with ConsignmentReferencesM
     "display data in all inputs" in {
 
       val view =
-        createView(ConsignmentReferences.form().fill(ConsignmentReferences(Ducr("GB/ABC4-ASIUDYFAHSDJF"), "test1", Some("ucr"))))
+        createView(
+          ConsignmentReferences.form().fill(ConsignmentReferences(Ducr("GB/ABC4-ASIUDYFAHSDJF"), "test1", Some("ucr")))
+        )
 
       getElementById(view, "ducr_ducr").attr("value") must be("GB/ABC4-ASIUDYFAHSDJF")
       getElementById(view, "lrn").attr("value") must be("test1")

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -65,10 +65,10 @@ class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages 
 
       getElementById(view, "Simplified declaration-label").text() must be(messages(documentY))
 
-      val optionThree = getElementById(view, "Previous document")
+      val optionThree = getElementById(view, "Related document")
       optionThree.attr("checked") must be("")
 
-      getElementById(view, "Previous document-label").text() must be(messages(documentZ))
+      getElementById(view, "Related document-label").text() must be(messages(documentZ))
     }
 
     "display empty input with label for Previous document code" in {
@@ -127,7 +127,7 @@ class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages 
       val optionTwo = getElementById(view, "Simplified declaration")
       optionTwo.attr("checked") must be("")
 
-      val optionThree = getElementById(view, "Previous document")
+      val optionThree = getElementById(view, "Related document")
       optionThree.attr("checked") must be("")
     }
 
@@ -141,7 +141,7 @@ class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages 
       val optionTwo = getElementById(view, "Simplified declaration")
       optionTwo.attr("checked") must be("checked")
 
-      val optionThree = getElementById(view, "Previous document")
+      val optionThree = getElementById(view, "Related document")
       optionThree.attr("checked") must be("")
     }
 
@@ -155,7 +155,7 @@ class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages 
       val optionTwo = getElementById(view, "Simplified declaration")
       optionTwo.attr("checked") must be("")
 
-      val optionThree = getElementById(view, "Previous document")
+      val optionThree = getElementById(view, "Related document")
       optionThree.attr("checked") must be("checked")
     }
 
@@ -196,7 +196,7 @@ class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages 
       val optionTwo = getElementById(view, "Simplified declaration")
       optionTwo.attr("checked") must be("")
 
-      val optionThree = getElementById(view, "Previous document")
+      val optionThree = getElementById(view, "Related document")
       optionThree.attr("checked") must be("")
 
       getElementById(view, "documentType").attr("value") must be("Test")


### PR DESCRIPTION
This was a request from @leszeklorek so that the CI tests can search
the html elements by their new name, making the domain language in code,
test and business consistent.