### PR TITLE
CEDS-1608 Allow a wider range of characters for LegalDeclaration

### DIFF
--- a/app/forms/declaration/LegalDeclaration.scala
+++ b/app/forms/declaration/LegalDeclaration.scala
@@ -30,12 +30,12 @@ object LegalDeclaration {
       .verifying("legal.declaration.fullName.empty", nonEmpty)
       .verifying("legal.declaration.fullName.short", isEmpty or noShorterThan(4))
       .verifying("legal.declaration.fullName.long", isEmpty or noLongerThan(64))
-      .verifying("legal.declaration.fullName.error", isEmpty or isAlphanumericWithSpace),
+      .verifying("legal.declaration.fullName.error", isEmpty or isValidName),
     "jobRole" -> text()
       .verifying("legal.declaration.jobRole.empty", nonEmpty)
       .verifying("legal.declaration.jobRole.short", isEmpty or noShorterThan(4))
       .verifying("legal.declaration.jobRole.long", isEmpty or noLongerThan(64))
-      .verifying("legal.declaration.jobRole.error", isEmpty or isAlphanumericWithSpace),
+      .verifying("legal.declaration.jobRole.error", isEmpty or isValidName),
     "email" -> text()
       .verifying("legal.declaration.email.empty", nonEmpty)
       .verifying("legal.declaration.email.long", isEmpty or noLongerThan(64))

--- a/test/forms/declaration/LegalDeclarationSpec.scala
+++ b/test/forms/declaration/LegalDeclarationSpec.scala
@@ -101,8 +101,8 @@ class LegalDeclarationSpec extends UnitSpec {
   private def validFormData = formDataWith()
 
   private def formDataWith(
-    name: String = "Some Name",
-    role: String = "Some Role",
+    name: String = "O'Neil Some-Name, Jr.",
+    role: String = "Traveling-Secretary for the N.Y. Yankees' Chairman",
     email: String = "some@email.com",
     checked: Boolean = true
   ) = {


### PR DESCRIPTION
This is to allow a wider set of characters than just English a-zA-Z
characters.
With this change the following name/job patterns will be allowed:
```
Mathias d'Arras
Martin Luther King, Jr.
Hector Sausage-Hausen
```