### PR TITLE
CEDS-1691 - notification field rename

### DIFF
--- a/app/controllers/util/SubmissionDisplayHelper.scala
+++ b/app/controllers/util/SubmissionDisplayHelper.scala
@@ -26,9 +26,9 @@ object SubmissionDisplayHelper {
     allNotifications: Seq[Notification]
   ): Seq[(Submission, Seq[Notification])] =
     allSubmissions.map { submission =>
-      val currentSubmissionConversationIds = submission.actions.map(_.conversationId)
+      val currentSubmissionConversationIds = submission.actions.map(_.id)
       val currentSubmissionNotifications = allNotifications
-        .filter(n => currentSubmissionConversationIds.contains(n.conversationId))
+        .filter(n => currentSubmissionConversationIds.contains(n.actionId))
         .sorted
         .reverse
 

--- a/app/models/declaration/notifications/Notification.scala
+++ b/app/models/declaration/notifications/Notification.scala
@@ -19,14 +19,14 @@ package models.declaration.notifications
 import java.time.LocalDateTime
 
 import models.declaration.submissions.SubmissionStatus
+import models.declaration.submissions.SubmissionStatus.SubmissionStatus
 import play.api.libs.json.Json
 
 case class Notification(
-  conversationId: String,
+  actionId: String,
   mrn: String,
   dateTimeIssued: LocalDateTime,
-  functionCode: String,
-  nameCode: Option[String],
+  status: SubmissionStatus,
   errors: Seq[NotificationError],
   payload: String
 ) extends Ordered[Notification] {
@@ -36,9 +36,8 @@ case class Notification(
     else if (this.dateTimeIssued.isAfter(that.dateTimeIssued)) 1
     else -1
 
-  val status: SubmissionStatus = SubmissionStatus.retrieve(this.functionCode, this.nameCode)
-
-  val isStatusRejected: Boolean = status == SubmissionStatus.Rejected
+  val displayStatus = SubmissionStatus.format(status)
+  val isStatusRejected: Boolean = status == SubmissionStatus.REJECTED
 }
 
 object Notification {

--- a/app/models/declaration/submissions/Action.scala
+++ b/app/models/declaration/submissions/Action.scala
@@ -20,11 +20,7 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.Json
 
-case class Action(
-  requestType: RequestType,
-  conversationId: String,
-  requestTimestamp: LocalDateTime = LocalDateTime.now()
-)
+case class Action(requestType: RequestType, id: String, requestTimestamp: LocalDateTime = LocalDateTime.now())
 
 object Action {
   implicit val format = Json.format[Action]

--- a/app/models/declaration/submissions/SubmissionStatus.scala
+++ b/app/models/declaration/submissions/SubmissionStatus.scala
@@ -15,136 +15,36 @@
  */
 
 package models.declaration.submissions
+import play.api.libs.json.Format
+import utils.EnumJson
 
-import play.api.libs.json._
+object SubmissionStatus extends Enumeration {
+  type SubmissionStatus = Value
+  implicit val format: Format[SubmissionStatus.Value] = EnumJson.format(SubmissionStatus)
 
-sealed trait SubmissionStatus {
-  val fullCode: String
-}
+  val PENDING, REQUESTED_CANCELLATION, ACCEPTED, RECEIVED, REJECTED, UNDERGOING_PHYSICAL_CHECK,
+  ADDITIONAL_DOCUMENTS_REQUIRED, AMENDED, RELEASED, CLEARED, CANCELLED, CUSTOMS_POSITION_GRANTED,
+  CUSTOMS_POSITION_DENIED, GOODS_HAVE_EXITED_THE_COMMUNITY, DECLARATION_HANDLED_EXTERNALLY, AWAITING_EXIT_RESULTS,
+  UNKNOWN = Value
 
-object SubmissionStatus {
-
-  implicit object StatusFormat extends Format[SubmissionStatus] {
-    def reads(status: JsValue): JsResult[SubmissionStatus] = status match {
-      case JsString(code) => JsSuccess(getStatusOrUnknown(code))
-      case _              => JsSuccess(UnknownStatus)
-    }
-
-    def writes(status: SubmissionStatus): JsValue = JsString(status.fullCode)
+  def format(status: SubmissionStatus): String = status match {
+    case PENDING                         => "Pending"
+    case REQUESTED_CANCELLATION          => "Cancellation Requested"
+    case ACCEPTED                        => "Accepted"
+    case RECEIVED                        => "Received"
+    case REJECTED                        => "Rejected"
+    case UNDERGOING_PHYSICAL_CHECK       => "Undergoing Physical Check"
+    case ADDITIONAL_DOCUMENTS_REQUIRED   => "Additional Documents Required"
+    case AMENDED                         => "Amended"
+    case RELEASED                        => "Released"
+    case CLEARED                         => "Cleared"
+    case CANCELLED                       => "Cancelled"
+    case CUSTOMS_POSITION_GRANTED        => "Customs Position Granted"
+    case CUSTOMS_POSITION_DENIED         => "Customs Position Denied"
+    case GOODS_HAVE_EXITED_THE_COMMUNITY => "Goods Have Exited The Community"
+    case DECLARATION_HANDLED_EXTERNALLY  => "Declaration Handled Externally"
+    case AWAITING_EXIT_RESULTS           => "Awaiting Exit Results"
+    case UNKNOWN                         => "Unknown status"
   }
 
-  private val codesMap: Map[String, SubmissionStatus] = Map(
-    Pending.fullCode -> Pending,
-    RequestedCancellation.fullCode -> RequestedCancellation,
-    Accepted.fullCode -> Accepted,
-    Received.fullCode -> Received,
-    Rejected.fullCode -> Rejected,
-    UndergoingPhysicalCheck.fullCode -> UndergoingPhysicalCheck,
-    AdditionalDocumentsRequired.fullCode -> AdditionalDocumentsRequired,
-    Amended.fullCode -> Amended,
-    Released.fullCode -> Released,
-    Cleared.fullCode -> Cleared,
-    Cancelled.fullCode -> Cancelled,
-    CustomsPositionGranted.fullCode -> CustomsPositionGranted,
-    CustomsPositionDenied.fullCode -> CustomsPositionDenied,
-    GoodsHaveExitedTheCommunity.fullCode -> GoodsHaveExitedTheCommunity,
-    DeclarationHandledExternally.fullCode -> DeclarationHandledExternally,
-    AwaitingExitResults.fullCode -> AwaitingExitResults,
-    UnknownStatus.fullCode -> UnknownStatus
-  )
-
-  def retrieve(functionCode: String, nameCode: Option[String]): SubmissionStatus =
-    getStatusOrUnknown(functionCode + nameCode.getOrElse(""))
-
-  private def getStatusOrUnknown(searchKey: String): SubmissionStatus =
-    codesMap.get(searchKey) match {
-      case Some(status) => status
-      case None         => UnknownStatus
-    }
-
-  case object Pending extends SubmissionStatus {
-    val fullCode: String = "Pending"
-  }
-
-  case object RequestedCancellation extends SubmissionStatus {
-    val fullCode: String = "Cancellation Requested"
-
-    override def toString: String = "Cancellation Requested"
-  }
-
-  case object Accepted extends SubmissionStatus {
-    val fullCode: String = "01"
-  }
-
-  case object Received extends SubmissionStatus {
-    val fullCode: String = "02"
-  }
-
-  case object Rejected extends SubmissionStatus {
-    val fullCode: String = "03"
-  }
-
-  case object UndergoingPhysicalCheck extends SubmissionStatus {
-    val fullCode: String = "05"
-
-    override def toString(): String = "Undergoing Physical Check"
-  }
-
-  case object AdditionalDocumentsRequired extends SubmissionStatus {
-    val fullCode: String = "06"
-
-    override def toString(): String = "Additional Documents Required"
-  }
-
-  case object Amended extends SubmissionStatus {
-    val fullCode: String = "07"
-  }
-
-  case object Released extends SubmissionStatus {
-    val fullCode: String = "08"
-  }
-
-  case object Cleared extends SubmissionStatus {
-    val fullCode: String = "09"
-  }
-
-  case object Cancelled extends SubmissionStatus {
-    val fullCode: String = "10"
-  }
-
-  case object CustomsPositionGranted extends SubmissionStatus {
-    val fullCode: String = "1139"
-
-    override def toString(): String = "Customs Position Granted"
-  }
-
-  case object CustomsPositionDenied extends SubmissionStatus {
-    val fullCode: String = "1141"
-
-    override def toString(): String = "Customs Position Denied"
-  }
-
-  case object GoodsHaveExitedTheCommunity extends SubmissionStatus {
-    val fullCode: String = "16"
-
-    override def toString(): String = "Goods Have Exited The Community"
-  }
-
-  case object DeclarationHandledExternally extends SubmissionStatus {
-    val fullCode: String = "17"
-
-    override def toString(): String = "Declaration Handled Externally"
-  }
-
-  case object AwaitingExitResults extends SubmissionStatus {
-    val fullCode: String = "18"
-
-    override def toString(): String = "Awaiting Exit Results"
-  }
-
-  case object UnknownStatus extends SubmissionStatus {
-    val fullCode: String = "UnknownStatus"
-
-    override def toString(): String = "Unknown status"
-  }
 }

--- a/app/services/model/RejectionReason.scala
+++ b/app/services/model/RejectionReason.scala
@@ -20,9 +20,8 @@ import java.io.File
 
 import com.github.tototoshi.csv._
 import models.declaration.notifications.Notification
-import models.declaration.submissions.SubmissionStatus
 import play.api.Logger
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class RejectionReason(code: String, description: String)
 
@@ -30,7 +29,7 @@ object RejectionReason {
 
   private val logger = Logger(this.getClass)
 
-  implicit val format = Json.format[RejectionReason]
+  implicit val format: OFormat[RejectionReason] = Json.format[RejectionReason]
 
   def apply(list: List[String]): RejectionReason = list match {
     case code :: description :: Nil => RejectionReason(code, description)
@@ -44,7 +43,7 @@ object RejectionReason {
 
     val errors: List[List[String]] = reader.all()
 
-    errors.map(RejectionReason.apply _)
+    errors.map(RejectionReason.apply)
   }
 
   def getErrorDescription(errorCode: String): String =
@@ -52,7 +51,7 @@ object RejectionReason {
 
   def fromNotifications(notifications: Seq[Notification]): Seq[RejectionReason] = {
 
-    val rejectionNotification = notifications.find(_.functionCode == SubmissionStatus.Rejected.fullCode)
+    val rejectionNotification = notifications.find(_.isStatusRejected)
 
     val errorCodes = rejectionNotification.map { notification =>
       notification.errors.map { error =>

--- a/app/views/notifications.scala.html
+++ b/app/views/notifications.scala.html
@@ -17,7 +17,6 @@
 @import java.time.format.DateTimeFormatter
 
 @import models.declaration.notifications.Notification
-@import models.declaration.submissions.SubmissionStatus
 
 @this(main_template: views.html.main_template)
 
@@ -41,8 +40,8 @@
             @for(notification <- notifications){
                 <tr class="table-row">
                     <td class="table-cell">@eori</td>
-                    <td class="table-cell">@notification.conversationId</td>
-                    <td class="table-cell">@SubmissionStatus.retrieve(notification.functionCode, notification.nameCode)</td>
+                    <td class="table-cell">@notification.actionId</td>
+                    <td class="table-cell">@notification.displayStatus</td>
                     <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").format(notification.dateTimeIssued)</td>
                 </tr>
             }

--- a/app/views/submission_notifications.scala.html
+++ b/app/views/submission_notifications.scala.html
@@ -17,7 +17,8 @@
 @import views.ViewDates
 
 @import models.declaration.notifications.Notification
-@import models.declaration.submissions.{Submission, SubmissionStatus}
+@import models.declaration.submissions.Submission
+@import models.declaration.submissions.SubmissionStatus
 
 @this(main_template: views.html.main_template)
 
@@ -44,10 +45,10 @@
         <tbody>
         @for((notification, index) <- notifications.zipWithIndex){
             <tr id="submission_notifications-table-row@index" class="table-row">
-                <td id="submission_notifications-table-row@index-status" class="table-cell">@notification.status.toString</td>
+                <td id="submission_notifications-table-row@index-status" class="table-cell">@notification.displayStatus</td>
                 <td id="submission_notifications-table-row@index-date" class="table-cell">@ViewDates.format(notification.dateTimeIssued)</td>
                 <td class="table-cell">
-                @if(notification.status == SubmissionStatus.Rejected) {
+                @if(notification.isStatusRejected) {
                     <a id="submission_notifications-table-row@index-amend_link" href="@routes.SubmissionsController.amend(submission.uuid)">@messages("notifications.amend")</a>
                 }
                 </td>

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -18,7 +18,8 @@
 @import views.ViewDates
 
 @import models.declaration.notifications.Notification
-@import models.declaration.submissions.{Submission, SubmissionStatus}
+@import models.declaration.submissions.SubmissionStatus
+@import models.declaration.submissions.Submission
 @import models.declaration.submissions.RequestType.SubmissionRequest
 
 @this(main_template: views.html.main_template)
@@ -56,7 +57,7 @@
                 <td class="table-cell">@submission.lrn</td>
                 <td class="table-cell">@submission.mrn</td>
                 <td class="table-cell">@{submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.formatter.withZone(ZoneId.systemDefault()).format(_))}</td>
-                <td class="table-cell">@{notifications.headOption.map(n => n.status).getOrElse(SubmissionStatus.UnknownStatus)}</td>
+                <td class="table-cell">@{SubmissionStatus.format(notifications.headOption.map(n => n.status).getOrElse(SubmissionStatus.UNKNOWN))}</td>
                 <td class="table-cell">
                     @if(notifications.nonEmpty){
                         <a href="@routes.NotificationsController.listOfNotificationsForSubmission(submission.uuid)">@{notifications.length}</a>

--- a/test/base/MockConnectors.scala
+++ b/test/base/MockConnectors.scala
@@ -23,7 +23,7 @@ import connectors.{CustomsDeclareExportsConnector, NrsConnector}
 import models._
 import models.declaration.notifications.Notification
 import models.declaration.submissions.RequestType.SubmissionRequest
-import models.declaration.submissions.{Action, Submission}
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
@@ -53,7 +53,9 @@ trait MockConnectors extends MockitoSugar {
   def listOfNotifications(): OngoingStubbing[Future[Seq[Notification]]] =
     when(mockCustomsDeclareExportsConnector.fetchNotifications()(any(), any()))
       .thenReturn(
-        Future.successful(Seq(Notification("convId", "mrn", LocalDateTime.now(), "01", None, Seq.empty, "payload")))
+        Future.successful(
+          Seq(Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload"))
+        )
       )
 
   def listOfSubmissions(): OngoingStubbing[Future[Seq[Submission]]] =
@@ -68,11 +70,7 @@ trait MockConnectors extends MockitoSugar {
               mrn = None,
               ducr = None,
               actions = Seq(
-                Action(
-                  requestType = SubmissionRequest,
-                  conversationId = "conversationID",
-                  requestTimestamp = LocalDateTime.now()
-                )
+                Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now())
               )
             )
           )

--- a/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
@@ -23,7 +23,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import connectors.exchange.ExportsDeclarationExchange
 import forms.CancelDeclaration
 import models.declaration.notifications.Notification
-import models.declaration.submissions.{Action, RequestType, Submission}
+import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
 import models.{Page, Paginated}
 import org.mockito.BDDMockito._
 import org.scalatest.BeforeAndAfterEach
@@ -46,7 +46,8 @@ class CustomsDeclareExportsConnectorIntegrationSpec
   private val existingDeclarationExchange = ExportsDeclarationExchange(existingDeclaration)
   private val action = Action(RequestType.SubmissionRequest, UUID.randomUUID().toString)
   private val submission = Submission(id, "eori", "lrn", Some("mrn"), None, Seq(action))
-  private val notification = Notification("conv-id", "mrn", LocalDateTime.now, "f-code", None, Seq.empty, "payload")
+  private val notification =
+    Notification("action-id", "mrn", LocalDateTime.now, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val connector = new CustomsDeclareExportsConnector(config, httpClient)
 
   implicit val defaultPatience: PatienceConfig =

--- a/test/controllers/util/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/util/SubmissionDisplayHelperSpec.scala
@@ -21,8 +21,8 @@ import java.util.UUID
 
 import base.TestHelper.createRandomAlphanumericString
 import models.declaration.notifications.{ErrorPointer, Notification, NotificationError}
-import models.declaration.submissions.{Action, Submission}
 import models.declaration.submissions.RequestType.{CancellationRequest, SubmissionRequest}
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import org.scalatest.{MustMatchers, WordSpec}
 
 import scala.util.Random
@@ -95,7 +95,7 @@ class SubmissionDisplayHelperSpec extends WordSpec with MustMatchers {
     "provided with multiple Submissions and additional non-matching Notification" should {
       "return Map with matching Notifications only" in {
         val submissions = Seq(submission, submission_2)
-        val additionalNotification = notification.copy(conversationId = "anything-different", mrn = "any-other-mrn")
+        val additionalNotification = notification.copy(actionId = "anything-different", mrn = "any-other-mrn")
         val notifications = Seq(notification, notification_2, notification_3, additionalNotification)
 
         val result =
@@ -118,9 +118,9 @@ class SubmissionDisplayHelperSpec extends WordSpec with MustMatchers {
       "return Map with empty lists as values" in {
         val submissions = Seq(submission, submission_2)
         val notifications = Seq(
-          notification.copy(conversationId = "convId1", mrn = "mrn1"),
-          notification_2.copy(conversationId = "convId2", mrn = "mrn2"),
-          notification_3.copy(conversationId = "convId3", mrn = "mrn3")
+          notification.copy(actionId = "actionId1", mrn = "mrn1"),
+          notification_2.copy(actionId = "actionId2", mrn = "mrn2"),
+          notification_3.copy(actionId = "actionId3", mrn = "mrn3")
         )
 
         val result =
@@ -138,7 +138,7 @@ class SubmissionDisplayHelperSpec extends WordSpec with MustMatchers {
       "return Map with Notifications sorted in descending order" in {
         val submissions = Seq(submission)
         val newNotification_3 =
-          notification_3.copy(conversationId = notification.conversationId, mrn = notification.mrn)
+          notification_3.copy(actionId = notification.actionId, mrn = notification.mrn)
         val notifications = Seq(notification, newNotification_3, notification_2)
 
         val result =
@@ -179,20 +179,20 @@ object SubmissionDisplayHelperSpec {
   val conversationId_2: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e22"
   val conversationId_3: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e23"
 
-  lazy val action = Action(requestType = SubmissionRequest, conversationId = conversationId)
+  lazy val action = Action(requestType = SubmissionRequest, id = conversationId)
   lazy val action_2 = Action(
     requestType = SubmissionRequest,
-    conversationId = conversationId_2,
+    id = conversationId_2,
     requestTimestamp = action.requestTimestamp.plusDays(2)
   )
   lazy val action_3 = Action(
     requestType = SubmissionRequest,
-    conversationId = conversationId_2,
+    id = conversationId_2,
     requestTimestamp = action.requestTimestamp.minusDays(2)
   )
   lazy val actionCancellation = Action(
     requestType = CancellationRequest,
-    conversationId = conversationId,
+    id = conversationId,
     requestTimestamp = action.requestTimestamp.plusHours(3)
   )
 
@@ -236,29 +236,26 @@ object SubmissionDisplayHelperSpec {
   val payload_3 = createRandomAlphanumericString(payloadExemplaryLength)
 
   val notification = Notification(
-    conversationId = conversationId,
+    actionId = conversationId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued,
-    functionCode = functionCode,
-    nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload
   )
   val notification_2 = Notification(
-    conversationId = conversationId,
+    actionId = conversationId,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_2,
-    functionCode = functionCode_2,
-    nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = errors,
     payload = payload_2
   )
   val notification_3 = Notification(
-    conversationId = conversationId_2,
+    actionId = conversationId_2,
     mrn = mrn,
     dateTimeIssued = dateTimeIssued_3,
-    functionCode = functionCode_3,
-    nameCode = nameCode,
+    status = SubmissionStatus.UNKNOWN,
     errors = Seq.empty,
     payload = payload_3
   )

--- a/test/models/declaration/notifications/NotificationSpec.scala
+++ b/test/models/declaration/notifications/NotificationSpec.scala
@@ -18,15 +18,16 @@ package models.declaration.notifications
 
 import java.time.LocalDateTime
 
+import models.declaration.submissions.SubmissionStatus
 import org.scalatest.{MustMatchers, WordSpec}
 
 class NotificationSpec extends WordSpec with MustMatchers {
   val earlierDate = LocalDateTime.of(2019, 6, 10, 10, 10)
   val laterDate = LocalDateTime.of(2019, 6, 15, 10, 10)
   val latestDate = LocalDateTime.of(2019, 6, 20, 10, 10)
-  val firstNotification = Notification("convId", "mrn", earlierDate, "01", None, Seq.empty, "payload")
-  val secondNotification = Notification("convId", "mrn", laterDate, "01", None, Seq.empty, "payload")
-  val thirdNotification = Notification("convId", "mrn", latestDate, "01", None, Seq.empty, "payload")
+  val firstNotification = Notification("convId", "mrn", earlierDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
+  val secondNotification = Notification("convId", "mrn", laterDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
+  val thirdNotification = Notification("convId", "mrn", latestDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
 
   "Notification compare method" should {
 

--- a/test/models/declaration/submissions/SubmissionStatusSpec.scala
+++ b/test/models/declaration/submissions/SubmissionStatusSpec.scala
@@ -16,59 +16,32 @@
 
 package models.declaration.submissions
 
-import models.declaration.submissions.SubmissionStatus._
+import SubmissionStatus._
 import org.scalatest.{MustMatchers, WordSpec}
-import play.api.libs.json._
 
 class SubmissionStatusSpec extends WordSpec with MustMatchers {
 
-  "Reads for status" should {
-    "correctly read a value for every scenario" in {
-      SubmissionStatus.StatusFormat.reads(JsString("01")) must be(JsSuccess(Accepted))
-      SubmissionStatus.StatusFormat.reads(JsString("02")) must be(JsSuccess(Received))
-      SubmissionStatus.StatusFormat.reads(JsString("03")) must be(JsSuccess(Rejected))
-      SubmissionStatus.StatusFormat.reads(JsString("05")) must be(JsSuccess(UndergoingPhysicalCheck))
-      SubmissionStatus.StatusFormat.reads(JsString("06")) must be(JsSuccess(AdditionalDocumentsRequired))
-      SubmissionStatus.StatusFormat.reads(JsString("07")) must be(JsSuccess(Amended))
-      SubmissionStatus.StatusFormat.reads(JsString("08")) must be(JsSuccess(Released))
-      SubmissionStatus.StatusFormat.reads(JsString("09")) must be(JsSuccess(Cleared))
-      SubmissionStatus.StatusFormat.reads(JsString("10")) must be(JsSuccess(Cancelled))
-      SubmissionStatus.StatusFormat.reads(JsString("1139")) must be(JsSuccess(CustomsPositionGranted))
-      SubmissionStatus.StatusFormat.reads(JsString("1141")) must be(JsSuccess(CustomsPositionDenied))
-      SubmissionStatus.StatusFormat.reads(JsString("16")) must be(JsSuccess(GoodsHaveExitedTheCommunity))
-      SubmissionStatus.StatusFormat.reads(JsString("17")) must be(JsSuccess(DeclarationHandledExternally))
-      SubmissionStatus.StatusFormat.reads(JsString("18")) must be(JsSuccess(AwaitingExitResults))
-      SubmissionStatus.StatusFormat.reads(JsString("WrongStatus")) must be(JsSuccess(UnknownStatus))
-      SubmissionStatus.StatusFormat.reads(JsString("UnknownStatus")) must be(JsSuccess(UnknownStatus))
-    }
-
-    "correctly write a value for every scenario" in {
-      Json.toJson(Accepted) must be(JsString("01"))
-      Json.toJson(Received) must be(JsString("02"))
-      Json.toJson(Rejected) must be(JsString("03"))
-      Json.toJson(UndergoingPhysicalCheck) must be(JsString("05"))
-      Json.toJson(AdditionalDocumentsRequired) must be(JsString("06"))
-      Json.toJson(Amended) must be(JsString("07"))
-      Json.toJson(Released) must be(JsString("08"))
-      Json.toJson(Cleared) must be(JsString("09"))
-      Json.toJson(Cancelled) must be(JsString("10"))
-      Json.toJson(CustomsPositionGranted) must be(JsString("1139"))
-      Json.toJson(CustomsPositionDenied) must be(JsString("1141"))
-      Json.toJson(GoodsHaveExitedTheCommunity) must be(JsString("16"))
-      Json.toJson(DeclarationHandledExternally) must be(JsString("17"))
-      Json.toJson(AwaitingExitResults) must be(JsString("18"))
-      Json.toJson(UnknownStatus) must be(JsString("UnknownStatus"))
-    }
+  "format" should {
 
     "correctly convert status to specified string" in {
-      AdditionalDocumentsRequired.toString() must be("Additional Documents Required")
-      AwaitingExitResults.toString() must be("Awaiting Exit Results")
-      CustomsPositionGranted.toString() must be("Customs Position Granted")
-      CustomsPositionDenied.toString() must be("Customs Position Denied")
-      DeclarationHandledExternally.toString() must be("Declaration Handled Externally")
-      GoodsHaveExitedTheCommunity.toString() must be("Goods Have Exited The Community")
-      RequestedCancellation.toString must be("Cancellation Requested")
-      UndergoingPhysicalCheck.toString() must be("Undergoing Physical Check")
+
+      format(PENDING) must be("Pending")
+      format(REQUESTED_CANCELLATION) must be("Cancellation Requested")
+      format(ACCEPTED) must be("Accepted")
+      format(RECEIVED) must be("Received")
+      format(REJECTED) must be("Rejected")
+      format(UNDERGOING_PHYSICAL_CHECK) must be("Undergoing Physical Check")
+      format(ADDITIONAL_DOCUMENTS_REQUIRED) must be("Additional Documents Required")
+      format(AMENDED) must be("Amended")
+      format(RELEASED) must be("Released")
+      format(CLEARED) must be("Cleared")
+      format(CANCELLED) must be("Cancelled")
+      format(CUSTOMS_POSITION_GRANTED) must be("Customs Position Granted")
+      format(CUSTOMS_POSITION_DENIED) must be("Customs Position Denied")
+      format(GOODS_HAVE_EXITED_THE_COMMUNITY) must be("Goods Have Exited The Community")
+      format(DECLARATION_HANDLED_EXTERNALLY) must be("Declaration Handled Externally")
+      format(AWAITING_EXIT_RESULTS) must be("Awaiting Exit Results")
+      format(UNKNOWN) must be("Unknown status")
     }
   }
 }

--- a/test/unit/controllers/NotificationControllerSpec.scala
+++ b/test/unit/controllers/NotificationControllerSpec.scala
@@ -21,8 +21,8 @@ import java.util.UUID
 
 import controllers.NotificationsController
 import models.declaration.notifications.Notification
-import models.declaration.submissions.{Action, Submission}
 import models.declaration.submissions.RequestType.SubmissionRequest
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito._
 import play.api.mvc.{AnyContentAsEmpty, Request, Result}
@@ -35,16 +35,16 @@ import scala.concurrent.Future.successful
 
 class NotificationControllerSpec extends ControllerSpec {
 
-  private val notification = Notification("convId", "mrn", LocalDateTime.now(), "01", None, Seq.empty, "payload")
+  private val notification =
+    Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val submission = Submission(
     uuid = UUID.randomUUID().toString,
     eori = "eori",
     lrn = "lrn",
     mrn = None,
     ducr = None,
-    actions = Seq(
-      Action(requestType = SubmissionRequest, conversationId = "conversationID", requestTimestamp = LocalDateTime.now())
-    )
+    actions =
+      Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now()))
   )
 
   trait SetUp {

--- a/test/unit/controllers/SubmissionsControllerSpec.scala
+++ b/test/unit/controllers/SubmissionsControllerSpec.scala
@@ -23,32 +23,32 @@ import akka.util.Timeout
 import controllers.SubmissionsController
 import models.declaration.notifications.Notification
 import models.declaration.submissions.RequestType.SubmissionRequest
-import models.declaration.submissions.{Action, Submission}
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import models.requests.ExportsSessionKeys
 import models.{DeclarationStatus, ExportsDeclaration, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
-import org.scalatest.matchers.{BeMatcher, MatchResult, Matcher}
+import org.scalatest.matchers.{BeMatcher, MatchResult}
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
 import views.html.submissions
 
-import scala.concurrent.duration._
 import scala.concurrent.Future.successful
+import scala.concurrent.duration._
 
 class SubmissionsControllerSpec extends ControllerSpec {
 
-  private val notification = Notification("convId", "mrn", LocalDateTime.now(), "01", None, Seq.empty, "payload")
+  private val notification =
+    Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val submission = Submission(
     uuid = UUID.randomUUID().toString,
     eori = "eori",
     lrn = "lrn",
     mrn = None,
     ducr = None,
-    actions = Seq(
-      Action(requestType = SubmissionRequest, conversationId = "conversationID", requestTimestamp = LocalDateTime.now())
-    )
+    actions =
+      Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now()))
   )
 
   trait SetUp {

--- a/test/unit/services/model/RejectionReasonSpec.scala
+++ b/test/unit/services/model/RejectionReasonSpec.scala
@@ -88,7 +88,7 @@ class RejectionReasonSpec extends UnitSpec {
     "successfully convert list of notifications to list of rejection reasons" when {
 
       val nonRejectionNotification =
-        Notification("convId", "mrn", LocalDateTime.now(), SubmissionStatus.Accepted.fullCode, None, Seq.empty, "")
+        Notification("convId", "mrn", LocalDateTime.now(), SubmissionStatus.ACCEPTED, Seq.empty, "")
 
       "list is empty" in {
 
@@ -105,15 +105,8 @@ class RejectionReasonSpec extends UnitSpec {
         val firstError = NotificationError("CDS12016", Seq.empty)
         val secondError = NotificationError("CDS12022", Seq.empty)
         val notificationErrors = Seq(firstError, secondError)
-        val rejectionNotification = Notification(
-          "convId",
-          "mrn",
-          LocalDateTime.now(),
-          SubmissionStatus.Rejected.fullCode,
-          None,
-          notificationErrors,
-          ""
-        )
+        val rejectionNotification =
+          Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, notificationErrors, "")
         val notifications = Seq(nonRejectionNotification, rejectionNotification)
         val firstExpectedRejectionReason = RejectionReason("CDS12016", "Date error: Date of acceptance is not allowed.")
         val secondExpectedRejectionReason =

--- a/test/views/NotificationsViewSpec.scala
+++ b/test/views/NotificationsViewSpec.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import controllers.routes
 import models.declaration.notifications.Notification
+import models.declaration.submissions.SubmissionStatus.SubmissionStatus
 import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
 import org.jsoup.nodes.Document
 import unit.tools.Stubs
@@ -34,8 +35,8 @@ class NotificationsViewSpec extends UnitViewSpec with Stubs {
   private val page = new submission_notifications(mainTemplate)
   private val actions = Action(RequestType.SubmissionRequest, UUID.randomUUID().toString)
   private val submission = Submission("id", "eori", "lrn", None, None, Seq(actions))
-  private def notification(status: SubmissionStatus = SubmissionStatus.Accepted) =
-    Notification("conv-id", "mrn", LocalDateTime.of(2019, 1, 1, 0, 0), status.fullCode, None, Seq.empty, "payload")
+  private def notification(status: SubmissionStatus = SubmissionStatus.ACCEPTED) =
+    Notification("conv-id", "mrn", LocalDateTime.of(2019, 1, 1, 0, 0), status, Seq.empty, "payload")
 
   private def createView(submission: Submission, notifications: Seq[Notification]): Document =
     page(submission, notifications)
@@ -43,7 +44,7 @@ class NotificationsViewSpec extends UnitViewSpec with Stubs {
   "View" should {
     "render notification" when {
       "status Accepted" in {
-        val view = createView(submission, Seq(notification(SubmissionStatus.Accepted)))
+        val view = createView(submission, Seq(notification(SubmissionStatus.ACCEPTED)))
 
         val rows = view.select("tbody tr")
         rows must haveSize(1)
@@ -55,7 +56,7 @@ class NotificationsViewSpec extends UnitViewSpec with Stubs {
       }
 
       "status Rejected" in {
-        val view = createView(submission, Seq(notification(SubmissionStatus.Rejected)))
+        val view = createView(submission, Seq(notification(SubmissionStatus.REJECTED)))
 
         val rows = view.select("tbody tr")
         rows must haveSize(1)

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -22,7 +22,7 @@ import base.Injector
 import controllers.routes
 import models.declaration.notifications.Notification
 import models.declaration.submissions.RequestType.{CancellationRequest, SubmissionRequest}
-import models.declaration.submissions.{Action, Submission}
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import org.jsoup.nodes.Element
 import play.api.i18n.MessagesApi
 import play.twirl.api.Html
@@ -69,13 +69,13 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
     "display page submissions" when {
       val actionSubmission = Action(
         requestType = SubmissionRequest,
-        conversationId = "conv-id",
+        id = "conv-id",
         requestTimestamp = LocalDateTime.of(2019, 1, 1, 0, 0, 0)
       )
 
       val actionCancellation = Action(
         requestType = CancellationRequest,
-        conversationId = "conv-id",
+        id = "conv-id",
         requestTimestamp = LocalDateTime.of(2021, 1, 1, 0, 0, 0)
       )
 
@@ -89,21 +89,19 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       )
 
       val notification = Notification(
-        conversationId = "conv-id",
+        actionId = "action-id",
         mrn = "mrn",
         dateTimeIssued = LocalDateTime.of(2020, 1, 1, 0, 0, 0),
-        functionCode = "01",
-        nameCode = None,
+        status = SubmissionStatus.ACCEPTED,
         errors = Seq.empty,
         payload = "payload"
       )
 
       val rejectedNotification = Notification(
-        conversationId = "convId",
+        actionId = "actionId",
         mrn = "mrn",
         dateTimeIssued = LocalDateTime.now(),
-        functionCode = "03",
-        nameCode = None,
+        status = SubmissionStatus.REJECTED,
         errors = Seq.empty,
         payload = ""
       )
@@ -148,20 +146,6 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
         tableCell(view)(1, 0).toString must include(
           routes.RejectedNotificationsController.displayPage(submission.uuid).url
         )
-      }
-
-      "submission status is unknown due to invalid notification functionCode" in {
-        val notificationWithUnknownStatus = notification.copy(functionCode = "abc")
-        val view = createView(Seq(submission -> Seq(notificationWithUnknownStatus)))
-
-        tableCell(view)(1, 4).text() mustBe "Unknown status"
-      }
-
-      "submission status is unknown due to invalid notification nameCode" in {
-        val notificationWithUnknownStatus = notification.copy(nameCode = Some("abc"))
-        val view = createView(Seq(submission -> Seq(notificationWithUnknownStatus)))
-
-        tableCell(view)(1, 4).text() mustBe "Unknown status"
       }
 
       "submission date is unknown due to missing submit action" in {


### PR DESCRIPTION
This PR requires both of the changes to the BE - i.e. the new `notification.actionId` and `action.id` fields 