### PR TITLE
CEDS-1119 Add Label to autocomplete element

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -15,8 +15,16 @@ document.addEventListener("DOMContentLoaded", function (event) {
                 var selected = this.element.children(":selected"),
                     value = selected.val() ? selected.text() : "";
 
-                this.input = $("<input>")
+                this.comboBoxLabel = $("<label>")
                     .appendTo(this.wrapper)
+
+                this.span = $("<span>")
+                    .appendTo(this.comboBoxLabel)
+                    .addClass("visuallyhidden")
+                    .text("Please type or choose an item from the list")
+
+                this.input = $("<input>")
+                    .appendTo(this.comboBoxLabel)   
                     .val(value)
                     .attr("autocomplete", "off")
                     .addClass("custom-combobox-input ui-state-default ui-corner-left")
@@ -51,7 +59,7 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     .attr("tabIndex", -1)
                     .attr("title", "Show All Items")
                     .tooltip()
-                    .appendTo(this.wrapper)
+                    .appendTo(this.comboBoxLabel)
                     .button({
                         icons: {
                             primary: "ui-icon-triangle-1-s"


### PR DESCRIPTION
This is an element that is generated by JS on our pages that require
list codes.
I decided to wrap the `<input>` element with a `<label>` in order to
avoid having to name unique ids, since on some pages we have more than
one autocomplete element.