### PR TITLE
CEDS-1691 - re-order action fields

### DIFF
--- a/app/models/declaration/submissions/Action.scala
+++ b/app/models/declaration/submissions/Action.scala
@@ -20,7 +20,7 @@ import java.time.LocalDateTime
 
 import play.api.libs.json.Json
 
-case class Action(requestType: RequestType, id: String, requestTimestamp: LocalDateTime = LocalDateTime.now())
+case class Action(id: String, requestType: RequestType, requestTimestamp: LocalDateTime = LocalDateTime.now())
 
 object Action {
   implicit val format = Json.format[Action]

--- a/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
@@ -23,6 +23,7 @@ import com.github.tomakehurst.wiremock.client.WireMock._
 import connectors.exchange.ExportsDeclarationExchange
 import forms.{CancelDeclaration, Lrn}
 import models.declaration.notifications.Notification
+import models.declaration.submissions.RequestType.SubmissionRequest
 import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
 import models.{Page, Paginated}
 import org.mockito.BDDMockito._
@@ -45,7 +46,7 @@ class CustomsDeclareExportsConnectorIntegrationSpec
   private val existingDeclaration = aDeclaration(withId(id))
   private val newDeclarationExchange = ExportsDeclarationExchange(newDeclaration)
   private val existingDeclarationExchange = ExportsDeclarationExchange(existingDeclaration)
-  private val action = Action(RequestType.SubmissionRequest, UUID.randomUUID().toString)
+  private val action = Action(UUID.randomUUID().toString, SubmissionRequest)
   private val submission = Submission(id, "eori", "lrn", Some("mrn"), None, Seq(action))
   private val notification =
     Notification("action-id", "mrn", LocalDateTime.now, SubmissionStatus.UNKNOWN, Seq.empty, "payload")

--- a/test/unit/controllers/RejectedNotificationsControllerSpec.scala
+++ b/test/unit/controllers/RejectedNotificationsControllerSpec.scala
@@ -17,7 +17,8 @@
 package unit.controllers
 
 import controllers.{routes, RejectedNotificationsController}
-import models.declaration.submissions.{Action, RequestType, Submission}
+import models.declaration.submissions.RequestType.SubmissionRequest
+import models.declaration.submissions.{Action, Submission}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
 import org.scalatest.OptionValues
@@ -40,7 +41,7 @@ class RejectedNotificationsControllerSpec extends ControllerSpec with OptionValu
   )(global)
 
   private val submissionId = "SubmissionId"
-  private val action = Action(RequestType.SubmissionRequest, "convId")
+  private val action = Action("convId", SubmissionRequest)
   private val submission = Submission(submissionId, "eori", "lrn", actions = Seq(action))
 
   override protected def beforeEach(): Unit = {

--- a/test/views/NotificationsViewSpec.scala
+++ b/test/views/NotificationsViewSpec.scala
@@ -21,6 +21,7 @@ import java.util.UUID
 
 import controllers.routes
 import models.declaration.notifications.Notification
+import models.declaration.submissions.RequestType.SubmissionRequest
 import models.declaration.submissions.SubmissionStatus.SubmissionStatus
 import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
 import org.jsoup.nodes.Document
@@ -33,7 +34,7 @@ import views.tags.ViewTest
 class NotificationsViewSpec extends UnitViewSpec with Stubs {
 
   private val page = new submission_notifications(mainTemplate)
-  private val actions = Action(RequestType.SubmissionRequest, UUID.randomUUID().toString)
+  private val actions = Action(UUID.randomUUID().toString, SubmissionRequest)
   private val submission = Submission("id", "eori", "lrn", None, None, Seq(actions))
   private def notification(status: SubmissionStatus = SubmissionStatus.ACCEPTED) =
     Notification("conv-id", "mrn", LocalDateTime.of(2019, 1, 1, 0, 0), status, Seq.empty, "payload")

--- a/test/views/RejectedNotificationErrorsViewSpec.scala
+++ b/test/views/RejectedNotificationErrorsViewSpec.scala
@@ -18,7 +18,8 @@ package views
 
 import base.Injector
 import controllers.routes
-import models.declaration.submissions.{Action, RequestType, Submission}
+import models.declaration.submissions.RequestType.SubmissionRequest
+import models.declaration.submissions.{Action, Submission}
 import play.api.i18n.MessagesApi
 import play.api.test.Helpers._
 import services.model.RejectionReason
@@ -31,13 +32,7 @@ class RejectedNotificationErrorsViewSpec extends UnitViewSpec with Stubs with In
   private val page = new rejected_notification_errors(mainTemplate)
   private val ducr = Some("DUCR")
   private val submission =
-    Submission(
-      "submissionId",
-      "eori",
-      "lrn",
-      ducr = ducr,
-      actions = Seq(Action(RequestType.SubmissionRequest, "convId"))
-    )
+    Submission("submissionId", "eori", "lrn", ducr = ducr, actions = Seq(Action("convId", SubmissionRequest)))
   private val rejectionReason = Seq(RejectionReason("code", "description"))
   private val view = page(submission, rejectionReason)(request, messages)
 


### PR DESCRIPTION
Something Ed suggested when I did the "conversationId" field rename but forgot to push.