### PR TITLE
CEDS-1558 Mode in action refiner spike

### DIFF
--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -20,6 +20,7 @@ import java.time.Instant
 
 import controllers.actions.AuthAction
 import controllers.declaration.ModelCacheable
+import controllers.navigation.StandardDeclarationJorney
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
 import forms.Choice._
@@ -70,11 +71,11 @@ class ChoiceController @Inject()(
               request.declarationId match {
                 case Some(id) =>
                   updateChoice(id, choice).map { _ =>
-                    Redirect(controllers.declaration.routes.DispatchLocationController.displayPage(Mode.Normal))
+                    StandardDeclarationJorney.start
                   }
                 case _ =>
                   create(choice) map { created =>
-                    Redirect(controllers.declaration.routes.DispatchLocationController.displayPage(Mode.Normal))
+                    StandardDeclarationJorney.start
                       .addingToSession(ExportsSessionKeys.declarationId -> created.id.get)
                   }
               }

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -42,14 +42,14 @@ class DispatchLocationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.dispatchLocation match {
       case Some(data) => Ok(dispatchLocationPage(DispatchLocation.form().fill(data)))
       case _          => Ok(dispatchLocationPage(DispatchLocation.form()))
     }
   }
 
-  def submitForm(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     DispatchLocation
       .form()
       .bindFromRequest()

--- a/app/controllers/navigation/StandardDeclarationJorney.scala
+++ b/app/controllers/navigation/StandardDeclarationJorney.scala
@@ -14,15 +14,16 @@
  * limitations under the License.
  */
 
-package models.requests
+package controllers.navigation
 
-import forms.Choice
-import models.{ExportsDeclaration, Mode}
-import play.api.mvc.WrappedRequest
+import models.Mode
+import play.api.mvc.Result
 
-case class JourneyRequest[A](authenticatedRequest: AuthenticatedRequest[A], cacheModel: ExportsDeclaration, mode: Mode)
-    extends WrappedRequest[A](authenticatedRequest) {
-  val choice: Choice = Choice(cacheModel.choice)
+import play.api.mvc.Results._
 
-  def declarationId: String = authenticatedRequest.declarationId.getOrElse(throw new IllegalAccessError)
+object StandardDeclarationJorney {
+  def start: Result = Redirect(
+    controllers.declaration.routes.DispatchLocationController.displayPage().path(),
+    Map("mode" -> Seq(Mode.Normal.name))
+  )
 }

--- a/app/views/components/declaration_form.scala.html
+++ b/app/views/components/declaration_form.scala.html
@@ -1,0 +1,22 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.requests.JourneyRequest
+@(callFactory: Mode => Call)(formBody: Html)(implicit request: JourneyRequest[_], messages: Messages)
+
+@helper.form(callFactory(request.mode), 'autoComplete -> "off"){
+  formBody(request.mode)
+}

--- a/app/views/components/journey_back.scala.html
+++ b/app/views/components/journey_back.scala.html
@@ -1,0 +1,23 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.Mode
+@import models.requests.JourneyRequest
+
+@* mode is not currently used but will be once we add "change field" links to the summary page *@
+@(hrefFactory: Mode => Call)(implicit request: JourneyRequest[_], messages: Messages)
+
+@components.back_link(hrefFactory(request.mode))

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -38,16 +38,17 @@
 @import views.components.fields.LabelledValue
 
 @import services.view.AutoCompleteItem
+@import models.requests.JourneyRequest
 
 @this(main_template: views.html.main_template)
 
-@(mode: Mode, itemId:String, form: Form[AdditionalFiscalReference], additionalReferences: Seq[AdditionalFiscalReference] = Seq.empty)(implicit request: Request[_], messages: Messages)
+@(mode: Mode, itemId:String, form: Form[AdditionalFiscalReference], additionalReferences: Seq[AdditionalFiscalReference] = Seq.empty)(implicit request: JourneyRequest[_], messages: Messages)
 
 @main_template(
     title = messages("declaration.additionalFiscalReferences.title")
 ) {
 
-    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
+    @components.journey_back(routes.FiscalInformationController.displayPage(_, itemId))
 
     @components.error_summary(form.errors)
 
@@ -60,7 +61,7 @@
         elements = additionalReferences.map(_.asString).map(ref => LabelledValue(ref))
     )
 
-    @helper.form(routes.AdditionalFiscalReferencesController.saveReferences(mode, itemId), 'autoComplete -> "off") {
+    @components.declaration_form(routes.AdditionalFiscalReferencesController.saveReferences(_, itemId)) {
         @helper.CSRF.formField
 
         <div id="country-of-dispatch-field">

--- a/app/views/declaration/additionaldeclarationtype/declaration_type.scala.html
+++ b/app/views/declaration/additionaldeclarationtype/declaration_type.scala.html
@@ -27,10 +27,9 @@
     title = messages("declaration.declarationType.title")
 ) {
 
-    @components.back_link(controllers.declaration.routes.DispatchLocationController.displayPage(), request.mode)
+    @components.journey_back(controllers.declaration.routes.DispatchLocationController.displayPage)
 
-    @defining(controllers.declaration.routes.AdditionalDeclarationTypeController.submitForm()){ call =>
-        <form method="@call.method" action="@call.url?mode=@request.mode.name" autocomplete="off">
+    @components.declaration_form(controllers.declaration.routes.AdditionalDeclarationTypeController.submitForm){
         @helper.CSRF.formField
 
         @components.error_summary(form.errors)

--- a/app/views/declaration/additionaldeclarationtype/declaration_type.scala.html
+++ b/app/views/declaration/additionaldeclarationtype/declaration_type.scala.html
@@ -27,9 +27,10 @@
     title = messages("declaration.declarationType.title")
 ) {
 
-    @components.back_link(controllers.declaration.routes.DispatchLocationController.displayPage(mode), mode)
+    @components.back_link(controllers.declaration.routes.DispatchLocationController.displayPage(), request.mode)
 
-    @helper.form(controllers.declaration.routes.AdditionalDeclarationTypeController.submitForm(mode), 'autoComplete -> "off") {
+    @defining(controllers.declaration.routes.AdditionalDeclarationTypeController.submitForm()){ call =>
+        <form method="@call.method" action="@call.url?mode=@request.mode.name" autocomplete="off">
         @helper.CSRF.formField
 
         @components.error_summary(form.errors)

--- a/app/views/declaration/dispatch_location.scala.html
+++ b/app/views/declaration/dispatch_location.scala.html
@@ -30,17 +30,14 @@
 
     @request.mode match {
         case Mode.Draft | Mode.Amend => {
-            @components.back_link(controllers.declaration.routes.SummaryController.displayPage(request.mode), request.mode)
+            @components.journey_back(controllers.declaration.routes.SummaryController.displayPage)
         }
         case Mode.Normal => {
-            @components.back_link(controllers.routes.ChoiceController.displayPage(), request.mode)
+            @components.back_link(controllers.routes.ChoiceController.displayPage())
         }
     }
 
-  @defining(controllers.declaration.routes.DispatchLocationController.submitForm()){ call =>
-
-  <form method="@call.method" action="@call.url?mode=@request.mode.name" autocomplete="off">
- @*   @helper.form(?mode=@request.mode.name, 'autoComplete -> "off") { *@
+  @components.declaration_form(controllers.declaration.routes.DispatchLocationController.submitForm){
     @helper.CSRF.formField
 
     @components.error_summary(form.errors)
@@ -68,6 +65,6 @@
 
     @components.submit_button()
     @components.buttons.save_and_return_later_button()
-  </form>
+
   }
 }

--- a/app/views/declaration/dispatch_location.scala.html
+++ b/app/views/declaration/dispatch_location.scala.html
@@ -18,26 +18,30 @@
 @import forms.declaration.DispatchLocation.AllowedDispatchLocations._
 @import uk.gov.hmrc.play.views.html._
 @import views.components.inputs.RadioOption
+@import models.requests.JourneyRequest
 
 @this(main_template: views.html.main_template)
 
-@(mode: Mode, form: Form[DispatchLocation])(implicit request: Request[_], messages: Messages)
+@(form: Form[DispatchLocation])(implicit request: JourneyRequest[_], messages: Messages)
 
 @main_template(
   title = messages("supplementary.dispatchLocation.title")
 ) {
 
-    @mode match {
+    @request.mode match {
         case Mode.Draft | Mode.Amend => {
-            @components.back_link(controllers.declaration.routes.SummaryController.displayPage(mode), mode)
+            @components.back_link(controllers.declaration.routes.SummaryController.displayPage(request.mode), request.mode)
         }
         case Mode.Normal => {
-            @components.back_link(controllers.routes.ChoiceController.displayPage(), mode)
+            @components.back_link(controllers.routes.ChoiceController.displayPage(), request.mode)
         }
     }
 
-  @helper.form(controllers.declaration.routes.DispatchLocationController.submitForm(mode), 'autoComplete -> "off") {
-      @helper.CSRF.formField
+  @defining(controllers.declaration.routes.DispatchLocationController.submitForm()){ call =>
+
+  <form method="@call.method" action="@call.url?mode=@request.mode.name" autocomplete="off">
+ @*   @helper.form(?mode=@request.mode.name, 'autoComplete -> "off") { *@
+    @helper.CSRF.formField
 
     @components.error_summary(form.errors)
 
@@ -49,20 +53,21 @@
       field = form("dispatchLocation"),
       legend = "",
       inputs = Seq(
-        RadioOption(
-          "OutsideEU",
-          OutsideEU,
-          messages("supplementary.dispatchLocation.inputText.outsideEU")
-        ),
-        RadioOption(
-          "SpecialFiscalTerritory",
-          SpecialFiscalTerritory,
-          messages("supplementary.dispatchLocation.inputText.specialFiscalTerritory")
-        )
+          RadioOption(
+              "OutsideEU",
+              OutsideEU,
+              messages("supplementary.dispatchLocation.inputText.outsideEU")
+          ),
+          RadioOption(
+              "SpecialFiscalTerritory",
+              SpecialFiscalTerritory,
+              messages("supplementary.dispatchLocation.inputText.specialFiscalTerritory")
+          )
       )
     )
 
     @components.submit_button()
     @components.buttons.save_and_return_later_button()
+  </form>
   }
 }

--- a/app/views/declaration/summary/summary_page.scala.html
+++ b/app/views/declaration/summary/summary_page.scala.html
@@ -112,7 +112,7 @@
     @items_section(suppDecData.items)
 
     @if(mode == Mode.Amend) {
-        <a class="button mt-3" href="@routes.DispatchLocationController.displayPage(mode)">@messages("site.continue")</a>
+        <a class="button mt-3" href="@routes.DispatchLocationController.displayPage()?mode=@mode.name">@messages("site.continue")</a>
     }
 
     @if(mode == Mode.Normal) {
@@ -131,6 +131,6 @@
     @if(mode == Mode.Draft) {
         <p class="mt-5">@messages("saved.declarations.summary.paragraph")</p>
 
-        <a class="button mt-3" href="@routes.DispatchLocationController.displayPage(mode)">@messages("saved.declarations.summary.continue")</a>
+        <a class="button mt-3" href="@routes.DispatchLocationController.displayPage()?mode=@mode.name">@messages("saved.declarations.summary.continue")</a>
     }
 }

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -1,8 +1,8 @@
 # Declaration type
 
-GET         /dispatch-location                   controllers.declaration.DispatchLocationController.displayPage()
+GET         /dispatch-location                   controllers.declaration.DispatchLocationController.displayPage(mode: models.Mode ?= models.Mode.Normal)
 
-POST        /dispatch-location                   controllers.declaration.DispatchLocationController.submitForm()
+POST        /dispatch-location                   controllers.declaration.DispatchLocationController.submitForm(mode: models.Mode ?= models.Mode.Normal)
 
 GET         /type                                controllers.declaration.AdditionalDeclarationTypeController.displayPage(mode: models.Mode ?= models.Mode.Normal)
 

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -1,8 +1,8 @@
 # Declaration type
 
-GET         /dispatch-location                   controllers.declaration.DispatchLocationController.displayPage(mode: models.Mode ?= models.Mode.Normal)
+GET         /dispatch-location                   controllers.declaration.DispatchLocationController.displayPage()
 
-POST        /dispatch-location                   controllers.declaration.DispatchLocationController.submitForm(mode: models.Mode ?= models.Mode.Normal)
+POST        /dispatch-location                   controllers.declaration.DispatchLocationController.submitForm()
 
 GET         /type                                controllers.declaration.AdditionalDeclarationTypeController.displayPage(mode: models.Mode ?= models.Mode.Normal)
 

--- a/test/base/TestHelper.scala
+++ b/test/base/TestHelper.scala
@@ -20,7 +20,7 @@ import java.time.Instant
 
 import controllers.util.{Add, Remove, SaveAndContinue}
 import models.requests.{AuthenticatedRequest, JourneyRequest}
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, ExportsDeclaration, Mode}
 import play.api.mvc.Request
 import play.api.test.FakeRequest
 
@@ -45,7 +45,8 @@ object TestHelper {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
     JourneyRequest(
       AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
-      cache
+      cache,
+      Mode.Normal
     )
   }
 
@@ -53,7 +54,8 @@ object TestHelper {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
     JourneyRequest(
       AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))),
-      cache
+      cache,
+      Mode.Normal
     )
   }
 

--- a/test/controllers/navigation/NavigatorTest.scala
+++ b/test/controllers/navigation/NavigatorTest.scala
@@ -21,7 +21,7 @@ import java.util.concurrent.TimeUnit
 
 import config.AppConfig
 import controllers.util.{Add, FormAction, Remove, SaveAndContinue, SaveAndReturn, Unknown}
-import models.SignedInUser
+import models.{Mode, SignedInUser}
 import models.requests.{AuthenticatedRequest, ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys
 import org.mockito.BDDMockito._
@@ -53,7 +53,7 @@ class NavigatorTest extends WordSpec with Matchers with MockitoSugar with Export
       mock[SignedInUser]
     )
     def request(action: Option[FormAction]): JourneyRequest[AnyContent] =
-      JourneyRequest[AnyContent](authenticatedRequest(action), declaration)
+      JourneyRequest[AnyContent](authenticatedRequest(action), declaration, Mode.Normal)
 
     "Go to Save as Draft" in {
       given(config.draftTimeToLive).willReturn(FiniteDuration(10, TimeUnit.DAYS))

--- a/test/unit/base/ControllerSpec.scala
+++ b/test/unit/base/ControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.base
 import base.{MockAuthAction, MockConnectors, MockExportCacheService, MockNavigator}
 import config.AppConfig
 import controllers.util.{Add, SaveAndContinue}
-import models.ExportsDeclaration
+import models.{ExportsDeclaration, Mode}
 import models.requests.{ExportsSessionKeys, JourneyRequest}
 import play.api.libs.json.JsValue
 import play.api.mvc.{AnyContentAsEmpty, AnyContentAsFormUrlEncoded, AnyContentAsJson, Request, Result}
@@ -49,7 +49,7 @@ trait ControllerSpec
   protected def viewOf(result: Future[Result]) = Html(contentAsString(result))
 
   protected def getRequest(declaration: ExportsDeclaration): JourneyRequest[AnyContentAsEmpty.type] =
-    JourneyRequest(getAuthenticatedRequest(), declaration)
+    JourneyRequest(getAuthenticatedRequest(), declaration, Mode.Normal)
 
   protected def postRequest(body: JsValue): Request[AnyContentAsJson] =
     FakeRequest("POST", "")

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -17,6 +17,7 @@
 package views.declaration
 
 import controllers.util.{Add, SaveAndContinue, SaveAndReturn}
+import forms.Choice
 import forms.declaration.AdditionalFiscalReference
 import helpers.views.declaration.{AdditionalFiscalReferencesMessages, CommonMessages}
 import models.Mode
@@ -37,7 +38,7 @@ class AdditionalFiscalReferencesViewSpec extends ViewSpec with AdditionalFiscalR
     form: Form[AdditionalFiscalReference] = form,
     references: Seq[AdditionalFiscalReference] = Seq.empty
   ): Html =
-    additionalFiscalReferencesPage(Mode.Normal, itemId, form, references)(fakeRequest, messages)
+    additionalFiscalReferencesPage(Mode.Normal, itemId, form, references)(fakeJourneyRequest(Choice.AllowedChoiceValues.StandardDec, Mode.Normal), messages)
 
   "Additional Fiscal References View on empty page" should {
 

--- a/test/views/declaration/DispatchLocationViewSpec.scala
+++ b/test/views/declaration/DispatchLocationViewSpec.scala
@@ -17,6 +17,7 @@
 package views.declaration
 
 import controllers.util.SaveAndReturn
+import forms.Choice
 import forms.declaration.DispatchLocation
 import helpers.views.declaration.{CommonMessages, DispatchLocationMessages}
 import models.Mode
@@ -32,7 +33,7 @@ class DispatchLocationViewSpec extends ViewSpec with DispatchLocationMessages wi
   private val form: Form[DispatchLocation] = DispatchLocation.form()
   private val dispatchLocationPage = app.injector.instanceOf[dispatch_location]
   private def createView(form: Form[DispatchLocation] = form, mode: Mode = Mode.Normal): Html =
-    dispatchLocationPage(mode, form)(fakeRequest, messages)
+    dispatchLocationPage(form)(fakeJourneyRequest(Choice.AllowedChoiceValues.StandardDec, mode), messages)
 
   "Dispatch Location View on empty page" should {
 

--- a/test/views/declaration/spec/ViewSpec.scala
+++ b/test/views/declaration/spec/ViewSpec.scala
@@ -22,7 +22,7 @@ import base.{ExportsTestData, ViewValidator}
 import com.codahale.metrics.SharedMetricRegistries
 import config.AppConfig
 import models.requests.{AuthenticatedRequest, JourneyRequest}
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, ExportsDeclaration, Mode}
 import org.scalatestplus.play.PlaySpec
 import org.scalatestplus.play.guice.GuiceOneAppPerSuite
 import play.api.i18n.{Messages, MessagesApi}
@@ -45,9 +45,9 @@ trait ViewSpec extends PlaySpec with GuiceOneAppPerSuite with ViewValidator with
   implicit lazy val messages: Messages = messagesApi.preferred(FakeRequest())
   implicit lazy val flash: Flash = new Flash()
 
-  def fakeJourneyRequest(choice: String): JourneyRequest[AnyContentAsEmpty.type] = {
+  def fakeJourneyRequest(choice: String, mode: Mode = Mode.Normal): JourneyRequest[AnyContentAsEmpty.type] = {
     val cache = ExportsDeclaration(None, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), choice)
-    JourneyRequest(AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), cache)
+    JourneyRequest(AuthenticatedRequest(fakeRequest, ExportsTestData.newUser("", "")), cache, mode)
   }
 
   SharedMetricRegistries.clear()

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -44,7 +44,7 @@ class SummaryPageViewSpec
     withItem(anItem())
   )
   val request =
-    JourneyRequest(AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
+    JourneyRequest(AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration, Mode.Normal)
   val summaryPage = contentAsString(
     new summary_page(mainTemplate)(Mode.Normal, SupplementaryDeclarationData(declaration))(
       request,


### PR DESCRIPTION
Done only on single page. Working and pass first page

Props: Mode is hidden in request
Cons: Manual form generation - could be overcome with little our infrastructure.

We discuss with @ed0906  and there could be stay with `Mode` in `Controllers` signature and routes because they require it but pass it with request for view as meet in middle