### PR TITLE
CEDS-1402 - fix bug when redirecting to summary page

### DIFF
--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -146,7 +146,9 @@ class TransportContainerController @Inject()(
               Future.successful(navigator.continueTo(routes.TransportContainerController.displayAddContainer(mode)))
             case YesNoAnswers.no =>
               Future
-                .successful(navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(mode)))
+                .successful(
+                  navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(Mode.Normal))
+                )
         }
       )
 

--- a/app/controllers/declaration/TransportDetailsController.scala
+++ b/app/controllers/declaration/TransportDetailsController.scala
@@ -64,7 +64,7 @@ class TransportDetailsController @Inject()(
   ): Result =
     if (transportDetails.container)
       navigator.continueTo(controllers.declaration.routes.TransportContainerController.displayContainerSummary(mode))
-    else navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(mode))
+    else navigator.continueTo(controllers.declaration.routes.SummaryController.displayPage(Mode.Normal))
 
   private def updateCache(
     formData: TransportDetails

--- a/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
@@ -200,7 +200,6 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
       }
     }
 
-
   }
 
   "Transport Container submit remove page" should {

--- a/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
@@ -189,7 +189,18 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
       }
+
+      "user indicates they do not want to add another container and they are in draft mode" in new SetUp {
+        val body = Seq(("yesNo", "No"))
+
+        val result = controller.submitSummaryAction(Mode.Draft)(postRequestAsFormUrlEncoded(body: _*))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+      }
     }
+
+
   }
 
   "Transport Container submit remove page" should {

--- a/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportDetailsControllerSpec.scala
@@ -93,10 +93,20 @@ class TransportDetailsControllerSpec extends ControllerSpec {
         val correctForm =
           Json.toJson(TransportDetails(Some("United Kingdom"), false, IMOShipIDNumber, Some("correct"), Some(cash)))
 
+        val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
+      }
+
+      "Container is not selected in draft mode" in new SetUp {
+        val correctForm =
+          Json.toJson(TransportDetails(Some("United Kingdom"), false, IMOShipIDNumber, Some("correct"), Some(cash)))
+
         val result = controller.submitForm(Mode.Draft)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Draft)
+        thePageNavigatedTo mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Normal)
       }
     }
   }


### PR DESCRIPTION
Previously the TransportContainerController and SealController used to set the "Mode" to normal when re-directing to SummaryController.

This was missed during the recent re-factoring of Container/Seals.   The exit point from this mini-journey is when the user selects "No" to "do you want to add another container.

There was also a similar problem when coming from the TransportDetails page having selected "No" to having used containers