### PR TITLE
CEDS-1487 - fix couple of issues with 'choice' page

### DIFF
--- a/app/controllers/SavedDeclarationsController.scala
+++ b/app/controllers/SavedDeclarationsController.scala
@@ -40,7 +40,7 @@ class SavedDeclarationsController @Inject()(
 
   def displayDeclarations(pageNumber: Int = 1): Action[AnyContent] = authenticate.async { implicit request =>
     customsDeclareExportsConnector.findSavedDeclarations(Page(pageNumber, appConfig.paginationItemsPerPage)).map { page =>
-      Ok(savedDeclarationsPage(page))
+      Ok(savedDeclarationsPage(page)).removingFromSession(ExportsSessionKeys.declarationId)
     }
   }
 

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -39,11 +39,11 @@
                 field = form("value"),
                 legend = "",
                 inputs = Seq(
-                    RadioOption("Supplementary declaration", SupplementaryDec, messages("declaration.choice.SMP")),
                     RadioOption("Standard declaration", StandardDec, messages("declaration.choice.STD")),
+                    RadioOption("Supplementary declaration", SupplementaryDec, messages("declaration.choice.SMP")),
+                    RadioOption("Submissions", Submissions, messages("declaration.choice.SUB")),
                     RadioOption("Continue declaration", ContinueDec, messages("declaration.choice.CON")),
-                    RadioOption("Cancel declaration", CancelDec, messages("declaration.choice.CAN")),
-                    RadioOption("Submissions", Submissions, messages("declaration.choice.SUB"))
+                    RadioOption("Cancel declaration", CancelDec, messages("declaration.choice.CAN"))
                 ).filter(radioOption => appConfig.availableJourneys().contains(radioOption.value))
             )
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -141,11 +141,11 @@ cancellation.reason.noLongerRequired = No longer required
 
 
 declaration.choice.description = What do you want to do?
-declaration.choice.SMP = Supplementary declaration
-declaration.choice.STD = Standard declaration
-declaration.choice.CAN = Cancel declaration
+declaration.choice.SMP = Make a supplementary declaration
+declaration.choice.STD = Make a standard declaration
+declaration.choice.CAN = Cancel a declaration
 declaration.choice.CON = Continue a saved declaration
-declaration.choice.SUB = View recent declarations
+declaration.choice.SUB = View declarations
 
 startPage.title = Register for customs services
 startPage.heading = Make an export declaration


### PR DESCRIPTION
- order (and text) of choice items changed to reflect latest prototype
- cleared the declarationId from session when landing on the "saved drafts" page so that when you navigate back to the choice page the previously viewed dec type is not pre-selected.