### PR TITLE
CEDS-1612 Stop performing Json.toJson outside of Audit method

### DIFF
--- a/app/controllers/CancelDeclarationController.scala
+++ b/app/controllers/CancelDeclarationController.scala
@@ -63,7 +63,7 @@ class CancelDeclarationController @Inject()(
         (formWithErrors: Form[CancelDeclaration]) =>
           Future.successful(BadRequest(cancelDeclarationPage(formWithErrors))),
         form => {
-          auditService.auditAllPagesUserInput(Json.toJson(form).as[JsObject])
+          auditService.auditAllPagesDeclarationCancellation(form)
           val context = exportsMetrics.startTimer(cancelMetric)
           customsDeclareExportsConnector.createCancellation(form) andThen {
             case Failure(exception) =>

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -21,9 +21,8 @@ import controllers.util.{FormAction, SaveAndReturn}
 import javax.inject.Inject
 import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys
-import play.api.libs.json.{JsObject, Json}
 import play.api.mvc.{AnyContent, Call, Result, Results}
-import services.audit.AuditService
+import services.audit.{AuditService, AuditTypes}
 import uk.gov.hmrc.http.HeaderCarrier
 
 class Navigator @Inject()(appConfig: AppConfig, auditService: AuditService) {
@@ -31,7 +30,7 @@ class Navigator @Inject()(appConfig: AppConfig, auditService: AuditService) {
   def continueTo(call: Call)(implicit req: JourneyRequest[AnyContent], hc: HeaderCarrier): Result =
     FormAction.bindFromRequest match {
       case SaveAndReturn =>
-        auditService.auditAllPagesUserInput(Json.toJson(req.cacheModel).as[JsObject])
+        auditService.auditAllPagesUserInput(AuditTypes.SaveAndReturnSubmission, req.cacheModel)
         goToDraftConfirmation()
       case _ => Results.Redirect(call)
     }

--- a/app/services/SubmissionService.scala
+++ b/app/services/SubmissionService.scala
@@ -26,7 +26,6 @@ import metrics.MetricIdentifiers.submissionMetric
 import models.requests.JourneyRequest
 import models.{DeclarationStatus, ExportsDeclaration}
 import play.api.Logger
-import play.api.libs.json.{JsObject, Json}
 import services.audit.EventData._
 import services.audit.{AuditService, AuditTypes}
 import services.cache.ExportsCacheService
@@ -51,7 +50,7 @@ class SubmissionService @Inject()(
     legalDeclaration: LegalDeclaration
   )(implicit request: JourneyRequest[_], hc: HeaderCarrier, ec: ExecutionContext): Future[Option[String]] = {
     val timerContext = exportsMetrics.startTimer(submissionMetric)
-    auditService.auditAllPagesUserInput(getCachedData(exportsDeclaration))
+    auditService.auditAllPagesUserInput(AuditTypes.SubmissionPayload, exportsDeclaration)
 
     val completedDeclaration = if (exportsDeclaration.isComplete) {
       Future.successful(exportsDeclaration)
@@ -95,9 +94,6 @@ class SubmissionService @Inject()(
       Confirmed.toString -> legalDeclaration.confirmation.toString,
       SubmissionResult.toString -> result
     )
-
-  def getCachedData(exportsCacheModel: ExportsDeclaration)(implicit request: JourneyRequest[_]): JsObject =
-    Json.toJson(exportsCacheModel).as[JsObject]
 
   protected case class FormattedData(lrn: Option[String], ducr: Option[String], payload: String)
 

--- a/test/controllers/navigation/NavigatorTest.scala
+++ b/test/controllers/navigation/NavigatorTest.scala
@@ -24,6 +24,7 @@ import controllers.util._
 import models.SignedInUser
 import models.requests.{AuthenticatedRequest, ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys
+import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito._
 import org.mockito.Mockito.{verify, verifyZeroInteractions}
@@ -32,7 +33,7 @@ import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContent, Call, Result}
 import play.api.test.FakeRequest
 import play.api.test.Helpers._
-import services.audit.AuditService
+import services.audit.{AuditService, AuditTypes}
 import services.cache.ExportsDeclarationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -75,7 +76,7 @@ class NavigatorTest extends WordSpec with Matchers with MockitoSugar with Export
       )
       session(result).get(ExportsSessionKeys.declarationId) shouldBe None
 
-      verify(auditService).auditAllPagesUserInput(any())(any())
+      verify(auditService).auditAllPagesUserInput(ArgumentMatchers.eq(AuditTypes.SaveAndReturnSubmission), any())(any())
     }
 
     "Go to URL provided" when {

--- a/test/models/declaration/SupplementaryDeclarationTestData.scala
+++ b/test/models/declaration/SupplementaryDeclarationTestData.scala
@@ -37,6 +37,7 @@ import forms.declaration._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDec.AllowedAdditionalDeclarationTypes
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDecSpec._
 import forms.declaration.additionaldocuments.{DocumentIdentifierAndPart, DocumentWriteOff, DocumentsProduced}
+import forms.{CancelDeclaration, Lrn}
 import models.declaration.DeclarationAdditionalActorsDataSpec._
 import models.declaration.DeclarationHoldersDataSpec._
 import models.declaration.dectype.DeclarationTypeSupplementarySpec._
@@ -170,7 +171,6 @@ class SupplementaryDeclarationTestData extends WordSpec with MustMatchers {
 }
 
 object TransportInformationContainerSpec {
-  private val containerId = "id"
   val correctTransportInformationContainerData =
     TransportInformationContainerData(Seq(Container(id = "M1l3s", Seq.empty)))
   val emptyTransportInformationContainerData = TransportInformationContainer("")
@@ -178,6 +178,7 @@ object TransportInformationContainerSpec {
   val incorrectTransportInformationContainerJSON: JsValue = JsObject(Map(containerId -> JsString("123456789012345678")))
   val emptyTransportInformationContainerJSON: JsValue = JsObject(Map(containerId -> JsString("")))
   val correctTransportInformationContainerDataJSON: JsValue = Json.toJson(correctTransportInformationContainerData)
+  private val containerId = "id"
 }
 
 object SupplementaryDeclarationTestData {
@@ -207,6 +208,8 @@ object SupplementaryDeclarationTestData {
       officeOfExit = Some(correctOfficeOfExit)
     )
   )
+
+  lazy val cancellationDeclarationTest = CancelDeclaration(Lrn("FG7676767889"), "mrn", "description", "reason")
 
   lazy val allRecordsXmlMarshallingTest = allRecords.copy(
     items = Set(

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -53,12 +53,6 @@ class SubmissionServiceSpec
   val request = TestHelper.journeyRequest(FakeRequest("", ""), AllowedChoiceValues.SupplementaryDec)
 
   val legal = LegalDeclaration("Name", "Role", "email@test.com", true)
-
-  override def beforeEach(): Unit = {
-    super.beforeEach()
-    reset(mockExportsCacheService, mockCustomsDeclareExportsConnector, mockAuditService)
-  }
-
   val auditData = Map(
     EventData.EORI.toString -> request.authenticatedRequest.user.eori,
     EventData.LRN.toString -> "123LRN",
@@ -77,6 +71,11 @@ class SubmissionServiceSpec
     mockAuditService,
     exportMetrics
   )
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(mockExportsCacheService, mockCustomsDeclareExportsConnector, mockAuditService)
+  }
 
   def theExportsDeclarationSubmitted: ExportsDeclaration = {
     val captor: ArgumentCaptor[ExportsDeclaration] = ArgumentCaptor.forClass(classOf[ExportsDeclaration])
@@ -117,7 +116,8 @@ class SubmissionServiceSpec
 
       theExportsDeclarationSubmitted.status mustBe DeclarationStatus.COMPLETE
       verify(mockAuditService, times(1)).audit(any(), any())(any())
-      verify(mockAuditService, times(1)).auditAllPagesUserInput(any())(any())
+      verify(mockAuditService, times(1))
+        .auditAllPagesUserInput(ArgumentMatchers.eq(AuditTypes.SubmissionPayload), any())(any())
       verify(mockAuditService)
         .audit(ArgumentMatchers.eq(AuditTypes.Submission), ArgumentMatchers.eq[Map[String, String]](auditData))(any())
       registry.getTimers.get(exportMetrics.timerName(metric)).getCount mustBe >(timerBefore)

--- a/test/unit/controllers/CancelDeclarationControllerSpec.scala
+++ b/test/unit/controllers/CancelDeclarationControllerSpec.scala
@@ -20,8 +20,8 @@ import base.Injector
 import com.codahale.metrics.Timer
 import com.kenshoo.play.metrics.Metrics
 import controllers.CancelDeclarationController
-import forms.{CancelDeclaration, Lrn}
 import forms.cancellation.CancellationChangeReason.NoLongerRequired
+import forms.{CancelDeclaration, Lrn}
 import metrics.{ExportsMetrics, MetricIdentifiers}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -108,7 +108,7 @@ class CancelDeclarationControllerSpec
       stringResult must include("cancellation.confirmationPage.message")
       cancelTimer.getCount mustBe >=(timerBefore)
       cancelCounter.getCount mustBe >=(counterBefore)
-      verify(mockAuditService).auditAllPagesUserInput(any())(any())
+      verify(mockAuditService).auditAllPagesDeclarationCancellation(any())(any())
       verify(mockAuditService).audit(ArgumentMatchers.eq(AuditTypes.Cancellation), any())(any())
     }
 


### PR DESCRIPTION
Delegate the responsibility of converting a Declaration or Cancellation
form to a JsObject to the AuditService.

This makes clear who the responsibility is, although we now need to
create two methods to audit a declaration submission and a cancellation.