### PR TITLE
CEDS-1549 Fix not removeble additional fiscal reference for item

### DIFF
--- a/app/controllers/actions/AuthAction.scala
+++ b/app/controllers/actions/AuthAction.scala
@@ -87,7 +87,7 @@ class AuthActionImpl @Inject()(
 
           val cdsLoggedInUser = SignedInUser(eori.get.value, allEnrolments, identityData)
 
-          block(AuthenticatedRequest(request, cdsLoggedInUser))
+          block(new AuthenticatedRequest(request, cdsLoggedInUser))
       }
   }
 

--- a/app/controllers/actions/ItemAction.scala
+++ b/app/controllers/actions/ItemAction.scala
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import javax.inject.Inject
+import models.requests.{ItemRequest, JourneyRequest}
+import play.api.mvc.{ActionRefiner, Result}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class ItemAction(itemId: String)(implicit val executionContext: ExecutionContext) extends ActionRefiner[JourneyRequest, ItemRequest]  {
+
+  import play.api.mvc.Results._
+
+  private val itemsController = controllers.declaration.routes.ItemsSummaryController
+
+  override protected def refine[A](request: JourneyRequest[A]): Future[Either[Result, ItemRequest[A]]] = Future.successful {
+    request.cacheModel
+      .itemBy(itemId)
+      .map(item => Right(new ItemRequest[A](item, request)))
+      .getOrElse(Left(Redirect(itemsController.displayPage())))
+  }
+}
+
+class ItemActionBuilder @Inject()(authorized: AuthAction, journeyAction: JourneyAction)(implicit val executionContext: ExecutionContext) {
+
+  def apply(itemId: String) = authorized andThen journeyAction andThen ItemAction(itemId)
+}

--- a/app/controllers/actions/ItemAction.scala
+++ b/app/controllers/actions/ItemAction.scala
@@ -22,21 +22,25 @@ import play.api.mvc.{ActionRefiner, Result}
 
 import scala.concurrent.{ExecutionContext, Future}
 
-case class ItemAction(itemId: String)(implicit val executionContext: ExecutionContext) extends ActionRefiner[JourneyRequest, ItemRequest]  {
+case class ItemAction(itemId: String)(implicit val executionContext: ExecutionContext)
+    extends ActionRefiner[JourneyRequest, ItemRequest] {
 
   import play.api.mvc.Results._
 
   private val itemsController = controllers.declaration.routes.ItemsSummaryController
 
-  override protected def refine[A](request: JourneyRequest[A]): Future[Either[Result, ItemRequest[A]]] = Future.successful {
-    request.cacheModel
-      .itemBy(itemId)
-      .map(item => Right(new ItemRequest[A](item, request)))
-      .getOrElse(Left(Redirect(itemsController.displayPage())))
-  }
+  override protected def refine[A](request: JourneyRequest[A]): Future[Either[Result, ItemRequest[A]]] =
+    Future.successful {
+      request.cacheModel
+        .itemBy(itemId)
+        .map(item => Right(new ItemRequest[A](item, request)))
+        .getOrElse(Left(Redirect(itemsController.displayPage())))
+    }
 }
 
-class ItemActionBuilder @Inject()(authorized: AuthAction, journeyAction: JourneyAction)(implicit val executionContext: ExecutionContext) {
+class ItemActionBuilder @Inject()(authorized: AuthAction, journeyAction: JourneyAction)(
+  implicit val executionContext: ExecutionContext
+) {
 
   def apply(itemId: String) = authorized andThen journeyAction andThen ItemAction(itemId)
 }

--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -39,7 +39,7 @@ class JourneyAction @Inject()(cacheService: ExportsCacheService)(
     request.declarationId match {
       case Some(id) =>
         cacheService.get(id).map {
-          case Some(declaration) => Right(JourneyRequest(request, declaration))
+          case Some(declaration) => Right(new JourneyRequest(request, declaration))
           case _                 => handleMissingDeclarationId(request)
         }
       case None => Future.successful(handleMissingDeclarationId(request))

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -57,9 +57,9 @@ class AdditionalFiscalReferencesController @Inject()(
     val boundForm = form().bindFromRequest()
 
     actionTypeOpt match {
-      case Some(Add)                                   => addReference(mode, itemId, boundForm, cache)
-      case Some(SaveAndContinue) | Some(SaveAndReturn) => saveAndContinue(mode, itemId, boundForm, cache)
-      case _                                           => errorHandler.displayErrorPage()
+      case Add                             => addReference(mode, itemId, boundForm, cache)
+      case SaveAndContinue | SaveAndReturn => saveAndContinue(mode, itemId, boundForm, cache)
+      case _                               => errorHandler.displayErrorPage()
     }
 
   }

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -52,15 +52,15 @@ class AdditionalFiscalReferencesController @Inject()(
   }
 
   def saveReferences(mode: Mode, itemId: String): Action[AnyContent] = itemAction(itemId).async { implicit request =>
-      val actionTypeOpt = FormAction.bindFromRequest()
-      val cache = request.item.additionalFiscalReferencesData.getOrElse(AdditionalFiscalReferencesData(Seq.empty))
-      val boundForm = form().bindFromRequest()
+    val actionTypeOpt = FormAction.bindFromRequest()
+    val cache = request.item.additionalFiscalReferencesData.getOrElse(AdditionalFiscalReferencesData(Seq.empty))
+    val boundForm = form().bindFromRequest()
 
-      actionTypeOpt match {
-        case Some(Add)                                   => addReference(mode, itemId, boundForm, cache)
-        case Some(SaveAndContinue) | Some(SaveAndReturn) => saveAndContinue(mode, itemId, boundForm, cache)
-        case _                                           => errorHandler.displayErrorPage()
-      }
+    actionTypeOpt match {
+      case Some(Add)                                   => addReference(mode, itemId, boundForm, cache)
+      case Some(SaveAndContinue) | Some(SaveAndReturn) => saveAndContinue(mode, itemId, boundForm, cache)
+      case _                                           => errorHandler.displayErrorPage()
+    }
 
   }
 
@@ -96,18 +96,15 @@ class AdditionalFiscalReferencesController @Inject()(
           else Future.successful(navigator.continueTo(routes.ItemTypeController.displayPage(mode, itemId)))
       )
 
-  def removeReference(
-    mode: Mode,
-    itemId: String,
-    value: String
-  ) =  itemAction(itemId).async { implicit request =>
+  def removeReference(mode: Mode, itemId: String, value: String) = itemAction(itemId).async { implicit request =>
     val cacheModel = request.item.additionalFiscalReferencesData
       .getOrElse(AdditionalFiscalReferencesData(Seq.empty))
     val updatedCache = cacheModel.removeReference(value)
     val valueOnPage = form().bindFromRequest()
     updateExportsCache(itemId, updatedCache).map {
-      case Some(_) => Ok(additionalFiscalReferencesPage(mode, itemId, valueOnPage.discardingErrors, updatedCache.references))
-      case None    => Redirect(routes.ItemsSummaryController.displayPage())
+      case Some(_) =>
+        Ok(additionalFiscalReferencesPage(mode, itemId, valueOnPage.discardingErrors, updatedCache.references))
+      case None => Redirect(routes.ItemsSummaryController.displayPage())
     }
   }
 

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, ItemActionBuilder, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.{MultipleItemsHelper, _}
 import forms.declaration.AdditionalFiscalReference.form
@@ -36,8 +36,7 @@ import views.html.declaration.additional_fiscal_references
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalFiscalReferencesController @Inject()(
-  authenticate: AuthAction,
-  journeyType: JourneyAction,
+  itemAction: ItemActionBuilder,
   errorHandler: ErrorHandler,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,33 +45,21 @@ class AdditionalFiscalReferencesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) {
-    implicit request =>
-      request.cacheModel.itemBy(itemId) match {
-        case Some(model) =>
-          model.additionalFiscalReferencesData.fold(Ok(additionalFiscalReferencesPage(mode, itemId, form()))) { data =>
-            Ok(additionalFiscalReferencesPage(mode, itemId, form(), data.references))
-          }
-        case _ => Ok(additionalFiscalReferencesPage(mode, itemId, form()))
-      }
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = itemAction(itemId) { implicit request =>
+    request.item.additionalFiscalReferencesData.fold(Ok(additionalFiscalReferencesPage(mode, itemId, form()))) { data =>
+      Ok(additionalFiscalReferencesPage(mode, itemId, form(), data.references))
+    }
   }
 
-  def saveReferences(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async {
-    implicit request =>
+  def saveReferences(mode: Mode, itemId: String): Action[AnyContent] = itemAction(itemId).async { implicit request =>
       val actionTypeOpt = FormAction.bindFromRequest()
-
-      val cache = request.cacheModel
-        .itemBy(itemId)
-        .flatMap(_.additionalFiscalReferencesData)
-        .getOrElse(AdditionalFiscalReferencesData(Seq.empty))
-
+      val cache = request.item.additionalFiscalReferencesData.getOrElse(AdditionalFiscalReferencesData(Seq.empty))
       val boundForm = form().bindFromRequest()
 
       actionTypeOpt match {
-        case Add                             => addReference(mode, itemId, boundForm, cache)
-        case SaveAndContinue | SaveAndReturn => saveAndContinue(mode, itemId, boundForm, cache)
-        case Remove(values)                  => removeReference(mode, itemId, values, boundForm, cache)
-        case _                               => errorHandler.displayErrorPage()
+        case Some(Add)                                   => addReference(mode, itemId, boundForm, cache)
+        case Some(SaveAndContinue) | Some(SaveAndReturn) => saveAndContinue(mode, itemId, boundForm, cache)
+        case _                                           => errorHandler.displayErrorPage()
       }
 
   }
@@ -109,17 +96,18 @@ class AdditionalFiscalReferencesController @Inject()(
           else Future.successful(navigator.continueTo(routes.ItemTypeController.displayPage(mode, itemId)))
       )
 
-  private def removeReference(
+  def removeReference(
     mode: Mode,
     itemId: String,
-    values: Seq[String],
-    form: Form[AdditionalFiscalReference],
-    cachedData: AdditionalFiscalReferencesData
-  )(implicit request: JourneyRequest[_]): Future[Result] = {
-    val updatedCache = cachedData.removeReferences(values)
+    value: String
+  ) =  itemAction(itemId).async { implicit request =>
+    val cacheModel = request.item.additionalFiscalReferencesData
+      .getOrElse(AdditionalFiscalReferencesData(Seq.empty))
+    val updatedCache = cacheModel.removeReference(value)
+    val valueOnPage = form().bindFromRequest()
     updateExportsCache(itemId, updatedCache).map {
-      case Some(_) => Ok(additionalFiscalReferencesPage(mode, itemId, form.discardingErrors, updatedCache.references))
-      case None    => Redirect(routes.ItemsSummaryController.displayPage(mode))
+      case Some(_) => Ok(additionalFiscalReferencesPage(mode, itemId, valueOnPage.discardingErrors, updatedCache.references))
+      case None    => Redirect(routes.ItemsSummaryController.displayPage())
     }
   }
 

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -118,9 +118,7 @@ class DestinationCountriesController @Inject()(
         updateCache(countriesStandardUpdated).map {
           _.flatMap(_.locations.destinationCountries) match {
             case Some(model) =>
-              Ok(
-                destinationCountriesStandardPage(mode, Standard.form.fill(model), cachedData.countriesOfRouting)
-              )
+              Ok(destinationCountriesStandardPage(mode, Standard.form.fill(model), cachedData.countriesOfRouting))
             case _ =>
               Ok(destinationCountriesStandardPage(mode, Standard.form))
           }

--- a/app/controllers/declaration/DestinationCountriesController.scala
+++ b/app/controllers/declaration/DestinationCountriesController.scala
@@ -115,7 +115,17 @@ class DestinationCountriesController @Inject()(
 
     DestinationCountriesValidator.validateOnAddition(countriesStandardUpdated) match {
       case Valid =>
-        updateCache(countriesStandardUpdated).flatMap(_ => refreshPage(mode, countriesStandardInput))
+        updateCache(countriesStandardUpdated).map {
+          _.flatMap(_.locations.destinationCountries) match {
+            case Some(model) =>
+              Ok(
+                destinationCountriesStandardPage(mode, Standard.form.fill(model), cachedData.countriesOfRouting)
+              )
+            case _ =>
+              Ok(destinationCountriesStandardPage(mode, Standard.form))
+          }
+        }
+
       case Invalid(errors) =>
         Future.successful(
           BadRequest(
@@ -181,22 +191,6 @@ class DestinationCountriesController @Inject()(
     updateCache(updatedCache)
       .map(_ => Ok(destinationCountriesStandardPage(mode, userInput.discardingErrors, updatedCache.countriesOfRouting)))
   }
-
-  private def refreshPage(mode: Mode, inputDestinationCountries: DestinationCountries)(
-    implicit request: JourneyRequest[_]
-  ): Future[Result] =
-    exportsCacheService.get(request.declarationId).map(_.flatMap(_.locations.destinationCountries)).map {
-      case Some(cachedData) =>
-        Ok(
-          destinationCountriesStandardPage(
-            mode,
-            Standard.form.fill(inputDestinationCountries),
-            cachedData.countriesOfRouting
-          )
-        )
-      case _ =>
-        Ok(destinationCountriesStandardPage(mode, Standard.form))
-    }
 
   private def updateCache(
     formData: DestinationCountries

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -82,9 +82,9 @@ class SealController @Inject()(
   private def badRequest(mode: Mode, formWithErrors: Form[Seal], cachedSeals: Seq[Seal])(
     implicit request: JourneyRequest[_]
   ) = {
-    val d = request.cacheModel.transportDetails
-    val s = request.cacheModel.seals
-    BadRequest(sealPage(mode, formWithErrors, s, d.fold(false)(_.container)))
+    val transportDetails = request.cacheModel.transportDetails
+    val seals = request.cacheModel.seals
+    BadRequest(sealPage(mode, formWithErrors, seals, transportDetails.fold(false)(_.container)))
   }
 
   private def removeSeal(

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -79,7 +79,9 @@ class SealController @Inject()(
         } else Future.successful(navigator.continueTo(routes.SummaryController.displayPage(Mode.Normal)))
     )
 
-  private def badRequest(mode: Mode, formWithErrors: Form[Seal], cachedSeals: Seq[Seal])(implicit request: JourneyRequest[_]) = {
+  private def badRequest(mode: Mode, formWithErrors: Form[Seal], cachedSeals: Seq[Seal])(
+    implicit request: JourneyRequest[_]
+  ) = {
     val d = request.cacheModel.transportDetails
     val s = request.cacheModel.seals
     BadRequest(sealPage(mode, formWithErrors, s, d.fold(false)(_.container)))

--- a/app/forms/declaration/AdditionalFiscalReference.scala
+++ b/app/forms/declaration/AdditionalFiscalReference.scala
@@ -49,6 +49,10 @@ case class AdditionalFiscalReferencesData(references: Seq[AdditionalFiscalRefere
     val patterns = values.toSet
     copy(references = references.filterNot(reference => patterns.contains(reference.asString)))
   }
+
+  def removeReference(value: String): AdditionalFiscalReferencesData = {
+    removeReferences(Seq(value))
+  }
 }
 
 object AdditionalFiscalReferencesData {

--- a/app/forms/declaration/AdditionalFiscalReference.scala
+++ b/app/forms/declaration/AdditionalFiscalReference.scala
@@ -50,9 +50,8 @@ case class AdditionalFiscalReferencesData(references: Seq[AdditionalFiscalRefere
     copy(references = references.filterNot(reference => patterns.contains(reference.asString)))
   }
 
-  def removeReference(value: String): AdditionalFiscalReferencesData = {
+  def removeReference(value: String): AdditionalFiscalReferencesData =
     removeReferences(Seq(value))
-  }
 }
 
 object AdditionalFiscalReferencesData {

--- a/app/models/requests/ItemRequest.scala
+++ b/app/models/requests/ItemRequest.scala
@@ -19,5 +19,4 @@ package models.requests
 import services.cache.ExportItem
 
 class ItemRequest[A](val item: ExportItem, journeyRequest: JourneyRequest[A])
-  extends JourneyRequest[A](journeyRequest.authenticatedRequest, journeyRequest.cacheModel){
-}
+    extends JourneyRequest[A](journeyRequest.authenticatedRequest, journeyRequest.cacheModel) {}

--- a/app/models/requests/ItemRequest.scala
+++ b/app/models/requests/ItemRequest.scala
@@ -16,9 +16,8 @@
 
 package models.requests
 
-import models.SignedInUser
-import play.api.mvc.{Request, WrappedRequest}
+import services.cache.ExportItem
 
-class AuthenticatedRequest[A](request: Request[A], val user: SignedInUser) extends WrappedRequest[A](request) {
-  def declarationId: Option[String] = request.session.data.get(ExportsSessionKeys.declarationId)
+class ItemRequest[A](val item: ExportItem, journeyRequest: JourneyRequest[A])
+  extends JourneyRequest[A](journeyRequest.authenticatedRequest, journeyRequest.cacheModel){
 }

--- a/app/models/requests/JourneyRequest.scala
+++ b/app/models/requests/JourneyRequest.scala
@@ -20,9 +20,7 @@ import forms.Choice
 import models.ExportsDeclaration
 import play.api.mvc.WrappedRequest
 
-case class JourneyRequest[A](authenticatedRequest: AuthenticatedRequest[A], cacheModel: ExportsDeclaration)
-    extends WrappedRequest[A](authenticatedRequest) {
+class JourneyRequest[A](val authenticatedRequest: AuthenticatedRequest[A], val cacheModel: ExportsDeclaration)
+    extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {
   val choice: Choice = Choice(cacheModel.choice)
-
-  def declarationId: String = authenticatedRequest.declarationId.getOrElse(throw new IllegalAccessError)
 }

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -79,7 +79,7 @@
     title = messages("declaration.additionalFiscalReferences.title")
 ) {
 
-    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId))
+    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
 
     @components.error_summary(form.errors)
 

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -43,11 +43,41 @@
 
 @(mode: Mode, itemId:String, form: Form[AdditionalFiscalReference], additionalReferences: Seq[AdditionalFiscalReference] = Seq.empty)(implicit request: Request[_], messages: Messages)
 
+@referenceTable = {
+    <div class="field-group mb-2">
+        <table id="removable_elements">
+
+            <thead>
+                <tr>
+                    <th id="@messages("declaration.additionalFiscalReferences.numbers.header")-heading" colspan="2">@messages("declaration.additionalFiscalReferences.numbers.header")</th>
+                </tr>
+            </thead>
+
+            <tbody>
+            @for((elem, index) <- additionalReferences.map(_.asString).zipWithIndex) {
+                <tr id="removable_elements__row@index">
+                    <td id="removable_elements-row@index-label">@{elem}</td>
+                    <td id="removable_elements-row@index-remove_button">
+                        <input
+                            type="submit"
+                            class="button--secondary"
+                            formmethod="post"
+                            formaction="@routes.AdditionalFiscalReferencesController.removeReference(mode, itemId, elem)"
+                            value="@messages("site.remove")"
+                        >
+                    </td>
+                </tr>
+            }
+            </tbody>
+        </table>
+    </div>
+}
+
 @main_template(
     title = messages("declaration.additionalFiscalReferences.title")
 ) {
 
-    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
+    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId))
 
     @components.error_summary(form.errors)
 
@@ -55,39 +85,12 @@
 
     @components.page_title(Some(messages("declaration.additionalFiscalReferences.title")))
 
-
-
     @helper.form(routes.AdditionalFiscalReferencesController.saveReferences(mode, itemId), 'autoComplete -> "off") {
         @helper.CSRF.formField
 
-        @defining(additionalReferences.map(_.asString).map(ref => LabelledValue(ref))){ labels =>
-            <div class="field-group mb-2">
-                <table id="removable_elements">
 
-                    <thead>
-                        <tr>
-                            <th id="@messages("declaration.additionalFiscalReferences.numbers.header")-heading" colspan="2">@messages("declaration.additionalFiscalReferences.numbers.header")</th>
-                        </tr>
-                    </thead>
+        @referenceTable
 
-                    <tbody>
-                    @for((elem, index) <- labels.zipWithIndex) {
-                        <tr id="removable_elements__row@index">
-                            <th id="removable_elements-row@index-label">@{elem.label}</th>
-                            <th id="removable_elements-row@index-remove_button">
-                                <input type="submit" formmethod="post" formaction="@routes.AdditionalFiscalReferencesController.removeReference(mode, itemId, elem.value)" value="Remove">
-                            </th>
-                        </tr>
-                    }
-                    </tbody>
-                </table>
-            </div>
-        }
-
-        @components.fields.removable_elements_table(
-            title = Some(messages("declaration.additionalFiscalReferences.numbers.header")),
-            elements = additionalReferences.map(_.asString).map(ref => LabelledValue(ref))
-        )
 
         <div id="country-of-dispatch-field">
             @components.fields.field_autocomplete(

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -44,33 +44,35 @@
 @(mode: Mode, itemId:String, form: Form[AdditionalFiscalReference], additionalReferences: Seq[AdditionalFiscalReference] = Seq.empty)(implicit request: Request[_], messages: Messages)
 
 @referenceTable = {
-    <div class="field-group mb-2">
-        <table id="removable_elements">
+    @if(additionalReferences.nonEmpty){
+        <div class="field-group mb-2">
+            <table id="removable_elements">
 
-            <thead>
-                <tr>
-                    <th id="@messages("declaration.additionalFiscalReferences.numbers.header")-heading" colspan="2">@messages("declaration.additionalFiscalReferences.numbers.header")</th>
-                </tr>
-            </thead>
+                <thead>
+                    <tr>
+                        <th id="@messages("declaration.additionalFiscalReferences.numbers.header")-heading" colspan="2">@messages("declaration.additionalFiscalReferences.numbers.header")</th>
+                    </tr>
+                </thead>
 
-            <tbody>
-            @for((elem, index) <- additionalReferences.map(_.asString).zipWithIndex) {
-                <tr id="removable_elements__row@index">
-                    <td id="removable_elements-row@index-label">@{elem}</td>
-                    <td id="removable_elements-row@index-remove_button">
-                        <input
-                            type="submit"
-                            class="button--secondary"
-                            formmethod="post"
-                            formaction="@routes.AdditionalFiscalReferencesController.removeReference(mode, itemId, elem)"
-                            value="@messages("site.remove")"
-                        >
-                    </td>
-                </tr>
-            }
-            </tbody>
-        </table>
-    </div>
+                <tbody>
+                @for((elem, index) <- additionalReferences.map(_.asString).zipWithIndex) {
+                    <tr id="removable_elements__row@index">
+                        <td id="removable_elements-row@index-label">@{elem}</td>
+                        <td id="removable_elements-row@index-remove_button">
+                            <input
+                                type="submit"
+                                class="button--secondary"
+                                formmethod="post"
+                                formaction="@routes.AdditionalFiscalReferencesController.removeReference(itemId, elem)"
+                                value="@messages("site.remove")"
+                            >
+                        </td>
+                    </tr>
+                }
+                </tbody>
+            </table>
+        </div>
+    }
 }
 
 @main_template(

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -55,13 +55,39 @@
 
     @components.page_title(Some(messages("declaration.additionalFiscalReferences.title")))
 
-    @components.fields.removable_elements_table(
-        title = Some(messages("declaration.additionalFiscalReferences.numbers.header")),
-        elements = additionalReferences.map(_.asString).map(ref => LabelledValue(ref))
-    )
+
 
     @helper.form(routes.AdditionalFiscalReferencesController.saveReferences(mode, itemId), 'autoComplete -> "off") {
         @helper.CSRF.formField
+
+        @defining(additionalReferences.map(_.asString).map(ref => LabelledValue(ref))){ labels =>
+            <div class="field-group mb-2">
+                <table id="removable_elements">
+
+                    <thead>
+                        <tr>
+                            <th id="@messages("declaration.additionalFiscalReferences.numbers.header")-heading" colspan="2">@messages("declaration.additionalFiscalReferences.numbers.header")</th>
+                        </tr>
+                    </thead>
+
+                    <tbody>
+                    @for((elem, index) <- labels.zipWithIndex) {
+                        <tr id="removable_elements__row@index">
+                            <th id="removable_elements-row@index-label">@{elem.label}</th>
+                            <th id="removable_elements-row@index-remove_button">
+                                <input type="submit" formmethod="post" formaction="@routes.AdditionalFiscalReferencesController.removeReference(mode, itemId, elem.value)" value="Remove">
+                            </th>
+                        </tr>
+                    }
+                    </tbody>
+                </table>
+            </div>
+        }
+
+        @components.fields.removable_elements_table(
+            title = Some(messages("declaration.additionalFiscalReferences.numbers.header")),
+            elements = additionalReferences.map(_.asString).map(ref => LabelledValue(ref))
+        )
 
         <div id="country-of-dispatch-field">
             @components.fields.field_autocomplete(

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -63,7 +63,7 @@
                                 type="submit"
                                 class="button--secondary"
                                 formmethod="post"
-                                formaction="@routes.AdditionalFiscalReferencesController.removeReference(itemId, elem)"
+                                formaction="@routes.AdditionalFiscalReferencesController.removeReference(mode, itemId, elem)"
                                 value="@messages("site.remove")"
                             >
                         </td>

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -136,9 +136,11 @@ POST         /items/:itemId/fiscal-information   controllers.declaration.FiscalI
 
 # Additional Fiscal References
 
-GET         /items/:itemId/additional-fiscal-references        controllers.declaration.AdditionalFiscalReferencesController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId)
+GET         /items/:itemId/additional-fiscal-references             controllers.declaration.AdditionalFiscalReferencesController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId)
 
-POST        /items/:itemId/additional-fiscal-references        controllers.declaration.AdditionalFiscalReferencesController.saveReferences(mode: models.Mode ?= models.Mode.Normal, itemId)
+POST        /items/:itemId/additional-fiscal-references             controllers.declaration.AdditionalFiscalReferencesController.saveReferences(mode: models.Mode ?= models.Mode.Normal, itemId)
+
+POST        /items/:itemId/additional-fiscal-references/:reference  controllers.declaration.AdditionalFiscalReferencesController.removeReference(mode: models.Mode ?= models.Mode.Normal, itemId, reference)
 
 # Item Type
 

--- a/test/base/ExportsTestData.scala
+++ b/test/base/ExportsTestData.scala
@@ -57,8 +57,6 @@ object ExportsTestData extends ExportsDeclarationBuilder {
 
   val nrsLoginTimes = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
-
-
   def newUser(eori: String, externalId: String): SignedInUser =
     SignedInUser(
       eori,

--- a/test/base/ExportsTestData.scala
+++ b/test/base/ExportsTestData.scala
@@ -57,6 +57,8 @@ object ExportsTestData extends ExportsDeclarationBuilder {
 
   val nrsLoginTimes = LoginTimes(currentLoginTime, Some(previousLoginTime))
 
+
+
   def newUser(eori: String, externalId: String): SignedInUser =
     SignedInUser(
       eori,

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -262,7 +262,7 @@ trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks {
 
   def getAuthenticatedRequest(declarationId: String = "declarationId"): AuthenticatedRequest[AnyContentAsEmpty.type] = {
     import utils.FakeRequestCSRFSupport._
-    AuthenticatedRequest(
+    new AuthenticatedRequest(
       FakeRequest("GET", "").withSession((ExportsSessionKeys.declarationId, declarationId)).withCSRFToken,
       exampleUser
     )

--- a/test/base/TestHelper.scala
+++ b/test/base/TestHelper.scala
@@ -43,16 +43,16 @@ object TestHelper {
 
   def journeyRequest(fakeRequest: FakeRequest[_], choice: String): JourneyRequest[_] = {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
-    JourneyRequest(
-      AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
+    new JourneyRequest(
+      new AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
       cache
     )
   }
 
   def journeyRequest(fakeRequest: Request[_], choice: String): JourneyRequest[_] = {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
-    JourneyRequest(
-      AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
+    new JourneyRequest(
+      new AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
       cache
     )
   }

--- a/test/connectors/ConnectorSpec.scala
+++ b/test/connectors/ConnectorSpec.scala
@@ -16,11 +16,13 @@
 
 package connectors
 
+import com.codahale.metrics.SharedMetricRegistries
 import config.AppConfig
 import org.mockito.BDDMockito.given
 import org.scalatestplus.mockito.MockitoSugar
 import org.scalatest.{BeforeAndAfterEach, WordSpec}
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
+import play.api.Application
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.http.DefaultHttpClient
 
@@ -28,6 +30,14 @@ import scala.concurrent.ExecutionContext
 
 class ConnectorSpec
     extends WordSpec with GuiceOneAppPerSuite with WiremockTestServer with MockitoSugar with BeforeAndAfterEach {
+
+  /**
+    * @see [[base.Injector]]
+    */
+  override def fakeApplication(): Application = {
+    SharedMetricRegistries.clear()
+    super.fakeApplication()
+  }
 
   protected implicit val ec: ExecutionContext = scala.concurrent.ExecutionContext.Implicits.global
   protected implicit val hc: HeaderCarrier = HeaderCarrier()

--- a/test/controllers/navigation/NavigatorTest.scala
+++ b/test/controllers/navigation/NavigatorTest.scala
@@ -46,14 +46,14 @@ class NavigatorTest extends WordSpec with Matchers with MockitoSugar with Export
     val expiryDate = LocalDate.of(2020, 1, 1).plusDays(10)
 
     val declaration = aDeclaration(withUpdateDate(updatedDate))
-    def authenticatedRequest(action: Option[FormAction]) = AuthenticatedRequest[AnyContent](
+    def authenticatedRequest(action: Option[FormAction]) = new AuthenticatedRequest[AnyContent](
       FakeRequest("GET", "uri")
         .withFormUrlEncodedBody(action.getOrElse("other-field").toString -> "")
         .withSession(ExportsSessionKeys.declarationId -> "declarationId"),
       mock[SignedInUser]
     )
     def request(action: Option[FormAction]): JourneyRequest[AnyContent] =
-      JourneyRequest[AnyContent](authenticatedRequest(action), declaration)
+      new JourneyRequest[AnyContent](authenticatedRequest(action), declaration)
 
     "Go to Save as Draft" in {
       given(config.draftTimeToLive).willReturn(FiniteDuration(10, TimeUnit.DAYS))

--- a/test/unit/base/ControllerSpec.scala
+++ b/test/unit/base/ControllerSpec.scala
@@ -49,7 +49,7 @@ trait ControllerSpec
   protected def viewOf(result: Future[Result]) = Html(contentAsString(result))
 
   protected def getRequest(declaration: ExportsDeclaration): JourneyRequest[AnyContentAsEmpty.type] =
-    JourneyRequest(getAuthenticatedRequest(), declaration)
+    new JourneyRequest(getAuthenticatedRequest(), declaration)
 
   protected def postRequest(body: JsValue): Request[AnyContentAsJson] =
     FakeRequest("POST", "")

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.controllers.declaration
 
-import controllers.declaration.{AdditionalFiscalReferencesController, routes}
+import controllers.declaration.{routes, AdditionalFiscalReferencesController}
 import controllers.util.Remove
 import forms.Choice
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -98,7 +98,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val wrongAction: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "12345"), ("WrongAction", ""))
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(wrongAction: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(wrongAction: _*))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -112,7 +113,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val incorrectForm: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "!@#$"), addActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(incorrectForm: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(incorrectForm: _*))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -149,7 +151,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val form: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "54321"), addActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(form: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(form: _*))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -164,7 +167,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val incorrectForm: Seq[(String, String)] =
           Seq(("country", "PL"), ("reference", "!@#$"), saveAndContinueActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(incorrectForm: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(incorrectForm: _*))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -203,7 +207,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val form: Seq[(String, String)] =
           Seq(("country", "PL"), ("reference", "54321"), saveAndContinueActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(form: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(form: _*))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -217,7 +222,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val correctForm: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "12345"), addActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(correctForm: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(correctForm: _*))
 
         status(result) must be(SEE_OTHER)
       }
@@ -229,7 +235,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val correctForm: Seq[(String, String)] =
           Seq(("country", "PL"), ("reference", "12345"), saveAndContinueActionUrlEncoded)
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(correctForm: _*))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(correctForm: _*))
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.ItemTypeController.displayPage(Mode.Normal, item.id)
@@ -247,7 +254,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val correctForm: (String, String) = saveAndContinueActionUrlEncoded
 
-        val result: Future[Result] = controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(correctForm))
+        val result: Future[Result] =
+          controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.ItemTypeController.displayPage(Mode.Normal, "itemId")
@@ -266,7 +274,8 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
         val removeForm: (String, String) = (Remove.toString, "0")
 
-        val result: Future[Result] = controller.removeReference(Mode.Normal, itemCacheData.id, "12345")(postRequestAsFormUrlEncoded(removeForm))
+        val result: Future[Result] =
+          controller.removeReference(Mode.Normal, itemCacheData.id, "12345")(postRequestAsFormUrlEncoded(removeForm))
 
         status(result) must be(OK)
       }

--- a/test/unit/mock/ItemActionMocks.scala
+++ b/test/unit/mock/ItemActionMocks.scala
@@ -23,7 +23,8 @@ import org.scalatest.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext
 
-trait ItemActionMocks extends JourneyActionMocks with MockAuthAction { self: MockitoSugar with Suite with BeforeAndAfterEach =>
+trait ItemActionMocks extends JourneyActionMocks with MockAuthAction {
+  self: MockitoSugar with Suite with BeforeAndAfterEach =>
 
   val mockItemAction = new ItemActionBuilder(mockAuthAction, mockJourneyAction)(ExecutionContext.global)
 }

--- a/test/unit/mock/ItemActionMocks.scala
+++ b/test/unit/mock/ItemActionMocks.scala
@@ -14,11 +14,16 @@
  * limitations under the License.
  */
 
-package models.requests
+package unit.mock
 
-import models.SignedInUser
-import play.api.mvc.{Request, WrappedRequest}
+import base.MockAuthAction
+import controllers.actions.ItemActionBuilder
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatest.mockito.MockitoSugar
 
-class AuthenticatedRequest[A](request: Request[A], val user: SignedInUser) extends WrappedRequest[A](request) {
-  def declarationId: Option[String] = request.session.data.get(ExportsSessionKeys.declarationId)
+import scala.concurrent.ExecutionContext
+
+trait ItemActionMocks extends JourneyActionMocks with MockAuthAction { self: MockitoSugar with Suite with BeforeAndAfterEach =>
+
+  val mockItemAction = new ItemActionBuilder(mockAuthAction, mockJourneyAction)(ExecutionContext.global)
 }

--- a/test/unit/mock/ItemActionMocks.scala
+++ b/test/unit/mock/ItemActionMocks.scala
@@ -19,7 +19,7 @@ package unit.mock
 import base.MockAuthAction
 import controllers.actions.ItemActionBuilder
 import org.scalatest.{BeforeAndAfterEach, Suite}
-import org.scalatest.mockito.MockitoSugar
+import org.scalatestplus.mockito.MockitoSugar
 
 import scala.concurrent.ExecutionContext
 

--- a/test/views/ChoiceViewSpec.scala
+++ b/test/views/ChoiceViewSpec.scala
@@ -25,14 +25,14 @@ import play.api.data.Form
 import play.api.{Configuration, Environment}
 import play.twirl.api.Html
 import uk.gov.hmrc.play.bootstrap.config.{RunMode, ServicesConfig}
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.{choice_page, main_template}
 import views.tags.ViewTest
 
 import scala.collection.JavaConversions._
 
 @ViewTest
-class ChoiceViewSpec extends ViewSpec with ChoiceMessages with CommonMessages {
+class ChoiceViewSpec extends AppViewSpec with ChoiceMessages with CommonMessages {
 
   private val form: Form[Choice] = Choice.form()
   private val choicePage = app.injector.instanceOf[choice_page]

--- a/test/views/NotificationsViewSpec.scala
+++ b/test/views/NotificationsViewSpec.scala
@@ -23,12 +23,12 @@ import controllers.routes
 import models.declaration.notifications.Notification
 import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
 import org.jsoup.nodes.Document
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.submission_notifications
 import views.tags.ViewTest
 
 @ViewTest
-class NotificationsViewSpec extends ViewSpec {
+class NotificationsViewSpec extends AppViewSpec {
 
   private val page = app.injector.instanceOf[submission_notifications]
   private val actions = Action(RequestType.SubmissionRequest, UUID.randomUUID().toString)

--- a/test/views/RemoveSavedDeclarationsViewSpec.scala
+++ b/test/views/RemoveSavedDeclarationsViewSpec.scala
@@ -27,12 +27,12 @@ import models.{DeclarationStatus, ExportsDeclaration}
 import org.jsoup.nodes.{Document, Element}
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
 import views.html.remove_declaration
 import views.tags.ViewTest
+import views.declaration.spec.AppViewSpec
 
 @ViewTest
-class RemoveSavedDeclarationsViewSpec extends ViewSpec with CommonMessages {
+class RemoveSavedDeclarationsViewSpec extends AppViewSpec with CommonMessages {
 
   val title: String = "saved.declarations.remove.title"
   val ducr: String = "saved.declarations.ducr"
@@ -81,9 +81,9 @@ class RemoveSavedDeclarationsViewSpec extends ViewSpec with CommonMessages {
 
   private def numberOfTableRows(view: Html) = view.getElementsByClass("table-row").size() - 1
 
-  private def tableCell(view: Document)(row: Int, column: Int): Element =
+  private def tableCell(view: Html)(row: Int, column: Int): Element =
     view
-      .select(".table-row")
+      .getElementsByClass("table-row")
       .get(row)
       .getElementsByClass("table-cell")
       .get(column)

--- a/test/views/SavedDeclarationsViewSpec.scala
+++ b/test/views/SavedDeclarationsViewSpec.scala
@@ -26,12 +26,12 @@ import helpers.views.declaration.CommonMessages
 import models.{DeclarationStatus, ExportsDeclaration, Page, Paginated}
 import org.jsoup.nodes.Element
 import play.twirl.api.{Html, HtmlFormat}
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.saved_declarations
 import views.tags.ViewTest
 
 @ViewTest
-class SavedDeclarationsViewSpec extends ViewSpec with CommonMessages {
+class SavedDeclarationsViewSpec extends AppViewSpec with CommonMessages {
 
   val title: String = "saved.declarations.title"
   val ducr: String = "saved.declarations.ducr"

--- a/test/views/StartViewSpec.scala
+++ b/test/views/StartViewSpec.scala
@@ -18,12 +18,12 @@ package views
 
 import helpers.views.declaration.StartMessages
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.start_page
 import views.tags.ViewTest
 
 @ViewTest
-class StartViewSpec extends ViewSpec with StartMessages {
+class StartViewSpec extends AppViewSpec with StartMessages {
 
   private val startPage = app.injector.instanceOf[start_page]
   private def createView(): Html = startPage()

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -25,12 +25,12 @@ import models.declaration.submissions.{Action, Submission}
 import models.declaration.submissions.RequestType.{CancellationRequest, SubmissionRequest}
 import org.jsoup.nodes.Element
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.submissions
 import views.tags.ViewTest
 
 @ViewTest
-class SubmissionsViewSpec extends ViewSpec with SubmissionsMessages with CommonMessages {
+class SubmissionsViewSpec extends AppViewSpec with SubmissionsMessages with CommonMessages {
 
   private val submissionsPage = app.injector.instanceOf[submissions]
   private def createView(data: Seq[(Submission, Seq[Notification])] = Seq.empty): Html = submissionsPage(data)

--- a/test/views/cancellation/CancelDeclarationViewSpec.scala
+++ b/test/views/cancellation/CancelDeclarationViewSpec.scala
@@ -22,12 +22,12 @@ import forms.cancellation.CancellationChangeReason.NoLongerRequired
 import helpers.views.declaration.CommonMessages
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.cancel_declaration
 import views.tags.ViewTest
 
 @ViewTest
-class CancelDeclarationViewSpec extends ViewSpec with CommonMessages {
+class CancelDeclarationViewSpec extends AppViewSpec with CommonMessages {
 
   private val form: Form[CancelDeclaration] = CancelDeclaration.form
   private val cancelDeclarationPage = app.injector.instanceOf[cancel_declaration]

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -29,7 +29,8 @@ import views.html.declaration.additional_fiscal_references
 import views.tags.ViewTest
 
 @ViewTest
-class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with ViewMatchers with AdditionalFiscalReferencesMessages with CommonMessages {
+class AdditionalFiscalReferencesViewSpec
+    extends UnitViewSpec with Stubs with ViewMatchers with AdditionalFiscalReferencesMessages with CommonMessages {
 
   private val form: Form[AdditionalFiscalReference] = AdditionalFiscalReference.form()
 
@@ -67,10 +68,12 @@ class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with Vi
 
     "display 'Back' button to Fiscal Information page" in {
 
-      val backButton = view.getElementById( "link-back")
+      val backButton = view.getElementById("link-back")
 
       backButton.text() must be(backCaption)
-      backButton must haveHref(controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId))
+      backButton must haveHref(
+        controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId)
+      )
     }
 
     "display 'Save and continue' button" in {
@@ -89,9 +92,18 @@ class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with Vi
 
   "Additional Fiscal References" should {
 
+    val view = createView(references = Seq(AdditionalFiscalReference("FR", "12345")))
+
     "display references" in {
-      val view = createView(references = Seq(AdditionalFiscalReference("FR", "12345")))
       view.text() must include("FR12345")
+
+    }
+
+    "display remove button" in {
+      view.getElementsByAttributeValue("value", "site.remove").first() must submitTo(
+        controllers.declaration.routes.AdditionalFiscalReferencesController
+          .removeReference(Mode.Normal, itemId, "FR12345")
+      )
     }
   }
 

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -150,5 +150,4 @@ class AdditionalFiscalReferencesViewSpec extends AppViewSpec with AdditionalFisc
 
     }
   }
-
 }

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -98,7 +98,7 @@ class AdditionalFiscalReferencesViewSpec extends ViewSpec with AdditionalFiscalR
       val view = createView(references = Seq(AdditionalFiscalReference("FR", "12345")))
 
       view.body must include("FR12345")
-    }
+    } 
   }
 
   "Additional Fiscal References for invalid input" should {

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -23,12 +23,12 @@ import models.Mode
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.additional_fiscal_references
 import views.tags.ViewTest
 
 @ViewTest
-class AdditionalFiscalReferencesViewSpec extends ViewSpec with AdditionalFiscalReferencesMessages with CommonMessages {
+class AdditionalFiscalReferencesViewSpec extends AppViewSpec with AdditionalFiscalReferencesMessages with CommonMessages {
 
   private val form: Form[AdditionalFiscalReference] = AdditionalFiscalReference.form()
   private val additionalFiscalReferencesPage = app.injector.instanceOf[additional_fiscal_references]

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -23,12 +23,12 @@ import models.Mode
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.additional_information
 import views.tags.ViewTest
 
 @ViewTest
-class AdditionalInformationViewSpec extends ViewSpec with AdditionalInformationMessages with CommonMessages {
+class AdditionalInformationViewSpec extends AppViewSpec with AdditionalInformationMessages with CommonMessages {
 
   private val form: Form[AdditionalInformation] = AdditionalInformation.form()
   private val additionalInformationPage = app.injector.instanceOf[additional_information]

--- a/test/views/declaration/BorderTransportViewSpec.scala
+++ b/test/views/declaration/BorderTransportViewSpec.scala
@@ -21,7 +21,7 @@ import forms.declaration.BorderTransport
 import helpers.views.declaration.CommonMessages
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.border_transport
 import views.tags.ViewTest
 import views.html.components.fields.field_text
@@ -98,7 +98,7 @@ class BorderTransportViewSpec extends BorderTransportFields with CommonMessages 
 
 }
 
-trait BorderTransportFields extends ViewSpec {
+trait BorderTransportFields extends AppViewSpec {
   val form: Form[BorderTransport] = BorderTransport.form()
 
   val expBorderModeOfTransportCode = field_radio(

--- a/test/views/declaration/CarrierDetailsViewSpec.scala
+++ b/test/views/declaration/CarrierDetailsViewSpec.scala
@@ -24,12 +24,12 @@ import helpers.views.declaration.{CarrierDetailsMessages, CommonMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.carrier_details
 import views.tags.ViewTest
 
 @ViewTest
-class CarrierDetailsViewSpec extends ViewSpec with CarrierDetailsMessages with CommonMessages {
+class CarrierDetailsViewSpec extends AppViewSpec with CarrierDetailsMessages with CommonMessages {
 
   val form: Form[CarrierDetails] = CarrierDetails.form()
   private val carrierDetailsPage = app.injector.instanceOf[carrier_details]

--- a/test/views/declaration/CommodityMeasureViewSpec.scala
+++ b/test/views/declaration/CommodityMeasureViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommodityMeasureMessages, CommonMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.goods_measure
 import views.tags.ViewTest
 
 @ViewTest
-class CommodityMeasureViewSpec extends ViewSpec with CommodityMeasureMessages with CommonMessages {
+class CommodityMeasureViewSpec extends AppViewSpec with CommodityMeasureMessages with CommonMessages {
 
   private val form: Form[CommodityMeasure] = CommodityMeasure.form()
   private val goodsMeasurePage = app.injector.instanceOf[goods_measure]

--- a/test/views/declaration/ConsigneeDetailsViewSpec.scala
+++ b/test/views/declaration/ConsigneeDetailsViewSpec.scala
@@ -24,12 +24,12 @@ import helpers.views.declaration.{CommonMessages, ConsigneeDetailsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.consignee_details
 import views.tags.ViewTest
 
 @ViewTest
-class ConsigneeDetailsViewSpec extends ViewSpec with ConsigneeDetailsMessages with CommonMessages {
+class ConsigneeDetailsViewSpec extends AppViewSpec with ConsigneeDetailsMessages with CommonMessages {
 
   val form: Form[ConsigneeDetails] = ConsigneeDetails.form()
   val consigneeDetailsPage = app.injector.instanceOf[consignee_details]

--- a/test/views/declaration/ConsignmentReferencesViewSpec.scala
+++ b/test/views/declaration/ConsignmentReferencesViewSpec.scala
@@ -24,12 +24,12 @@ import helpers.views.declaration.{CommonMessages, ConsignmentReferencesMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.consignment_references
 import views.tags.ViewTest
 
 @ViewTest
-class ConsignmentReferencesViewSpec extends ViewSpec with ConsignmentReferencesMessages with CommonMessages {
+class ConsignmentReferencesViewSpec extends AppViewSpec with ConsignmentReferencesMessages with CommonMessages {
 
   /*
    * Seems like DUCR is Declaration UCR which is alphanumeric number up to 35 digits

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -25,12 +25,12 @@ import helpers.views.declaration.{CommonMessages, DeclarantDetailsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.declarant_details
 import views.tags.ViewTest
 
 @ViewTest
-class DeclarantDetailsViewSpec extends ViewSpec with DeclarantDetailsMessages with CommonMessages {
+class DeclarantDetailsViewSpec extends AppViewSpec with DeclarantDetailsMessages with CommonMessages {
 
   private val form: Form[DeclarantDetails] = DeclarantDetails.form()
   private val declarantDetailsPage = app.injector.instanceOf[declarant_details]

--- a/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
@@ -24,13 +24,13 @@ import helpers.views.declaration.{CommonMessages, DeclarationAdditionalActorsMes
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.declaration_additional_actors
 import views.tags.ViewTest
 
 @ViewTest
 class DeclarationAdditionalActorsViewSpec
-    extends ViewSpec with DeclarationAdditionalActorsMessages with CommonMessages {
+    extends AppViewSpec with DeclarationAdditionalActorsMessages with CommonMessages {
 
   private val form: Form[DeclarationAdditionalActors] = DeclarationAdditionalActors.form()
   private val declarationAdditionalActorsPage = app.injector.instanceOf[declaration_additional_actors]

--- a/test/views/declaration/DeclarationHolderViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderViewSpec.scala
@@ -23,12 +23,12 @@ import helpers.views.declaration.{CommonMessages, DeclarationHolderMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.declaration_holder
 import views.tags.ViewTest
 
 @ViewTest
-class DeclarationHolderViewSpec extends ViewSpec with DeclarationHolderMessages with CommonMessages {
+class DeclarationHolderViewSpec extends AppViewSpec with DeclarationHolderMessages with CommonMessages {
 
   private val form: Form[DeclarationHolder] = DeclarationHolder.form()
   private val declarationHolderPage = app.injector.instanceOf[declaration_holder]

--- a/test/views/declaration/DestinationCountriesViewSpec.scala
+++ b/test/views/declaration/DestinationCountriesViewSpec.scala
@@ -23,12 +23,12 @@ import helpers.views.declaration.{CommonMessages, DestinationCountriesMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.destination_countries_supplementary
 import views.tags.ViewTest
 
 @ViewTest
-class DestinationCountriesViewSpec extends ViewSpec with DestinationCountriesMessages with CommonMessages {
+class DestinationCountriesViewSpec extends AppViewSpec with DestinationCountriesMessages with CommonMessages {
 
   private val form: Form[DestinationCountries] = DestinationCountries.Supplementary.form
   private val destiantionCountriesSupplementaryPage = app.injector.instanceOf[destination_countries_supplementary]

--- a/test/views/declaration/DispatchLocationViewSpec.scala
+++ b/test/views/declaration/DispatchLocationViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.{CommonMessages, DispatchLocationMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.dispatch_location
 import views.tags.ViewTest
 
 @ViewTest
-class DispatchLocationViewSpec extends ViewSpec with DispatchLocationMessages with CommonMessages {
+class DispatchLocationViewSpec extends AppViewSpec with DispatchLocationMessages with CommonMessages {
 
   private val form: Form[DispatchLocation] = DispatchLocation.form()
   private val dispatchLocationPage = app.injector.instanceOf[dispatch_location]

--- a/test/views/declaration/DocumentsProducedViewSpec.scala
+++ b/test/views/declaration/DocumentsProducedViewSpec.scala
@@ -37,7 +37,8 @@ import views.html.declaration.documents_produced
 import views.tags.ViewTest
 
 @ViewTest
-class DocumentsProducedViewSpec extends AppViewSpec with DocumentsProducedMessages with DateMessages with CommonMessages {
+class DocumentsProducedViewSpec
+    extends AppViewSpec with DocumentsProducedMessages with DateMessages with CommonMessages {
 
   private val form: Form[DocumentsProduced] = DocumentsProduced.form()
   private val documentsProducedPage = app.injector.instanceOf[documents_produced]

--- a/test/views/declaration/DocumentsProducedViewSpec.scala
+++ b/test/views/declaration/DocumentsProducedViewSpec.scala
@@ -32,12 +32,12 @@ import models.Mode
 import play.api.data.Form
 import play.api.libs.json.Json
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.documents_produced
 import views.tags.ViewTest
 
 @ViewTest
-class DocumentsProducedViewSpec extends ViewSpec with DocumentsProducedMessages with DateMessages with CommonMessages {
+class DocumentsProducedViewSpec extends AppViewSpec with DocumentsProducedMessages with DateMessages with CommonMessages {
 
   private val form: Form[DocumentsProduced] = DocumentsProduced.form()
   private val documentsProducedPage = app.injector.instanceOf[documents_produced]

--- a/test/views/declaration/DraftConfirmationViewSpec.scala
+++ b/test/views/declaration/DraftConfirmationViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.CommonMessages
 import models.responses.FlashKeys
 import play.api.mvc.Flash
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.draft_confirmation_page
 import views.tags.ViewTest
 
 @ViewTest
-class DraftConfirmationViewSpec extends ViewSpec with CommonMessages {
+class DraftConfirmationViewSpec extends AppViewSpec with CommonMessages {
 
   private val page = app.injector.instanceOf[draft_confirmation_page]
   private def createView(flash: (String, String)*): Html = page()(fakeRequest, Flash(Map(flash: _*)), messages)

--- a/test/views/declaration/ExporterDetailsViewSpec.scala
+++ b/test/views/declaration/ExporterDetailsViewSpec.scala
@@ -24,12 +24,12 @@ import helpers.views.declaration.{CommonMessages, ExporterDetailsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.exporter_details
 import views.tags.ViewTest
 
 @ViewTest
-class ExporterDetailsViewSpec extends ViewSpec with ExporterDetailsMessages with CommonMessages {
+class ExporterDetailsViewSpec extends AppViewSpec with ExporterDetailsMessages with CommonMessages {
 
   private val form: Form[ExporterDetails] = ExporterDetails.form()
   private val exporterDetailsPage = app.injector.instanceOf[exporter_details]

--- a/test/views/declaration/FiscalInformationViewSpec.scala
+++ b/test/views/declaration/FiscalInformationViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.{CommonMessages, FiscalInformationMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.fiscal_information
 import views.tags.ViewTest
 
 @ViewTest
-class FiscalInformationViewSpec extends ViewSpec with FiscalInformationMessages with CommonMessages {
+class FiscalInformationViewSpec extends AppViewSpec with FiscalInformationMessages with CommonMessages {
 
   private val form: Form[FiscalInformation] = FiscalInformation.form()
   private val fiscalInformationPage = app.injector.instanceOf[fiscal_information]

--- a/test/views/declaration/ItemSummaryViewSpec.scala
+++ b/test/views/declaration/ItemSummaryViewSpec.scala
@@ -23,12 +23,12 @@ import models.Mode
 import models.declaration.ProcedureCodesData
 import org.jsoup.nodes.Document
 import services.cache.ExportItem
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.items_summary
 import views.tags.ViewTest
 
 @ViewTest
-class ItemSummaryViewSpec extends ViewSpec with ItemSummaryMessages {
+class ItemSummaryViewSpec extends AppViewSpec with ItemSummaryMessages {
 
   private val confirmationPage = app.injector.instanceOf[items_summary]
   private def view(items: List[ExportItem]): Document = confirmationPage(Mode.Normal, items)(fakeRequest, messages)

--- a/test/views/declaration/ItemTypeViewSpec.scala
+++ b/test/views/declaration/ItemTypeViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.{CommonMessages, ItemTypeMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.item_type
 import views.tags.ViewTest
 
 @ViewTest
-class ItemTypeViewSpec extends ViewSpec with ItemTypeMessages with CommonMessages {
+class ItemTypeViewSpec extends AppViewSpec with ItemTypeMessages with CommonMessages {
 
   private val form: Form[ItemType] = ItemType.form()
   private val itemTypePage = app.injector.instanceOf[item_type]

--- a/test/views/declaration/LocationViewSpec.scala
+++ b/test/views/declaration/LocationViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.{CommonMessages, LocationOfGoodsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.goods_location
 import views.tags.ViewTest
 
 @ViewTest
-class LocationViewSpec extends ViewSpec with LocationOfGoodsMessages with CommonMessages {
+class LocationViewSpec extends AppViewSpec with LocationOfGoodsMessages with CommonMessages {
 
   private val form: Form[GoodsLocation] = GoodsLocation.form()
   private val goodsLocationPage = app.injector.instanceOf[goods_location]

--- a/test/views/declaration/NatureOfTransactionViewSpec.scala
+++ b/test/views/declaration/NatureOfTransactionViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, NatureOfTransactionMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.nature_of_transaction
 import views.tags.ViewTest
 
 @ViewTest
-class NatureOfTransactionViewSpec extends ViewSpec with NatureOfTransactionMessages with CommonMessages {
+class NatureOfTransactionViewSpec extends AppViewSpec with NatureOfTransactionMessages with CommonMessages {
 
   private val form: Form[NatureOfTransaction] = NatureOfTransaction.form()
   private val natureOfTransactionPage = app.injector.instanceOf[nature_of_transaction]

--- a/test/views/declaration/NotEligibleViewSpec.scala
+++ b/test/views/declaration/NotEligibleViewSpec.scala
@@ -19,11 +19,11 @@ package views.declaration
 import helpers.views.declaration.{CommonMessages, NotEligibleMessages}
 import play.twirl.api.Html
 import views.html.declaration.not_eligible
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.tags.ViewTest
 
 @ViewTest
-class NotEligibleViewSpec extends ViewSpec with NotEligibleMessages with CommonMessages {
+class NotEligibleViewSpec extends AppViewSpec with NotEligibleMessages with CommonMessages {
 
   private val notEligiblePage = app.injector.instanceOf[not_eligible]
   private def createView(): Html = notEligiblePage()(fakeRequest, messages)

--- a/test/views/declaration/OfficeOfExitStandardViewSpec.scala
+++ b/test/views/declaration/OfficeOfExitStandardViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, OfficeOfExitMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.office_of_exit_standard
 import views.tags.ViewTest
 
 @ViewTest
-class OfficeOfExitStandardViewSpec extends ViewSpec with OfficeOfExitMessages with CommonMessages {
+class OfficeOfExitStandardViewSpec extends AppViewSpec with OfficeOfExitMessages with CommonMessages {
 
   private val form: Form[OfficeOfExitStandard] = OfficeOfExitForms.standardForm()
   private val officeOfExitStandardPage = app.injector.instanceOf[office_of_exit_standard]

--- a/test/views/declaration/OfficeOfExitSupplementaryViewSpec.scala
+++ b/test/views/declaration/OfficeOfExitSupplementaryViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, OfficeOfExitMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.office_of_exit_supplementary
 import views.tags.ViewTest
 
 @ViewTest
-class OfficeOfExitSupplementaryViewSpec extends ViewSpec with OfficeOfExitMessages with CommonMessages {
+class OfficeOfExitSupplementaryViewSpec extends AppViewSpec with OfficeOfExitMessages with CommonMessages {
 
   private val form: Form[OfficeOfExitSupplementary] = OfficeOfExitForms.supplementaryForm()
   private val officeOfExitSupplementary = app.injector.instanceOf[office_of_exit_supplementary]

--- a/test/views/declaration/PackageInformationViewSpec.scala
+++ b/test/views/declaration/PackageInformationViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, PackageInformationMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.package_information
 import views.tags.ViewTest
 
 @ViewTest
-class PackageInformationViewSpec extends ViewSpec with PackageInformationMessages with CommonMessages {
+class PackageInformationViewSpec extends AppViewSpec with PackageInformationMessages with CommonMessages {
 
   private val form: Form[PackageInformation] = PackageInformation.form()
   private val packageInformationPage = app.injector.instanceOf[package_information]

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -21,11 +21,11 @@ import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
 import views.html.declaration.previous_documents
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.tags.ViewTest
 
 @ViewTest
-class PreviousDocumentsViewSpec extends ViewSpec with PreviousDocumentsMessages with CommonMessages {
+class PreviousDocumentsViewSpec extends AppViewSpec with PreviousDocumentsMessages with CommonMessages {
 
   private val form: Form[Document] = Document.form()
   private val previousDocumentsPage = app.injector.instanceOf[previous_documents]

--- a/test/views/declaration/ProcedureCodesViewSpec.scala
+++ b/test/views/declaration/ProcedureCodesViewSpec.scala
@@ -22,11 +22,11 @@ import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
 import views.html.declaration.procedure_codes
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.tags.ViewTest
 
 @ViewTest
-class ProcedureCodesViewSpec extends ViewSpec with ProcedureCodesMessages with CommonMessages {
+class ProcedureCodesViewSpec extends AppViewSpec with ProcedureCodesMessages with CommonMessages {
 
   private val form: Form[ProcedureCodes] = ProcedureCodes.form()
   private val procedureCodesPage = app.injector.instanceOf[procedure_codes]

--- a/test/views/declaration/RepresentativeDetailsViewSpec.scala
+++ b/test/views/declaration/RepresentativeDetailsViewSpec.scala
@@ -22,12 +22,12 @@ import helpers.views.declaration.{CommonMessages, RepresentativeDetailsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.representative_details
 import views.tags.ViewTest
 
 @ViewTest
-class RepresentativeDetailsViewSpec extends ViewSpec with RepresentativeDetailsMessages with CommonMessages {
+class RepresentativeDetailsViewSpec extends AppViewSpec with RepresentativeDetailsMessages with CommonMessages {
 
   private val form: Form[RepresentativeDetails] = RepresentativeDetails.form()
   private val representativeDetailsPage = app.injector.instanceOf[representative_details]

--- a/test/views/declaration/SealViewSpec.scala
+++ b/test/views/declaration/SealViewSpec.scala
@@ -21,7 +21,7 @@ import helpers.views.declaration.CommonMessages
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.seal
 import views.tags.ViewTest
 import views.html.components.fields.field_text
@@ -73,7 +73,7 @@ class SealViewSpec extends SealFields with CommonMessages {
   }
 }
 
-trait SealFields extends ViewSpec {
+trait SealFields extends AppViewSpec {
   val form: Form[Seal] = Seal.form()
 
   val id = field_text(field = form("id"), label = "7/18 Seal identification number").body

--- a/test/views/declaration/SubmissionConfirmationPageViewSpec.scala
+++ b/test/views/declaration/SubmissionConfirmationPageViewSpec.scala
@@ -19,11 +19,11 @@ import helpers.views.declaration.ConfirmationMessages
 import play.api.mvc.Flash
 import play.twirl.api.Html
 import views.html.declaration.submission_confirmation_page
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.tags.ViewTest
 
 @ViewTest
-class SubmissionConfirmationPageViewSpec extends ViewSpec with ConfirmationMessages {
+class SubmissionConfirmationPageViewSpec extends AppViewSpec with ConfirmationMessages {
 
   private val confirmationPage = app.injector.instanceOf[submission_confirmation_page]
   private def createView(): Html = confirmationPage()(fakeRequest, flash, messages)

--- a/test/views/declaration/TotalNumberOfItemsViewSpec.scala
+++ b/test/views/declaration/TotalNumberOfItemsViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, TotalNumberOfItemsMessages}
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.total_number_of_items
 import views.tags.ViewTest
 
 @ViewTest
-class TotalNumberOfItemsViewSpec extends ViewSpec with TotalNumberOfItemsMessages with CommonMessages {
+class TotalNumberOfItemsViewSpec extends AppViewSpec with TotalNumberOfItemsMessages with CommonMessages {
 
   private val form: Form[TotalNumberOfItems] = TotalNumberOfItems.form()
   private val totalNumberOfItemsPage = app.injector.instanceOf[total_number_of_items]

--- a/test/views/declaration/TransportDetailsViewSpec.scala
+++ b/test/views/declaration/TransportDetailsViewSpec.scala
@@ -27,7 +27,7 @@ import play.twirl.api.Html
 import services.Countries
 import services.view.AutoCompleteItem
 import views.components.inputs.RadioOption
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.components.fields.field_text
 import views.html.components.fields.{field_autocomplete, field_radio}
 import views.html.declaration.transport_details
@@ -90,7 +90,7 @@ class TransportDetailsViewSpec extends TransportDetailsFields with CommonMessage
 
 }
 
-trait TransportDetailsFields extends ViewSpec {
+trait TransportDetailsFields extends AppViewSpec {
   val form: Form[TransportDetails] = TransportDetails.form()
 
   val meansOfTransportCrossingTheBorderNationality = field_autocomplete(

--- a/test/views/declaration/TransportInformationContainersViewSpec.scala
+++ b/test/views/declaration/TransportInformationContainersViewSpec.scala
@@ -21,13 +21,13 @@ import helpers.views.declaration.{CommonMessages, TransportInformationContainerM
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.add_transport_containers
 import views.tags.ViewTest
 
 @ViewTest
 class TransportInformationContainersViewSpec
-    extends ViewSpec with TransportInformationContainerMessages with CommonMessages {
+    extends AppViewSpec with TransportInformationContainerMessages with CommonMessages {
 
   private val form: Form[TransportInformationContainer] = TransportInformationContainer.form()
   private val transportContainersPage = app.injector.instanceOf[add_transport_containers]

--- a/test/views/declaration/WarehouseIdentificationViewSpec.scala
+++ b/test/views/declaration/WarehouseIdentificationViewSpec.scala
@@ -21,12 +21,12 @@ import helpers.views.declaration.{CommonMessages, WarehouseIdentificationMessage
 import models.Mode
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.warehouse_identification
 import views.tags.ViewTest
 
 @ViewTest
-class WarehouseIdentificationViewSpec extends ViewSpec with WarehouseIdentificationMessages with CommonMessages {
+class WarehouseIdentificationViewSpec extends AppViewSpec with WarehouseIdentificationMessages with CommonMessages {
 
   private val form: Form[WarehouseIdentification] = WarehouseIdentification.form()
 

--- a/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
+++ b/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
@@ -30,12 +30,12 @@ import models.Mode
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.additionaldeclarationtype.declaration_type
 import views.tags.ViewTest
 
 @ViewTest
-class DeclarationTypeViewSpec extends ViewSpec with DeclarationTypeMessages with CommonMessages {
+class DeclarationTypeViewSpec extends AppViewSpec with DeclarationTypeMessages with CommonMessages {
 
   private val formStandard: Form[AdditionalDeclarationType] = AdditionalDeclarationTypeStandardDec.form()
   private val formSupplementary: Form[AdditionalDeclarationType] = AdditionalDeclarationTypeSupplementaryDec.form()

--- a/test/views/declaration/spec/AppViewSpec.scala
+++ b/test/views/declaration/spec/AppViewSpec.scala
@@ -31,6 +31,7 @@ import play.api.mvc.{AnyContentAsEmpty, Flash, Request}
 import play.api.test.FakeRequest
 import utils.FakeRequestCSRFSupport._
 
+@deprecated("Please use unit UnitViewSpec", since = "2019-08-28")
 trait AppViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with ViewMatchers {
 
   lazy val basePrefix = "supplementary."

--- a/test/views/declaration/spec/AppViewSpec.scala
+++ b/test/views/declaration/spec/AppViewSpec.scala
@@ -31,7 +31,7 @@ import play.api.mvc.{AnyContentAsEmpty, Flash, Request}
 import play.api.test.FakeRequest
 import utils.FakeRequestCSRFSupport._
 
-trait ViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with ViewMatchers {
+trait AppViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with ViewMatchers {
 
   lazy val basePrefix = "supplementary."
   lazy val addressPrefix = "supplementary.address."

--- a/test/views/declaration/spec/UnitViewSpec.scala
+++ b/test/views/declaration/spec/UnitViewSpec.scala
@@ -21,7 +21,7 @@ import play.api.mvc.{AnyContent, Request}
 import play.api.test.{FakeRequest, Helpers}
 import unit.base.UnitSpec
 
-class UnitViewSpec extends UnitSpec {
+class UnitViewSpec extends UnitSpec with ViewMatchers {
 
   import utils.FakeRequestCSRFSupport._
 

--- a/test/views/declaration/spec/UnitViewSpec.scala
+++ b/test/views/declaration/spec/UnitViewSpec.scala
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration.spec
+
+import play.api.i18n.Messages
+import play.api.mvc.{AnyContent, Request}
+import play.api.test.{FakeRequest, Helpers}
+import unit.base.UnitSpec
+
+class UnitViewSpec extends UnitSpec {
+
+  import utils.FakeRequestCSRFSupport._
+
+  implicit val request: Request[AnyContent] = FakeRequest().withCSRFToken
+
+  implicit val messages: Messages = Helpers.stubMessages()
+}

--- a/test/views/declaration/spec/ViewMatchers.scala
+++ b/test/views/declaration/spec/ViewMatchers.scala
@@ -53,7 +53,7 @@ trait ViewMatchers {
   implicit protected def htmlBodyOf(page: String): Document = Jsoup.parse(page)
   implicit protected def htmlBodyOf(result: Future[Result]): Document = htmlBodyOf(contentAsString(result))
 
-  private def actualContentWas(node: Element): String =
+    private def actualContentWas(node: Element): String =
     if (node == null) {
       "Element did not exist"
     } else {

--- a/test/views/declaration/spec/ViewMatchers.scala
+++ b/test/views/declaration/spec/ViewMatchers.scala
@@ -35,7 +35,9 @@ package views.declaration.spec
 import org.jsoup.Jsoup
 import org.jsoup.nodes.{Document, Element}
 import org.jsoup.select.Elements
+import org.scalatest.MustMatchers
 import org.scalatest.matchers._
+import play.api.i18n.Messages
 import play.api.mvc.{Call, Result}
 import play.api.test.Helpers.contentAsString
 import play.twirl.api.Html
@@ -53,7 +55,14 @@ trait ViewMatchers {
   implicit protected def htmlBodyOf(page: String): Document = Jsoup.parse(page)
   implicit protected def htmlBodyOf(result: Future[Result]): Document = htmlBodyOf(contentAsString(result))
 
-    private def actualContentWas(node: Element): String =
+  implicit class PageComplexChecks(document: Document) extends MustMatchers {
+    def checkErrorsSummary(): Unit = {
+      document.getElementById("error-summary-heading").text() mustBe "error.summary.title"
+      document.select("div.error-summary.error-summary--show>p").text() must be("error.summary.text")
+    }
+  }
+
+  private def actualContentWas(node: Element): String =
     if (node == null) {
       "Element did not exist"
     } else {
@@ -244,5 +253,5 @@ trait ViewMatchers {
       link
     )
 
-  def haveGlobalErrorSummary: Matcher[Element] = new ContainElementWithIDMatcher("error-summary-heading")
+  def haveGlobalErrorSummary: Matcher[Document] = new ContainElementWithIDMatcher("error-summary-heading")
 }

--- a/test/views/declaration/spec/ViewMatchers.scala
+++ b/test/views/declaration/spec/ViewMatchers.scala
@@ -254,4 +254,19 @@ trait ViewMatchers {
     )
 
   def haveGlobalErrorSummary: Matcher[Document] = new ContainElementWithIDMatcher("error-summary-heading")
+
+  class FormSubmitTo(path: String) extends Matcher[Element] {
+    override def apply(left: Element): MatchResult = {
+      val action = left.attr("action")
+      val formaction = left.attr("formaction")
+      MatchResult(
+        action == path || formaction == path,
+        s"Element ${left} does not submit to {$path}",
+        s"Element ${left} does submit to {$path}"
+      )
+    }
+  }
+
+  def submitTo(path: String): Matcher[Element] = new FormSubmitTo(path)
+  def submitTo(call: Call): Matcher[Element] = new FormSubmitTo(call.url)
 }

--- a/test/views/declaration/spec/ViewSpec.scala
+++ b/test/views/declaration/spec/ViewSpec.scala
@@ -47,7 +47,7 @@ trait ViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with
 
   def fakeJourneyRequest(choice: String): JourneyRequest[AnyContentAsEmpty.type] = {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
-    JourneyRequest(AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), cache)
+    new JourneyRequest(new AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), cache)
   }
 
   SharedMetricRegistries.clear()

--- a/test/views/declaration/summary/PartiesSectionViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionViewSpec.scala
@@ -29,12 +29,12 @@ import helpers.views.declaration.summary.PartiesMessages
 import models.declaration.DeclarationAdditionalActorsDataSpec.correctAdditionalActorsData
 import models.declaration.{DeclarationHoldersData, Parties}
 import play.twirl.api.Html
-import views.declaration.spec.ViewSpec
+import views.declaration.spec.AppViewSpec
 import views.html.declaration.summary.parties_section
 import views.tags.ViewTest
 
 @ViewTest
-class PartiesSectionViewSpec extends ViewSpec with PartiesMessages {
+class PartiesSectionViewSpec extends AppViewSpec with PartiesMessages {
 
   private def createView(partiesOpt: Option[Parties] = None): Html = parties_section(partiesOpt)
 

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -64,7 +64,10 @@ class SummaryPageViewSpec
   "Summary page" should {
     def view(mode: Mode, declaration: ExportsDeclaration = declaration): Document =
       new summary_page(mainTemplate)(mode, SupplementaryDeclarationData(declaration))(
-        JourneyRequest(AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration),
+        new JourneyRequest(
+          new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")),
+          declaration
+        ),
         stubMessages(),
         minimalAppConfig
       )

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -48,7 +48,7 @@ class SummaryPageViewSpec
     withItem(anItem())
   )
   val request =
-    JourneyRequest(AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
+    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
   val summaryPage = contentAsString(
     new summary_page(mainTemplate)(Mode.Normal, SupplementaryDeclarationData(declaration))(
       request,

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -48,7 +48,10 @@ class SummaryPageViewSpec
     withItem(anItem())
   )
   val request =
-    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
+    new JourneyRequest(
+      new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")),
+      declaration
+    )
   val summaryPage = contentAsString(
     new summary_page(mainTemplate)(Mode.Normal, SupplementaryDeclarationData(declaration))(
       request,


### PR DESCRIPTION
Plus introducing ItemAction - would generalize flow for actions where we want to have item withId but such does not exist.

Introduce UnitViewSpec and rename old ViewSpec to AppViewSpec. 