### PR TITLE
CEDS-1676 - Back link for declaration 'error list view'

### DIFF
--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -18,8 +18,8 @@
 @import models.Mode._
 
 @* mode is not currently used but will be once we add "change field" links to the summary page *@
-@(href: Call, mode: Mode = Mode.Normal)(implicit messages: Messages)
+@(href: Call, mode: Mode = Mode.Normal, backMessage: String = "site.back")(implicit messages: Messages)
 
 <div class="js-visible">
-    <a id="link-back" class="link-back" href="@href">@messages("site.back")</a>
+    <a id="link-back" class="link-back" href="@href">@messages(backMessage)</a>
 </div>

--- a/app/views/declaration/summary/summary_page.scala.html
+++ b/app/views/declaration/summary/summary_page.scala.html
@@ -36,7 +36,7 @@
 
   @mode match {
       case Mode.Amend if request.cacheModel.sourceId.isDefined => {
-          @components.back_link(controllers.routes.NotificationsController.listOfNotificationsForSubmission(request.cacheModel.sourceId.get), mode)
+          @components.back_link(controllers.routes.SubmissionsController.displayListOfSubmissions(), mode)
       }
       case Mode.Draft => {
           @components.back_link(controllers.routes.SavedDeclarationsController.displayDeclarations(), mode)

--- a/app/views/declaration/summary/summary_page.scala.html
+++ b/app/views/declaration/summary/summary_page.scala.html
@@ -35,7 +35,7 @@
 ) {
 
   @mode match {
-      case Mode.Amend if request.cacheModel.sourceId.isDefined => {
+      case Mode.Amend => {
           @components.back_link(controllers.routes.SubmissionsController.displayListOfSubmissions(), mode, "supplementary.summary.back")
       }
       case Mode.Draft => {

--- a/app/views/declaration/summary/summary_page.scala.html
+++ b/app/views/declaration/summary/summary_page.scala.html
@@ -36,7 +36,7 @@
 
   @mode match {
       case Mode.Amend if request.cacheModel.sourceId.isDefined => {
-          @components.back_link(controllers.routes.SubmissionsController.displayListOfSubmissions(), mode)
+          @components.back_link(controllers.routes.SubmissionsController.displayListOfSubmissions(), mode, "supplementary.summary.back")
       }
       case Mode.Draft => {
           @components.back_link(controllers.routes.SavedDeclarationsController.displayDeclarations(), mode)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -675,6 +675,7 @@ supplementary.commodityMeasure.supplementaryUnits.hint = Enter the quantity in t
 supplementary.commodityMeasure.supplementaryUnits.error = Supplementary units should be a decimal value and should be less than or equal to 99999999999999.99 with 2 decimals
 
 supplementary.summary.title = Summary
+supplementary.summary.back = Back to Submissions
 supplementary.summary.normal-header = Check your answers before making this declaration
 supplementary.summary.amend-header = Check your answers
 supplementary.summary.saved-header = Continue saved declaration

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -98,7 +98,7 @@ class SummaryPageViewSpec
           val document = view(Mode.Amend, model)
           document must containElementWithID("link-back")
           document.getElementById("link-back") must haveHref(
-            controllers.routes.NotificationsController.listOfNotificationsForSubmission("source-id")
+            controllers.routes.SubmissionsController.displayListOfSubmissions()
           )
         }
       }

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -90,6 +90,7 @@ class SummaryPageViewSpec
         document.getElementById("link-back") must haveHref(
           controllers.routes.SavedDeclarationsController.displayDeclarations()
         )
+        document.getElementById("link-back") must containText("site.back")
       }
 
       "Amend Mode" when {
@@ -100,6 +101,7 @@ class SummaryPageViewSpec
           document.getElementById("link-back") must haveHref(
             controllers.routes.SubmissionsController.displayListOfSubmissions()
           )
+          document.getElementById("link-back") must containText("supplementary.summary.back")
         }
       }
 
@@ -114,6 +116,7 @@ class SummaryPageViewSpec
           document.getElementById("link-back") must haveHref(
             controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
           )
+          document.getElementById("link-back") must containText("site.back")
         }
 
         "standard declaration without containers" in {


### PR DESCRIPTION
- change the url and text for the "Back" button when on summary screen when amending a rejected declaration.