### PR TITLE
CEDS-1511 Fix Save & Resume Button Location & Summary Page Links

### DIFF
--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -74,9 +74,9 @@ class SealController @Inject()(
       updatedCache =>
         if (updatedCache != cachedSeals) {
           updateCache(updatedCache).map { _ =>
-            navigator.continueTo(routes.SummaryController.displayPage(mode))
+            navigator.continueTo(routes.SummaryController.displayPage(Mode.Normal))
           }
-        } else Future.successful(navigator.continueTo(routes.SummaryController.displayPage(mode)))
+        } else Future.successful(navigator.continueTo(routes.SummaryController.displayPage(Mode.Normal)))
     )
 
   private def badRequest(mode: Mode, formWithErrors: Form[Seal], cachedSeals: Seq[Seal])(

--- a/app/controllers/declaration/TransportDetailsController.scala
+++ b/app/controllers/declaration/TransportDetailsController.scala
@@ -67,7 +67,7 @@ class TransportDetailsController @Inject()(
       navigator.continueTo(controllers.declaration.routes.TransportContainerController.displayPage(mode))
     else if (request.choice.value == AllowedChoiceValues.StandardDec)
       navigator.continueTo(controllers.declaration.routes.SealController.displayForm(mode))
-    else navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(mode))
+    else navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(Mode.Normal))
 
   private def updateCache(
     formData: TransportDetails

--- a/app/views/declaration/destination_countries_standard.scala.html
+++ b/app/views/declaration/destination_countries_standard.scala.html
@@ -77,9 +77,7 @@
             )
         </div>
 
-        <div class="section align='right'">
-            @components.buttons.save_and_continue_button()
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @components.submit_button()
+        @components.buttons.save_and_return_later_button()
     }
 }

--- a/test/unit/controllers/declaration/SealControllerSpec.scala
+++ b/test/unit/controllers/declaration/SealControllerSpec.scala
@@ -133,26 +133,48 @@ class SealControllerSpec extends ControllerSpec with ScalaFutures with ErrorHand
         thePageNavigatedTo mustBe controllers.declaration.routes.SealController.displayForm()
       }
 
-      "user clicked save and continue with data in form" in new SetUp {
+      "user clicked save and continue with data in form" when {
+        "in Draft Mode" in new SetUp {
+          val body = Seq("id" -> "value", (SaveAndContinue.toString, ""))
 
-        val body = Seq("id" -> "value", (SaveAndContinue.toString, ""))
+          val result = controller.submitForm(Mode.Draft)(postRequestAsFormUrlEncoded(body: _*))
 
-        val result = controller.submitForm(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        }
 
-        await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        "in Normal Mode" in new SetUp {
+          val body = Seq("id" -> "value", (SaveAndContinue.toString, ""))
+
+          val result = controller.submitForm(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        }
       }
 
-      "user clicked save and continue with item in a cache" in new SetUp {
+      "user clicked save and continue with item in a cache" when {
+        "in Draft Mode" in new SetUp {
+          withNewCaching(aDeclaration(withSeal(Seal("value"))))
 
-        withNewCaching(aDeclaration(withSeal(Seal("value"))))
+          val body = Seq((SaveAndContinue.toString, ""))
 
-        val body = Seq((SaveAndContinue.toString, ""))
+          val result = controller.submitForm(Mode.Draft)(postRequestAsFormUrlEncoded(body: _*))
 
-        val result = controller.submitForm(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        }
 
-        await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        "in Normal Mode" in new SetUp {
+          withNewCaching(aDeclaration(withSeal(Seal("value"))))
+
+          val body = Seq((SaveAndContinue.toString, ""))
+
+          val result = controller.submitForm(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+        }
       }
     }
   }

--- a/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -77,15 +77,24 @@ class TransportDetailsControllerSpec extends ControllerSpec {
       }
     }
 
-    "return 303 (SEE_OTHER)" in new SetUp {
+    "return 303 (SEE_OTHER)" when {
+      "Container is selected" in new SetUp {
+        val correctForm = Json.toJson(TransportDetails(Some("United Kingdom"), true, IMOShipIDNumber, Some("correct"), Some(cash)))
 
-      val correctForm =
-        Json.toJson(TransportDetails(Some("United Kingdom"), true, IMOShipIDNumber, Some("correct"), Some(cash)))
+        val result = controller.submitForm(Mode.Draft)(postRequest(correctForm))
 
-      val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.TransportContainerController.displayPage(Mode.Draft)
+      }
 
-      await(result) mustBe aRedirectToTheNextPage
-      thePageNavigatedTo mustBe controllers.declaration.routes.TransportContainerController.displayPage()
+      "Container is not selected" in new SetUp {
+        val correctForm = Json.toJson(TransportDetails(Some("United Kingdom"), false, IMOShipIDNumber, Some("correct"), Some(cash)))
+
+        val result = controller.submitForm(Mode.Draft)(postRequest(correctForm))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+      }
     }
   }
 }

--- a/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -79,7 +79,8 @@ class TransportDetailsControllerSpec extends ControllerSpec {
 
     "return 303 (SEE_OTHER)" when {
       "Container is selected" in new SetUp {
-        val correctForm = Json.toJson(TransportDetails(Some("United Kingdom"), true, IMOShipIDNumber, Some("correct"), Some(cash)))
+        val correctForm =
+          Json.toJson(TransportDetails(Some("United Kingdom"), true, IMOShipIDNumber, Some("correct"), Some(cash)))
 
         val result = controller.submitForm(Mode.Draft)(postRequest(correctForm))
 
@@ -88,7 +89,8 @@ class TransportDetailsControllerSpec extends ControllerSpec {
       }
 
       "Container is not selected" in new SetUp {
-        val correctForm = Json.toJson(TransportDetails(Some("United Kingdom"), false, IMOShipIDNumber, Some("correct"), Some(cash)))
+        val correctForm =
+          Json.toJson(TransportDetails(Some("United Kingdom"), false, IMOShipIDNumber, Some("correct"), Some(cash)))
 
         val result = controller.submitForm(Mode.Draft)(postRequest(correctForm))
 


### PR DESCRIPTION
When in Draft mode, at the end of the journey you would be taken to the `/saved-summary`, similar in Amend mode.
If you click "Save and continue" on the final page of the journey you are now always taken to `/summary` (your mode reverts to Normal)