### PR TITLE
CEDS-1695 Fix for Pointer Numerical Field Sections

### DIFF
--- a/app/models/Pointer.scala
+++ b/app/models/Pointer.scala
@@ -62,7 +62,7 @@ case class Pointer(sections: Seq[PointerSection]) {
 
 object Pointer {
   implicit val format: Format[Pointer] =
-    Format(Reads(js => js.validate[JsString].map(string => Pointer(string.value))), Writes(pointer => JsString(pointer.toString)))
+    Format(Reads(js => js.validate[String].map(Pointer(_))), Writes(pointer => JsString(pointer.toString)))
 
   def apply(sections: String): Pointer = Pointer(sections.split("\\.").map(PointerSection(_)))
 }

--- a/test/models/PointerSpec.scala
+++ b/test/models/PointerSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.{JsString, JsSuccess, Json}
+
+class PointerSpec extends WordSpec with MustMatchers {
+
+  "PointerSection" should {
+    val field = PointerSection("ABC", PointerSectionType.FIELD)
+    val sequence = PointerSection("123", PointerSectionType.SEQUENCE)
+
+    "map field to pattern" in {
+      field.pattern mustBe "ABC"
+    }
+
+    "map sequence to pattern" in {
+      sequence.pattern mustBe "$"
+    }
+
+    "map field to string" in {
+      field.toString mustBe "ABC"
+    }
+
+    "map sequence to string" in {
+      sequence.toString mustBe "#123"
+    }
+
+    "map field from string" in {
+      PointerSection("ABC") mustBe field
+    }
+
+    "map sequence from string" in {
+      PointerSection("#123") mustBe sequence
+    }
+  }
+
+  "Pointer" should {
+    val field1 = PointerSection("ABC", PointerSectionType.FIELD)
+    val sequence1 = PointerSection("123", PointerSectionType.SEQUENCE)
+    val field2 = PointerSection("000", PointerSectionType.FIELD)
+    val sequence2 = PointerSection("321", PointerSectionType.SEQUENCE)
+    val pointer = Pointer(List(field1, sequence1, field2, sequence2))
+
+    "map to pattern" in {
+      pointer.pattern mustBe "ABC.$.000.$"
+    }
+
+    "map to string" in {
+      pointer.toString mustBe "ABC.#123.000.#321"
+    }
+
+    "serialize to JSON" in {
+      Json.toJson(pointer)(Pointer.format) mustBe JsString("ABC.#123.000.#321")
+    }
+
+    "deserialize from JSON" in {
+      Json.fromJson(JsString("ABC.#123.000.#321"))(Pointer.format) mustBe JsSuccess(pointer)
+    }
+  }
+
+}

--- a/test/unit/services/model/RejectionReasonSpec.scala
+++ b/test/unit/services/model/RejectionReasonSpec.scala
@@ -111,7 +111,7 @@ class RejectionReasonSpec extends UnitSpec {
       "list contains rejected notification" when {
         "pointer is known" in {
           given(messages.isDefinedAt(anyString())).willReturn(true)
-          val error = NotificationError("CDS12016", Some(Pointer("x.0.z")))
+          val error = NotificationError("CDS12016", Some(Pointer("x.#0.z")))
           val notification =
             Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, Seq(error), "")
 
@@ -122,7 +122,7 @@ class RejectionReasonSpec extends UnitSpec {
 
         "pointer is unknown" in {
           given(messages.isDefinedAt(anyString())).willReturn(false)
-          val error = NotificationError("CDS12016", Some(Pointer("x.0.z")))
+          val error = NotificationError("CDS12016", Some(Pointer("x.#0.z")))
           val notification =
             Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, Seq(error), "")
 


### PR DESCRIPTION
We used to presume a numerical section meant it was a sequence.
This assumption is not correct.

Sequence sections are now rendered in JSON as `#1` (for index 1)
e.g.
Pointer Before: `abc.1.def`
Pointer After: `abc.#1.def`

It means we can convert to and from the string/json version and retain the "section type"