### PR TITLE
CEDS-1718 Separate Choice and DeclarationType

### DIFF
--- a/app/connectors/exchange/ExportsDeclarationExchange.scala
+++ b/app/connectors/exchange/ExportsDeclarationExchange.scala
@@ -21,6 +21,7 @@ import java.time.Instant
 import forms.declaration._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
 import models.DeclarationStatus.DeclarationStatus
+import models.DeclarationType.DeclarationType
 import models.ExportsDeclaration
 import models.declaration.{ExportItem, Locations, Parties, TransportInformationContainerData}
 import play.api.libs.json.{Json, OFormat}
@@ -31,7 +32,7 @@ case class ExportsDeclarationExchange(
   createdDateTime: Instant,
   updatedDateTime: Instant,
   sourceId: Option[String],
-  choice: String,
+  `type`: DeclarationType,
   dispatchLocation: Option[DispatchLocation] = None,
   additionalDeclarationType: Option[AdditionalDeclarationType] = None,
   consignmentReferences: Option[ConsignmentReferences] = None,
@@ -51,7 +52,7 @@ case class ExportsDeclarationExchange(
     createdDateTime = this.createdDateTime,
     updatedDateTime = this.updatedDateTime,
     sourceId = this.sourceId,
-    choice = this.choice,
+    `type` = this.`type`,
     dispatchLocation = this.dispatchLocation,
     additionalDeclarationType = this.additionalDeclarationType,
     consignmentReferences = this.consignmentReferences,
@@ -77,7 +78,7 @@ object ExportsDeclarationExchange {
       createdDateTime = declaration.createdDateTime,
       updatedDateTime = declaration.updatedDateTime,
       sourceId = declaration.sourceId,
-      choice = declaration.choice,
+      `type` = declaration.`type`,
       dispatchLocation = declaration.dispatchLocation,
       additionalDeclarationType = declaration.additionalDeclarationType,
       consignmentReferences = declaration.consignmentReferences,

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -78,7 +78,7 @@ class ChoiceController @Inject()(
                 .getOrElse(throw new IllegalArgumentException(s"Cannot deduce Declaration Type from Choice [${choice.value}]"))
               request.declarationId match {
                 case Some(id) =>
-                  updateDeclarationTyoe(id, declarationType).map { _ =>
+                  updateDeclarationType(id, declarationType).map { _ =>
                     Redirect(controllers.declaration.routes.DispatchLocationController.displayPage(Mode.Normal))
                   }
                 case _ =>
@@ -97,7 +97,7 @@ class ChoiceController @Inject()(
       )
   }
 
-  private def updateDeclarationTyoe(id: String, `type`: DeclarationType)(implicit hc: HeaderCarrier) =
+  private def updateDeclarationType(id: String, `type`: DeclarationType)(implicit hc: HeaderCarrier) =
     exportsCacheService.get(id).map(_.map(_.copy(`type` = `type`))).flatMap {
       case Some(declaration) => exportsCacheService.update(declaration)
       case None =>

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -25,6 +25,7 @@ import forms.Choice
 import forms.Choice.AllowedChoiceValues._
 import forms.Choice._
 import javax.inject.Inject
+import models.DeclarationType.DeclarationType
 import models.requests.ExportsSessionKeys
 import models.{DeclarationStatus, ExportsDeclaration, Mode}
 import play.api.Logger
@@ -73,13 +74,15 @@ class ChoiceController @Inject()(
         choice =>
           choice.value match {
             case SupplementaryDec | StandardDec =>
+              val declarationType = choice.toDeclarationType
+                .getOrElse(throw new IllegalArgumentException(s"Cannot deduce Declaration Type from Choice [${choice.value}]"))
               request.declarationId match {
                 case Some(id) =>
-                  updateChoice(id, choice).map { _ =>
+                  updateDeclarationTyoe(id, declarationType).map { _ =>
                     Redirect(controllers.declaration.routes.DispatchLocationController.displayPage(Mode.Normal))
                   }
                 case _ =>
-                  create(choice) map { created =>
+                  create(declarationType) map { created =>
                     Redirect(controllers.declaration.routes.DispatchLocationController.displayPage(Mode.Normal))
                       .addingToSession(ExportsSessionKeys.declarationId -> created.id)
                   }
@@ -94,15 +97,15 @@ class ChoiceController @Inject()(
       )
   }
 
-  private def updateChoice(id: String, choice: Choice)(implicit hc: HeaderCarrier) =
-    exportsCacheService.get(id).map(_.map(_.copy(`type` = choice.toDeclarationType.get))).flatMap {
+  private def updateDeclarationTyoe(id: String, `type`: DeclarationType)(implicit hc: HeaderCarrier) =
+    exportsCacheService.get(id).map(_.map(_.copy(`type` = `type`))).flatMap {
       case Some(declaration) => exportsCacheService.update(declaration)
       case None =>
         logger.error(s"Failed to find declaration for id $id")
         Future.successful(None)
     }
 
-  private def create(choice: Choice)(implicit hc: HeaderCarrier) =
+  private def create(`type`: DeclarationType)(implicit hc: HeaderCarrier) =
     exportsCacheService
       .create(
         ExportsDeclarationExchange(
@@ -111,7 +114,7 @@ class ChoiceController @Inject()(
           createdDateTime = Instant.now,
           updatedDateTime = Instant.now,
           sourceId = None,
-          choice.toDeclarationType.get
+          `type`
         )
       )
 }

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -56,7 +56,7 @@ class ChoiceController @Inject()(
 
     request.declarationId match {
       case Some(id) if previousChoice.isEmpty =>
-        exportsCacheService.get(id).map(_.map(_.choice)).map {
+        exportsCacheService.get(id).map(_.map(_.`type`)).map {
           case Some(data) => Ok(choicePage(Choice.form().fill(Choice(data))))
           case _          => Ok(choicePage(Choice.form()))
         }
@@ -95,7 +95,7 @@ class ChoiceController @Inject()(
   }
 
   private def updateChoice(id: String, choice: Choice)(implicit hc: HeaderCarrier) =
-    exportsCacheService.get(id).map(_.map(_.copy(choice = choice.value))).flatMap {
+    exportsCacheService.get(id).map(_.map(_.copy(`type` = choice.toDeclarationType.get))).flatMap {
       case Some(declaration) => exportsCacheService.update(declaration)
       case None =>
         logger.error(s"Failed to find declaration for id $id")
@@ -111,7 +111,7 @@ class ChoiceController @Inject()(
           createdDateTime = Instant.now,
           updatedDateTime = Instant.now,
           sourceId = None,
-          choice.value
+          choice.toDeclarationType.get
         )
       )
 }

--- a/app/forms/Choice.scala
+++ b/app/forms/Choice.scala
@@ -16,13 +16,21 @@
 
 package forms
 
+import models.DeclarationType
+import models.DeclarationType.DeclarationType
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms, Mapping}
 import play.api.libs.json.Json
 import play.api.mvc.QueryStringBindable
 import utils.validators.forms.FieldValidator.isContainedIn
 
-case class Choice(value: String)
+case class Choice(value: String) {
+  def toDeclarationType: Option[DeclarationType] = value match {
+    case Choice.AllowedChoiceValues.SupplementaryDec => Some(DeclarationType.SUPPLEMENTARY)
+    case Choice.AllowedChoiceValues.StandardDec      => Some(DeclarationType.STANDARD)
+    case _                                           => None
+  }
+}
 
 object Choice {
   implicit val format = Json.format[Choice]
@@ -39,6 +47,11 @@ object Choice {
     ).verifying("choicePage.input.error.empty", _.isDefined)
       .transform[Choice](choice => Choice(choice.getOrElse("")), choice => Some(choice.value))
   )
+
+  def apply(`type`: DeclarationType): Choice = `type` match {
+    case DeclarationType.STANDARD      => Choice(StandardDec)
+    case DeclarationType.SUPPLEMENTARY => Choice(SupplementaryDec)
+  }
 
   def form(): Form[Choice] = Form(choiceMapping)
 

--- a/app/models/DeclarationType.scala
+++ b/app/models/DeclarationType.scala
@@ -14,14 +14,13 @@
  * limitations under the License.
  */
 
-package models.requests
+package models
 
-import forms.Choice
-import models.ExportsDeclaration
-import play.api.mvc.WrappedRequest
+import play.api.libs.json._
+import utils.EnumJson
 
-class JourneyRequest[A](val authenticatedRequest: AuthenticatedRequest[A], val cacheModel: ExportsDeclaration)
-    extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {
-  val choice: Choice = Choice(cacheModel.`type`)
-  def eori: String = authenticatedRequest.user.eori
+object DeclarationType extends Enumeration {
+  type DeclarationType = Value
+  implicit val format: Format[DeclarationType.Value] = EnumJson.format(DeclarationType)
+  val STANDARD, SUPPLEMENTARY, SIMPLIFIED = Value
 }

--- a/app/models/ExportsDeclaration.scala
+++ b/app/models/ExportsDeclaration.scala
@@ -18,10 +18,10 @@ package models
 
 import java.time.{Clock, Instant}
 
-import connectors.exchange.ExportsDeclarationExchange
 import forms.declaration._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
 import models.DeclarationStatus.DeclarationStatus
+import models.DeclarationType.DeclarationType
 import models.declaration._
 import play.api.libs.json._
 
@@ -31,7 +31,7 @@ case class ExportsDeclaration(
   createdDateTime: Instant,
   updatedDateTime: Instant,
   sourceId: Option[String],
-  choice: String,
+  `type`: DeclarationType,
   dispatchLocation: Option[DispatchLocation] = None,
   additionalDeclarationType: Option[AdditionalDeclarationType] = None,
   consignmentReferences: Option[ConsignmentReferences] = None,

--- a/test/base/TestHelper.scala
+++ b/test/base/TestHelper.scala
@@ -43,14 +43,4 @@ object TestHelper {
   val saveAndContinueActionUrlEncoded = (SaveAndContinue.toString, "")
   def removeActionUrlEncoded(value: String) = (Remove.toString, value)
 
-  def journeyRequest(fakeRequest: FakeRequest[_], choice: String): JourneyRequest[_] = {
-    val cache = ExportsDeclaration(UUID.randomUUID.toString, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), None, choice)
-    new JourneyRequest(new AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))), cache)
-  }
-
-  def journeyRequest(fakeRequest: Request[_], choice: String): JourneyRequest[_] = {
-    val cache = ExportsDeclaration(UUID.randomUUID.toString, DeclarationStatus.COMPLETE, Instant.now(), Instant.now(), None, choice)
-    new JourneyRequest(new AuthenticatedRequest(fakeRequest, ExportsTestData.newUser(Random.nextString(10), Random.nextString(5))), cache)
-  }
-
 }

--- a/test/connectors/exchange/ExportsDeclarationExchangeSpec.scala
+++ b/test/connectors/exchange/ExportsDeclarationExchangeSpec.scala
@@ -22,7 +22,7 @@ import forms.{Ducr, Lrn}
 import forms.declaration._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
 import models.declaration.{ExportItem, Locations, Parties, TransportInformationContainerData}
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, DeclarationType, ExportsDeclaration}
 import org.scalatestplus.mockito.MockitoSugar
 import org.mockito.Mockito.when
 import org.scalatest.{Matchers, WordSpec}
@@ -33,7 +33,7 @@ class ExportsDeclarationExchangeSpec extends WordSpec with Matchers with Exports
   private val id = "id"
   private val sourceId = "source-id"
   private val status = DeclarationStatus.COMPLETE
-  private val choice = "choice"
+  private val `type` = DeclarationType.STANDARD
   private val createdDate = Instant.MIN
   private val updatedDate = Instant.MAX
   private val dispatchLocation = mock[DispatchLocation]
@@ -59,7 +59,7 @@ class ExportsDeclarationExchangeSpec extends WordSpec with Matchers with Exports
     createdDateTime = createdDate,
     updatedDateTime = updatedDate,
     sourceId = Some(sourceId),
-    choice = choice,
+    `type` = `type`,
     dispatchLocation = Some(dispatchLocation),
     additionalDeclarationType = Some(additionalDeclarationType),
     consignmentReferences = Some(consignmentReferences),
@@ -80,7 +80,7 @@ class ExportsDeclarationExchangeSpec extends WordSpec with Matchers with Exports
     createdDateTime = createdDate,
     updatedDateTime = updatedDate,
     sourceId = Some(sourceId),
-    choice = choice,
+    `type` = `type`,
     dispatchLocation = Some(dispatchLocation),
     additionalDeclarationType = Some(additionalDeclarationType),
     consignmentReferences = Some(consignmentReferences),

--- a/test/forms/ChoiceSpec.scala
+++ b/test/forms/ChoiceSpec.scala
@@ -17,6 +17,7 @@
 package forms
 
 import forms.Choice.AllowedChoiceValues._
+import models.DeclarationType
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 
@@ -49,6 +50,16 @@ class ChoiceSpec extends WordSpec with MustMatchers {
 
         form.hasErrors must be(false)
       }
+    }
+  }
+
+  "to declaration type" should {
+    "convert to dec type" in {
+      Choice(Choice.AllowedChoiceValues.StandardDec).toDeclarationType mustBe Some(DeclarationType.STANDARD)
+      Choice(Choice.AllowedChoiceValues.SupplementaryDec).toDeclarationType mustBe Some(DeclarationType.SUPPLEMENTARY)
+      Choice(Choice.AllowedChoiceValues.Submissions).toDeclarationType mustBe None
+      Choice(Choice.AllowedChoiceValues.CancelDec).toDeclarationType mustBe None
+      Choice(Choice.AllowedChoiceValues.ContinueDec).toDeclarationType mustBe None
     }
   }
 

--- a/test/models/declaration/SupplementaryDeclarationTestData.scala
+++ b/test/models/declaration/SupplementaryDeclarationTestData.scala
@@ -44,7 +44,7 @@ import models.declaration.DeclarationHoldersDataSpec._
 import models.declaration.dectype.DeclarationTypeSupplementarySpec._
 import models.declaration.governmentagencygoodsitem.Formats._
 import models.declaration.governmentagencygoodsitem.{Amount, GovernmentAgencyGoodsItem}
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, DeclarationType, ExportsDeclaration}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json._
 
@@ -300,7 +300,8 @@ object SupplementaryDeclarationTestData {
   val correctPackingJSON: JsValue = JsObject(
     Map("sequenceNumeric" -> JsString("0"), "marksNumbersId" -> JsString("wefdsf"), "typeCode" -> JsString("22"))
   )
-  val declaration = ExportsDeclaration(UUID.randomUUID.toString, DeclarationStatus.DRAFT, Instant.now(), Instant.now(), None, "SMP")
+  val declaration =
+    ExportsDeclaration(UUID.randomUUID.toString, DeclarationStatus.DRAFT, Instant.now(), Instant.now(), None, DeclarationType.SUPPLEMENTARY)
 
   def createGovernmentAgencyGoodsItem(): GovernmentAgencyGoodsItem =
     GovernmentAgencyGoodsItem(

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -22,7 +22,7 @@ import config.AppConfig
 import connectors.CustomsDeclareExportsConnector
 import forms.declaration.LegalDeclaration
 import metrics.{ExportsMetrics, MetricIdentifiers}
-import models.DeclarationStatus
+import models.{DeclarationStatus, DeclarationType}
 import models.declaration.submissions.{Action, Submission}
 import org.mockito.ArgumentMatchers.{any, eq => equalTo}
 import org.mockito.Mockito.{reset, verify, when}
@@ -49,7 +49,7 @@ class SubmissionServiceSpec
     EventData.eori.toString -> "eori",
     EventData.lrn.toString -> "123LRN",
     EventData.ducr.toString -> "ducr",
-    EventData.decType.toString -> "STD",
+    EventData.decType.toString -> "STANDARD",
     EventData.fullName.toString -> legal.fullName,
     EventData.jobRole.toString -> legal.jobRole,
     EventData.email.toString -> legal.email,
@@ -73,7 +73,12 @@ class SubmissionServiceSpec
       "valid declaration" in {
         // Given
         val declaration =
-          aDeclaration(withId("id"), withStatus(DeclarationStatus.DRAFT), withChoice("STD"), withConsignmentReferences(ducr = "ducr", lrn = "123LRN"))
+          aDeclaration(
+            withId("id"),
+            withStatus(DeclarationStatus.DRAFT),
+            withType(DeclarationType.STANDARD),
+            withConsignmentReferences(ducr = "ducr", lrn = "123LRN")
+          )
         val submission = Submission(uuid = "id", eori = "eori", lrn = "lrn", actions = Seq.empty[Action])
         when(connector.submitDeclaration(any[String])(any(), any())).thenReturn(Future.successful(submission))
 

--- a/test/services/cache/ExportsDeclarationBuilder.scala
+++ b/test/services/cache/ExportsDeclarationBuilder.scala
@@ -28,8 +28,9 @@ import forms.declaration.destinationCountries.DestinationCountries
 import forms.declaration.officeOfExit.OfficeOfExit
 import forms.{Choice, Ducr, Lrn}
 import models.DeclarationStatus.DeclarationStatus
+import models.DeclarationType.DeclarationType
 import models.declaration._
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, DeclarationType, ExportsDeclaration}
 
 //noinspection ScalaStyle
 trait ExportsDeclarationBuilder {
@@ -44,7 +45,7 @@ trait ExportsDeclarationBuilder {
     status = DeclarationStatus.COMPLETE,
     createdDateTime = LocalDateTime.of(2019, 1, 1, 0, 0, 0).toInstant(ZoneOffset.UTC),
     updatedDateTime = LocalDateTime.of(2019, 2, 2, 0, 0, 0).toInstant(ZoneOffset.UTC),
-    choice = Choice.AllowedChoiceValues.StandardDec,
+    `type` = DeclarationType.STANDARD,
     sourceId = None
   )
 
@@ -59,7 +60,7 @@ trait ExportsDeclarationBuilder {
 
   def withStatus(status: DeclarationStatus): ExportsDeclarationModifier = _.copy(status = status)
 
-  def withChoice(choice: String): ExportsDeclarationModifier = _.copy(choice = choice)
+  def withType(`type`: DeclarationType): ExportsDeclarationModifier = _.copy(`type` = `type`)
 
   def withSourceId(id: String = uuid): ExportsDeclarationModifier = _.copy(sourceId = Some(id))
 

--- a/test/services/cache/ExportsTestData.scala
+++ b/test/services/cache/ExportsTestData.scala
@@ -19,6 +19,8 @@ package services.cache
 import base.ExportsTestData.newUser
 import forms.Choice
 import forms.declaration.GoodsLocation
+import models.DeclarationType
+import models.DeclarationType.DeclarationType
 import models.declaration.Container
 import models.requests.{AuthenticatedRequest, JourneyRequest}
 import play.api.test.FakeRequest
@@ -26,8 +28,8 @@ import utils.FakeRequestCSRFSupport._
 
 trait ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder {
 
-  private def declaration(choice: String) = aDeclaration(
-    withChoice(choice),
+  private def declaration(`type`: DeclarationType) = aDeclaration(
+    withType(`type`),
     withConsignmentReferences(),
     withDestinationCountries(),
     withGoodsLocation(GoodsLocation("PL", "type", "id", Some("a"), Some("b"), Some("c"), Some("d"), Some("e"))),
@@ -39,6 +41,6 @@ trait ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder 
     withItem(anItem())
   )
 
-  protected def journeyRequest(choice: String = Choice.AllowedChoiceValues.StandardDec) =
-    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration(choice))
+  protected def journeyRequest(`type`: DeclarationType = DeclarationType.STANDARD) =
+    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration(`type`))
 }

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -19,8 +19,9 @@ package unit.controllers
 import controllers.ChoiceController
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
+import models.DeclarationType.DeclarationType
 import models.requests.ExportsSessionKeys
-import models.{DeclarationStatus, ExportsDeclaration}
+import models.{DeclarationStatus, DeclarationType, ExportsDeclaration}
 import org.scalatest.OptionValues
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.{AnyContentAsJson, Request}
@@ -33,11 +34,11 @@ import views.html.choice_page
 class ChoiceControllerSpec extends ControllerSpec with OptionValues {
   import ChoiceControllerSpec._
 
-  private def existingDeclaration(choice: String = SupplementaryDec) =
-    aDeclaration(withId("existingDeclarationId"), withChoice(choice))
+  private def existingDeclaration(choice: DeclarationType = DeclarationType.SUPPLEMENTARY) =
+    aDeclaration(withId("existingDeclarationId"), withType(choice))
 
   private val newDeclaration =
-    aDeclaration(withId("newDeclarationId"), withChoice(SupplementaryDec))
+    aDeclaration(withId("newDeclarationId"), withType(DeclarationType.SUPPLEMENTARY))
 
   val choicePage = new choice_page(mainTemplate, minimalAppConfig)
 
@@ -101,7 +102,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues {
     "pre-select declaration type " when {
 
       "choice parameter not given" in {
-        withNewCaching(existingDeclaration(SupplementaryDec))
+        withNewCaching(existingDeclaration(DeclarationType.SUPPLEMENTARY))
 
         val request = getRequest()
         val result = controller.displayPage(None)(request)
@@ -151,12 +152,12 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues {
         val created = theCacheModelCreated
         created.id mustBe None
         created.status mustBe DeclarationStatus.DRAFT
-        created.choice mustBe "SMP"
+        created.`type` mustBe DeclarationType.SUPPLEMENTARY
         created.sourceId mustBe None
       }
 
       "user chooses Supplementary Dec for existing Standard Dec" in {
-        val existingDec = existingDeclaration(StandardDec)
+        val existingDec = existingDeclaration(DeclarationType.STANDARD)
         withNewCaching(existingDec)
 
         val result = controller.submitChoice()(postRequest(supplementaryChoice, existingDec))
@@ -165,7 +166,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues {
         redirectLocation(result) must be(Some(controllers.declaration.routes.DispatchLocationController.displayPage().url))
         val updated: ExportsDeclaration = theCacheModelUpdated
         updated.id mustBe existingDec.id
-        updated.choice mustBe "SMP"
+        updated.`type` mustBe DeclarationType.SUPPLEMENTARY
       }
 
       "user chooses Standard Dec for new declaration" in {
@@ -179,11 +180,11 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues {
         val created = theCacheModelCreated
         created.id mustBe None
         created.status mustBe DeclarationStatus.DRAFT
-        created.choice mustBe "STD"
+        created.`type` mustBe DeclarationType.STANDARD
       }
 
       "user chooses Standard Dec for existing Supplementary Dec" in {
-        val existingDec = existingDeclaration(SupplementaryDec)
+        val existingDec = existingDeclaration(DeclarationType.SUPPLEMENTARY)
         withNewCaching(existingDec)
 
         val result = controller.submitChoice()(postRequest(standardChoice, existingDec))
@@ -192,7 +193,7 @@ class ChoiceControllerSpec extends ControllerSpec with OptionValues {
         redirectLocation(result) must be(Some(controllers.declaration.routes.DispatchLocationController.displayPage().url))
         val updated = theCacheModelUpdated
         updated.id mustBe existingDec.id
-        updated.choice mustBe "STD"
+        updated.`type` mustBe DeclarationType.STANDARD
       }
     }
 

--- a/test/unit/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.AdditionalDeclarationTypeController
 import controllers.util.SaveAndContinue
 import forms.Choice
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -44,11 +44,11 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec {
   }
 
   trait SupplementarySetUp extends SetUp {
-    withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   trait StandardSetUp extends SetUp {
-    withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.StandardDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
   }
 
   "Display Page" should {
@@ -60,7 +60,7 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec {
       }
 
       "cache is populated during supplementary journey" in new SupplementarySetUp {
-        val cachedData = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
+        val cachedData = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
           .copy(additionalDeclarationType = Some(AdditionalDeclarationType("Z")))
         withNewCaching(cachedData)
 
@@ -76,7 +76,7 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec {
       }
 
       "cache is populated during standard journey" in new StandardSetUp {
-        val cachedData = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
+        val cachedData = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
           .copy(additionalDeclarationType = Some(AdditionalDeclarationType("D")))
         withNewCaching(cachedData)
 

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.util.Remove
 import forms.Choice
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
 import models.declaration.ExportItem
-import models.{ExportsDeclaration, Mode}
+import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.mvc.Result
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -56,7 +56,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "display page method is invoked with empty cache" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
         val result: Future[Result] = controller.displayPage(Mode.Normal, item.id)(getRequest())
 
         status(result) must be(OK)
@@ -65,7 +65,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
       "display page method is invoked with empty additional fiscal references" in new SetUp {
         val itemCacheData = ExportItem("itemId", additionalFiscalReferencesData = None)
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val result: Future[Result] = controller.displayPage(Mode.Normal, itemCacheData.id)(getRequest())
@@ -78,7 +78,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val itemCacheData =
           ExportItem("itemId", additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("PL", "12345")))))
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val result: Future[Result] = controller.displayPage(Mode.Normal, itemCacheData.id)(getRequest())
@@ -91,7 +91,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "user provide wrong action" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
 
         val wrongAction: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "12345"), ("WrongAction", ""))
 
@@ -106,7 +106,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "user put incorrect data" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
 
         val incorrectForm: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "!@#$"), addActionUrlEncoded())
 
@@ -121,7 +121,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val itemCacheData =
           ExportItem("itemId", additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("PL", "12345")))))
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val duplicatedForm: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "12345"), addActionUrlEncoded())
@@ -139,7 +139,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
           additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq.fill(99)(AdditionalFiscalReference("PL", "12345"))))
         )
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val form: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "54321"), addActionUrlEncoded())
@@ -155,7 +155,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "user put incorrect data" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
 
         val incorrectForm: Seq[(String, String)] =
           Seq(("country", "PL"), ("reference", "!@#$"), saveAndContinueActionUrlEncoded)
@@ -171,7 +171,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val itemCacheData =
           ExportItem("itemId", additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("PL", "12345")))))
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val duplicatedForm: Seq[(String, String)] =
@@ -190,7 +190,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
           additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq.fill(99)(AdditionalFiscalReference("PL", "12345"))))
         )
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val form: Seq[(String, String)] =
@@ -207,7 +207,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "user correctly add new item" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
 
         val correctForm: Seq[(String, String)] = Seq(("country", "PL"), ("reference", "12345"), addActionUrlEncoded())
 
@@ -219,7 +219,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
 
       "user save correct data" in new SetUp {
         val item = anItem()
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item)))
 
         val correctForm: Seq[(String, String)] =
           Seq(("country", "PL"), ("reference", "12345"), saveAndContinueActionUrlEncoded)
@@ -237,7 +237,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
           additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq.fill(99)(AdditionalFiscalReference("PL", "12345"))))
         )
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val correctForm: (String, String) = saveAndContinueActionUrlEncoded
@@ -254,7 +254,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
         val itemCacheData =
           ExportItem("itemId", additionalFiscalReferencesData = Some(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("PL", "12345")))))
         val cachedData: ExportsDeclaration =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val removeForm: (String, String) = (Remove.toString, "0")

--- a/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.{routes, AdditionalInformationController}
 import controllers.util.Remove
 import forms.Choice
 import forms.declaration.AdditionalInformation
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.{AdditionalInformationData, ExportItem}
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -45,7 +45,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
 
     setupErrorHandler()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Additional information controller" should {
@@ -64,7 +64,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val result = controller.displayPage(Mode.Normal, "itemId")(getRequest())
@@ -102,7 +102,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val duplicatedForm = Seq(("code", "12345"), ("description", "description"), addActionUrlEncoded())
@@ -118,7 +118,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq.fill(99)(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val form = Seq(("code", "12345"), ("description", "text"), addActionUrlEncoded())
@@ -146,7 +146,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val duplicatedForm = Seq(("code", "12345"), ("description", "description"), saveAndContinueActionUrlEncoded)
@@ -162,7 +162,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq.fill(99)(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val form = Seq(("code", "12345"), ("description", "text"), saveAndContinueActionUrlEncoded)
@@ -199,7 +199,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq.fill(99)(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val correctForm = saveAndContinueActionUrlEncoded
@@ -215,7 +215,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
         val itemCacheData =
           ExportItem("itemId", additionalInformation = Some(AdditionalInformationData(Seq(AdditionalInformation("12345", "description")))))
         val cachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(itemCacheData))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(itemCacheData))
         withNewCaching(cachedData)
 
         val removeForm = (Remove.toString, "0")

--- a/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.BorderTransportController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.TransportCodes.{cash, IMOShipIDNumber}
 import forms.declaration.BorderTransport
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -41,7 +41,7 @@ class BorderTransportControllerSpec extends ControllerSpec {
     )(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Transport Details Controller" should {

--- a/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.{routes, CarrierDetailsController}
 import forms.Choice
 import forms.declaration.{CarrierDetails, EntityDetails}
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -40,7 +40,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
     )(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Carrier Details Controller" should {

--- a/test/unit/controllers/declaration/CommodityMeasureControllerSpec.scala
+++ b/test/unit/controllers/declaration/CommodityMeasureControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.{routes, CommodityMeasureController}
 import forms.Choice
 import forms.declaration.{CommodityMeasure, PackageInformation}
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.ExportItem
 import play.api.libs.json.Json
 import play.api.test.Helpers._
@@ -44,7 +44,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
     val item =
       ExportItem("itemId", packageInformation = List(PackageInformation("123", 123, "123")))
-    val cachedData = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item))
+    val cachedData = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item))
 
     withNewCaching(cachedData)
   }
@@ -64,7 +64,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
         val commodityItem = item.copy(commodityMeasure = Some(CommodityMeasure(None, "123", "123")))
         val commodityCachedData =
-          aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withItem(item))
+          aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(item))
         withNewCaching(commodityCachedData)
 
         val result = controller.displayPage(Mode.Normal, "itemId")(getRequest())
@@ -76,7 +76,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
     "return 400 (BAD_REQUEST)" when {
 
       "display page method is invoked and commodity package information cache is empty" in new SetUp {
-        val noPackageCache = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
+        val noPackageCache = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
         withNewCaching(noPackageCache)
 
         val result = controller.displayPage(Mode.Normal, "itemId")(getRequest())
@@ -86,7 +86,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
       "form is incorrect" in new SetUp {
 
-        val noPackageCache = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
+        val noPackageCache = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
         withNewCaching(noPackageCache)
 
         val incorrectForm = Json.toJson(CommodityMeasure(None, "", ""))
@@ -101,7 +101,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
       "information provided by user are correct" in new SetUp {
 
-        val noPackageCache = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec))
+        val noPackageCache = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
         withNewCaching(noPackageCache)
 
         val correctForm = Json.toJson(CommodityMeasure(None, "1234.12", "1234.12"))

--- a/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -17,9 +17,8 @@
 package unit.controllers.declaration
 
 import controllers.declaration.ConsigneeDetailsController
-import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.{ConsigneeDetails, EntityDetails}
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -39,7 +38,7 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
       consigneeDetailsPage
     )(ec)
 
-    val model = aDeclaration(withChoice(SupplementaryDec))
+    val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
     authorizedUser()
     withNewCaching(model)
   }

--- a/test/unit/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.ConsignmentReferencesController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.{Ducr, Lrn}
 import forms.declaration.ConsignmentReferences
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -41,7 +41,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec {
     )(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Consignment References controller" should {

--- a/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.DeclarantDetailsController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.{DeclarantDetails, EntityDetails}
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -40,7 +40,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec {
     )(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Declarant Details Controller" should {

--- a/test/unit/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
@@ -21,7 +21,7 @@ import controllers.declaration.DeclarationAdditionalActorsController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.DeclarationAdditionalActors
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.DeclarationAdditionalActorsData
 import play.api.libs.json.Json
 import play.api.test.Helpers._
@@ -46,7 +46,7 @@ class DeclarationAdditionalActorsControllerSpec extends ControllerSpec with Erro
 
     setupErrorHandler()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   val eori = "GB123456"

--- a/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.{routes, DepartureTransportController}
 import forms.Choice
 import forms.declaration.DepartureTransport
 import forms.declaration.TransportCodes.{Maritime, WagonNumber}
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.{JsValue, Json}
 import play.api.mvc.Result
 import play.api.test.Helpers._
@@ -46,7 +46,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
     setupErrorHandler()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Border transport controller" should {
@@ -62,7 +62,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "display page method is invoked and cache contains data" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withBorderTransport(Maritime, WagonNumber, "FAA")))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withBorderTransport(Maritime, WagonNumber, "FAA")))
 
         val result: Future[Result] = controller.displayPage(Mode.Normal)(getRequest())
 

--- a/test/unit/controllers/declaration/DestinationCountriesControllerSpec.scala
+++ b/test/unit/controllers/declaration/DestinationCountriesControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.DestinationCountriesController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.destinationCountries.DestinationCountries
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -49,11 +49,11 @@ class DestinationCountriesControllerSpec extends ControllerSpec with ErrorHandle
   }
 
   trait SupplementarySetUp extends SetUp {
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   trait StandardSetUp extends SetUp {
-    withNewCaching(aDeclaration(withChoice(StandardDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
   }
 
   "Destination Countries controller" should {

--- a/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
+++ b/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.DispatchLocationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.DispatchLocation
 import forms.declaration.DispatchLocation.AllowedDispatchLocations._
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -41,7 +41,7 @@ class DispatchLocationControllerSpec extends ControllerSpec {
     )(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Dispatch Location controller" should {

--- a/test/unit/controllers/declaration/DocumentProducedControllerSpec.scala
+++ b/test/unit/controllers/declaration/DocumentProducedControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.DocumentsProducedController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.additionaldocuments.DocumentsProduced
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.DocumentsProducedData
 import org.mockito.ArgumentMatchers.{any, refEq}
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -50,7 +50,7 @@ class DocumentProducedControllerSpec extends ControllerSpec with ErrorHandlerMoc
     super.beforeEach()
     authorizedUser()
     setupErrorHandler()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockDocumentProducedPage.apply(any(), any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.{routes, FiscalInformationController}
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.FiscalInformation
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers._
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -48,7 +48,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockFiscalInformationPage.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.ItemsSummaryController
 import controllers.util.{Add, SaveAndContinue, SaveAndReturn}
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.ExportItem
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.{any, eq => meq}
@@ -51,7 +51,7 @@ class ItemsSummaryControllerSpec extends ControllerSpec with OptionValues {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockItemsSummaryPage.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
     when(mockExportIdGeneratorService.generateItemId()).thenReturn(itemId)
   }
@@ -118,7 +118,7 @@ class ItemsSummaryControllerSpec extends ControllerSpec with OptionValues {
 
       "there is not completed item in the cache" in {
 
-        val cachedData = aDeclaration(withChoice(SupplementaryDec), withItem(anItem(withItemId("id"))))
+        val cachedData = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withItem(anItem(withItemId("id"))))
         withNewCaching(cachedData)
 
         val result = controller.submit(Mode.Normal)(postRequestAsFormUrlEncoded(SaveAndContinue.toString -> ""))

--- a/test/unit/controllers/declaration/LocationControllerSpec.scala
+++ b/test/unit/controllers/declaration/LocationControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.LocationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.GoodsLocation
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -47,7 +47,7 @@ class LocationControllerSpec extends ControllerSpec with OptionValues {
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockGoodsLocationPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/NatureOfTransactionControllerSpec.scala
+++ b/test/unit/controllers/declaration/NatureOfTransactionControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.NatureOfTransactionController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.NatureOfTransaction
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -47,7 +47,7 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockNatureOfTransactionPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
+++ b/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
@@ -18,6 +18,7 @@ package unit.controllers.declaration
 
 import controllers.declaration.NotEligibleController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
+import models.DeclarationType
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
 import views.html.declaration.not_eligible
@@ -31,7 +32,7 @@ class NotEligibleControllerSpec extends ControllerSpec {
       new NotEligibleController(mockAuthAction, mockJourneyAction, stubMessagesControllerComponents(), notEligiblePage)(ec)
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Not Eligible Controller" should {

--- a/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
+++ b/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.OfficeOfExitController
 import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.officeOfExit.{OfficeOfExitStandard, OfficeOfExitSupplementary}
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -83,7 +83,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "display page method is invoked and cache is empty" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val result = controller.displayPage(Mode.Normal)(getRequest())
 
@@ -96,7 +96,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
       "display page method is invoked and cache contains data" in {
 
         val officeId = "officeId"
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec), withOfficeOfExit(officeId)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withOfficeOfExit(officeId)))
 
         val result = controller.displayPage(Mode.Normal)(getRequest())
 
@@ -111,7 +111,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "form is incorrect" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val incorrectForm = Json.toJson(OfficeOfExitSupplementary("!@#$"))
 
@@ -126,7 +126,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "information provided by user are correct" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val correctForm = Json.toJson(OfficeOfExitSupplementary("officeId"))
 
@@ -145,7 +145,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "display page method is invoked and cache is empty" in {
 
-        withNewCaching(aDeclaration(withChoice(StandardDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
 
         val result = controller.displayPage(Mode.Normal)(getRequest())
 
@@ -159,7 +159,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
         val officeId = "officeId"
         val circumstancesCode = "Yes"
-        withNewCaching(aDeclaration(withChoice(StandardDec), withOfficeOfExit(officeId, Some(circumstancesCode))))
+        withNewCaching(aDeclaration(withType(DeclarationType.STANDARD), withOfficeOfExit(officeId, Some(circumstancesCode))))
 
         val result = controller.displayPage(Mode.Normal)(getRequest())
 
@@ -175,7 +175,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "form is incorrect" in {
 
-        withNewCaching(aDeclaration(withChoice(StandardDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
 
         val incorrectForm = Json.toJson(OfficeOfExitStandard("!@#$", "wrong"))
 
@@ -190,7 +190,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
       "information provided by user are correct" in {
 
-        withNewCaching(aDeclaration(withChoice(StandardDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
 
         val correctForm = Json.toJson(OfficeOfExitStandard("officeId", "Yes"))
 

--- a/test/unit/controllers/declaration/PackageInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/PackageInformationControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.PackageInformationController
 import controllers.util.{Add, SaveAndContinue}
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.PackageInformation
-import models.Mode
+import models.{DeclarationType, Mode}
 import play.api.test.Helpers._
 import services.cache.ExportsItemBuilder
 import unit.base.ControllerSpec
@@ -47,7 +47,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
     val itemId = exampleItem.id
 
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     setupErrorHandler()
   }
 
@@ -57,7 +57,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "display page method is invoked and cache is empty" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
 
@@ -80,7 +80,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "action is incorrect" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val body =
           Seq(("typesOfPackages", "NT"), ("numberOfPackages", "123"), ("shippingMarks", "abc"), ("wrongAction", ""))
@@ -92,7 +92,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "user tried to continue without adding an item" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val body = (SaveAndContinue.toString, "")
 
@@ -103,7 +103,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "user tried to add incorrect item" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val body =
           Seq(("typesOfPackages", "wrongType"), ("numberOfPackages", ""), ("shippingMarks", ""), (Add.toString, ""))
@@ -145,7 +145,7 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
 
       "user added correct item" in new SetUp {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val body =
           Seq(("typesOfPackages", "NT"), ("numberOfPackages", "1"), ("shippingMarks", "value"), (Add.toString, ""))

--- a/test/unit/controllers/declaration/PreviousDocumentsControllerSpec.scala
+++ b/test/unit/controllers/declaration/PreviousDocumentsControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.PreviousDocumentsController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.{Document, PreviousDocumentsData}
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -49,7 +49,7 @@ class PreviousDocumentsControllerSpec extends ControllerSpec with ErrorHandlerMo
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockPreviousDocumentsPage.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
+++ b/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.ProcedureCodesController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.ProcedureCodes
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.{ExportItem, ProcedureCodesData}
 import models.declaration.ProcedureCodesData.limitOfCodes
 import org.mockito.ArgumentCaptor
@@ -75,7 +75,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "display page method is invoked with empty cache" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
 
@@ -107,7 +107,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "user provide wrong action" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val wrongAction = Seq(("procedureCode", "1234"), ("additionalProcedureCode", "123"), ("WrongAction", ""))
 
@@ -122,7 +122,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "user put incorrect data" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val incorrectForm =
           Seq(("procedureCode", "1234"), ("additionalProcedureCode", "incorrect"), addActionUrlEncoded())
@@ -169,7 +169,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "user put incorrect data" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val incorrectForm =
           Seq(("procedureCode", "1234"), ("additionalProcedureCode", "incorrect"), saveAndContinueActionUrlEncoded)
@@ -216,7 +216,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "user correctly add new item" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val correctForm =
           Seq(("procedureCode", "1234"), ("additionalProcedureCode", "321"), addActionUrlEncoded())
@@ -232,7 +232,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
       "user save correct data" in {
 
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
         val correctForm =
           Seq(("procedureCode", "1234"), ("additionalProcedureCode", "321"), saveAndContinueActionUrlEncoded)

--- a/test/unit/controllers/declaration/RepresentativeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/RepresentativeDetailsControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.RepresentativeDetailsController
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
 import forms.declaration.{EntityDetails, RepresentativeDetails}
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -44,7 +44,7 @@ class RepresentativeDetailsControllerSpec extends ControllerSpec with OptionValu
     stubMessagesControllerComponents(),
     mockRepresentativeDetailsPage
   )(ec)
-  val exampleDeclaration = aDeclaration(withChoice(SupplementaryDec))
+  val exampleDeclaration = aDeclaration(withType(DeclarationType.SUPPLEMENTARY))
   val eori = "GB1000200"
 
   def theResponseForm: Form[RepresentativeDetails] = {
@@ -117,7 +117,7 @@ class RepresentativeDetailsControllerSpec extends ControllerSpec with OptionValu
 
       "form is correct and user is during Supplementary journey" in {
 
-        withNewCaching(exampleDeclaration.copy(choice = Choice.AllowedChoiceValues.SupplementaryDec))
+        withNewCaching(exampleDeclaration.copy(`type` = DeclarationType.SUPPLEMENTARY))
 
         val correctForm = Json.toJson(RepresentativeDetails(Some(EntityDetails(Some(eori), None)), Some("2")))
 
@@ -134,7 +134,7 @@ class RepresentativeDetailsControllerSpec extends ControllerSpec with OptionValu
 
       "form is correct and user is during Standard journey" in {
 
-        withNewCaching(exampleDeclaration.copy(choice = Choice.AllowedChoiceValues.StandardDec))
+        withNewCaching(exampleDeclaration.copy(`type` = DeclarationType.STANDARD))
 
         val correctForm = Json.toJson(RepresentativeDetails(Some(EntityDetails(Some(eori), None)), Some("2")))
 

--- a/test/unit/controllers/declaration/SealControllerSpec.scala
+++ b/test/unit/controllers/declaration/SealControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.SealController
 import controllers.util.{Remove, SaveAndContinue, SaveAndReturn}
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.Seal
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.Container
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -51,7 +51,7 @@ class SealControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
     authorizedUser()
     setupErrorHandler()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
   }
 
   "Seal Controller" should {

--- a/test/unit/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
+++ b/test/unit/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
@@ -19,7 +19,7 @@ package unit.controllers.declaration
 import controllers.declaration.TotalNumberOfItemsController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.TotalNumberOfItems
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
@@ -47,7 +47,7 @@ class TotalNumberOfItemsControllerSpec extends ControllerSpec with OptionValues 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
     authorizedUser()
-    withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(mockTotalNumberOfItemsPage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
   }
 

--- a/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.TransportContainerController
 import controllers.util.Remove
 import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.Seal
-import models.Mode
+import models.{DeclarationType, Mode}
 import models.declaration.{Container, TransportInformationContainerData}
 import play.api.test.Helpers._
 import unit.base.ControllerSpec
@@ -48,7 +48,7 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
 
     authorizedUser()
     setupErrorHandler()
-    withNewCaching(aDeclaration(withChoice(StandardDec)))
+    withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
   }
 
   val containerId = "434335468"
@@ -123,7 +123,7 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
 
     "add new container and redirect to add seal page" when {
       "working on standard declaration with cache empty" in new SetUp {
-        withNewCaching(aDeclaration(withChoice(StandardDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
         val body = Seq("id" -> "value")
 
         val result = controller.submitAddContainer(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))
@@ -138,7 +138,7 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
 
     "add new container and redirect to container summary page" when {
       "working on supplementary declaration with cache empty" in new SetUp {
-        withNewCaching(aDeclaration(withChoice(SupplementaryDec)))
+        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
         val body = Seq("id" -> "value")
 
         val result = controller.submitAddContainer(Mode.Normal)(postRequestAsFormUrlEncoded(body: _*))

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.WarehouseIdentificationController
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.TransportCodes.Maritime
 import helpers.views.declaration.WarehouseIdentificationMessages
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
 import org.mockito.Mockito.{times, verify, when}
@@ -50,7 +50,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
   val exampleTransportMode = Maritime
 
   val cacheModel = aDeclaration(
-    withChoice(SupplementaryDec),
+    withType(DeclarationType.SUPPLEMENTARY),
     withWarehouseIdentification(
       Some(exampleCustomsOfficeIdentifier),
       Some(exampleWarehauseIdentificationType),

--- a/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
@@ -22,7 +22,7 @@ import controllers.util.SaveAndReturn
 import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.DeclarationAdditionalActors
 import helpers.views.declaration.{CommonMessages, DeclarationAdditionalActorsMessages}
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.api.i18n.MessagesApi
@@ -115,7 +115,7 @@ class DeclarationAdditionalActorsViewSpec
 
     "display 'Back' button that links to 'Representative Details' page if on Supplementary journey" in {
 
-      val view = declarationAdditionalActorsPage(Mode.Normal, form, Seq())(journeyRequest(SupplementaryDec), messages)
+      val view = declarationAdditionalActorsPage(Mode.Normal, form, Seq())(journeyRequest(DeclarationType.SUPPLEMENTARY), messages)
 
       val backButton = view.getElementById("link-back")
 

--- a/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
+++ b/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
@@ -19,7 +19,6 @@ package views.declaration.additionaldeclarationtype
 import base.Injector
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeStandardDec.AllowedAdditionalDeclarationTypes._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationTypeSupplementaryDec.AllowedAdditionalDeclarationTypes._
 import forms.declaration.additionaldeclarationtype.{
@@ -28,7 +27,8 @@ import forms.declaration.additionaldeclarationtype.{
   AdditionalDeclarationTypeSupplementaryDec
 }
 import helpers.views.declaration.{CommonMessages, DeclarationTypeMessages}
-import models.Mode
+import models.DeclarationType.DeclarationType
+import models.{DeclarationType, Mode}
 import org.jsoup.nodes.Document
 import play.api.data.Form
 import play.api.i18n.Messages
@@ -45,7 +45,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
   private val formStandard: Form[AdditionalDeclarationType] = AdditionalDeclarationTypeStandardDec.form()
   private val formSupplementary: Form[AdditionalDeclarationType] = AdditionalDeclarationTypeSupplementaryDec.form()
   private val declarationTypePage = new declaration_type(mainTemplate)
-  private def createView(form: Form[AdditionalDeclarationType], journeyType: String, messages: Messages = stubMessages()): Document =
+  private def createView(form: Form[AdditionalDeclarationType], journeyType: DeclarationType, messages: Messages = stubMessages()): Document =
     declarationTypePage(Mode.Normal, form)(journeyRequest(journeyType), messages)
 
   "Declaration Type View on empty page" should {
@@ -53,12 +53,12 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
     "display page title" when {
 
       "used for Standard Declaration journey" in {
-        val viewWithMessage = createView(formStandard, StandardDec, realMessagesApi.preferred(request))
+        val viewWithMessage = createView(formStandard, DeclarationType.STANDARD, realMessagesApi.preferred(request))
         viewWithMessage.title() must include(viewWithMessage.getElementsByTag("h1").text())
       }
 
       "used for Supplementary Declaration journey" in {
-        val viewWithMessage = createView(formSupplementary, SupplementaryDec, realMessagesApi.preferred(request))
+        val viewWithMessage = createView(formSupplementary, DeclarationType.SUPPLEMENTARY, realMessagesApi.preferred(request))
         viewWithMessage.title() must include(viewWithMessage.getElementsByTag("h1").text())
       }
     }
@@ -66,7 +66,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
     "display 'Back' button that links to 'Dispatch Location' page" when {
 
       "used for Standard Declaration journey" in {
-        val backButton = createView(formStandard, StandardDec).getElementById("link-back")
+        val backButton = createView(formStandard, DeclarationType.STANDARD).getElementById("link-back")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe routes.DispatchLocationController.displayPage().url
@@ -74,7 +74,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey" in {
 
-        val backButton = createView(formSupplementary, SupplementaryDec).getElementById("link-back")
+        val backButton = createView(formSupplementary, DeclarationType.SUPPLEMENTARY).getElementById("link-back")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe routes.DispatchLocationController.displayPage().url
@@ -84,12 +84,12 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
     "display 'Save and continue' button" when {
 
       "used for Standard Declaration journey" in {
-        val view: Document = createView(formStandard, StandardDec)
+        val view: Document = createView(formStandard, DeclarationType.STANDARD)
         view.getElementById("submit").text() mustBe messages(saveAndContinueCaption)
       }
 
       "used for Supplementary Declaration journey" in {
-        val view: Document = createView(formSupplementary, SupplementaryDec)
+        val view: Document = createView(formSupplementary, DeclarationType.SUPPLEMENTARY)
         view.getElementById("submit").text() mustBe messages(saveAndContinueCaption)
       }
     }
@@ -97,14 +97,14 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
     "display 'Save and return' button" when {
 
       "used for Standard Declaration journey" in {
-        val view: Document = createView(formStandard, StandardDec)
+        val view: Document = createView(formStandard, DeclarationType.STANDARD)
         val button = view.getElementById("submit_and_return")
         button.text() mustBe messages(saveAndReturnCaption)
         button must haveAttribute("name", SaveAndReturn.toString)
       }
 
       "used for Supplementary Declaration journey" in {
-        val view: Document = createView(formSupplementary, SupplementaryDec)
+        val view: Document = createView(formSupplementary, DeclarationType.SUPPLEMENTARY)
         val button = view.getElementById("submit_and_return")
         button.text() mustBe messages(saveAndReturnCaption)
         button must haveAttribute("name", SaveAndReturn.toString)
@@ -115,14 +115,14 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey" in {
 
-        val view = createView(formStandard, StandardDec)
+        val view = createView(formStandard, DeclarationType.STANDARD)
 
         view.getElementById("title").text() mustBe messages(headerStandardDec)
       }
 
       "used for Supplementary Declaration journey" in {
 
-        val view = createView(formSupplementary, SupplementaryDec)
+        val view = createView(formSupplementary, DeclarationType.SUPPLEMENTARY)
 
         view.getElementById("title").text() mustBe messages(headerSupplementaryDec)
       }
@@ -132,7 +132,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey" in {
 
-        val view = createView(formStandard.fill(AdditionalDeclarationType("")), StandardDec)
+        val view = createView(formStandard.fill(AdditionalDeclarationType("")), DeclarationType.STANDARD)
 
         val optionOne = view.getElementById("PreLodged")
         optionOne.attr("checked") mustBe empty
@@ -149,7 +149,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey" in {
 
-        val view = createView(formSupplementary.fill(AdditionalDeclarationType("")), SupplementaryDec)
+        val view = createView(formSupplementary.fill(AdditionalDeclarationType("")), DeclarationType.SUPPLEMENTARY)
 
         val optionOne = view.getElementById("Simplified")
         optionOne.attr("checked") mustBe empty
@@ -173,7 +173,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey" in {
 
-        val view = createView(formStandard.bind(Map[String, String]()), StandardDec)
+        val view = createView(formStandard.bind(Map[String, String]()), DeclarationType.STANDARD)
 
         checkErrorsSummary(view)
         view must haveFieldErrorLink("additionalDeclarationType", "#additionalDeclarationType")
@@ -183,7 +183,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey" in {
 
-        val view = createView(formSupplementary.bind(Map[String, String]()), SupplementaryDec)
+        val view = createView(formSupplementary.bind(Map[String, String]()), DeclarationType.SUPPLEMENTARY)
 
         checkErrorsSummary(view)
         view must haveFieldErrorLink("additionalDeclarationType", "#additionalDeclarationType")
@@ -196,7 +196,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey" in {
 
-        val view = createView(formStandard.fillAndValidate(AdditionalDeclarationType("#")), StandardDec)
+        val view = createView(formStandard.fillAndValidate(AdditionalDeclarationType("#")), DeclarationType.STANDARD)
 
         checkErrorsSummary(view)
         view must haveFieldErrorLink("additionalDeclarationType", "#additionalDeclarationType")
@@ -206,7 +206,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey" in {
 
-        val view = createView(formSupplementary.fillAndValidate(AdditionalDeclarationType("#")), SupplementaryDec)
+        val view = createView(formSupplementary.fillAndValidate(AdditionalDeclarationType("#")), DeclarationType.SUPPLEMENTARY)
 
         checkErrorsSummary(view)
         view must haveFieldErrorLink("additionalDeclarationType", "#additionalDeclarationType")
@@ -223,7 +223,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey - Pre-lodged (D)" in {
 
-        val view = createView(formStandard.fill(AdditionalDeclarationType(PreLodged)), StandardDec)
+        val view = createView(formStandard.fill(AdditionalDeclarationType(PreLodged)), DeclarationType.STANDARD)
 
         val optionOne = view.getElementById("PreLodged")
         optionOne.attr("checked") mustBe "checked"
@@ -234,7 +234,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey - Simplified (Y)" in {
 
-        val view = createView(formSupplementary.fill(AdditionalDeclarationType(Simplified)), SupplementaryDec)
+        val view = createView(formSupplementary.fill(AdditionalDeclarationType(Simplified)), DeclarationType.SUPPLEMENTARY)
 
         val optionOne = view.getElementById("Simplified")
         optionOne.attr("checked") mustBe "checked"
@@ -248,7 +248,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Standard Declaration journey - Frontier (A)" in {
 
-        val view = createView(formStandard.fill(AdditionalDeclarationType(Frontier)), StandardDec)
+        val view = createView(formStandard.fill(AdditionalDeclarationType(Frontier)), DeclarationType.STANDARD)
 
         val optionOne = view.getElementById("PreLodged")
         optionOne.attr("checked") mustBe empty
@@ -259,7 +259,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey - Standard (Z)" in {
 
-        val view = createView(formSupplementary.fill(AdditionalDeclarationType(Standard)), SupplementaryDec)
+        val view = createView(formSupplementary.fill(AdditionalDeclarationType(Standard)), DeclarationType.SUPPLEMENTARY)
 
         val optionOne = view.getElementById("Simplified")
         optionOne.attr("checked") mustBe empty

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -21,7 +21,7 @@ import forms.Choice
 import forms.declaration.{GoodsLocation, LegalDeclaration}
 import models.declaration.{Container, SupplementaryDeclarationData}
 import models.requests.{AuthenticatedRequest, JourneyRequest}
-import models.{ExportsDeclaration, Mode}
+import models.{DeclarationType, ExportsDeclaration, Mode}
 import org.jsoup.nodes.Document
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.data.Form
@@ -87,7 +87,7 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
 
       "Normal Mode" when {
         "standard declaration with containers" in {
-          val model = aDeclaration(withChoice(Choice.AllowedChoiceValues.StandardDec), withContainerData(Container("1234", Seq.empty)))
+          val model = aDeclaration(withType(DeclarationType.STANDARD), withContainerData(Container("1234", Seq.empty)))
           val document = view(Mode.Normal, model)
           document must containElementWithID("link-back")
           document.getElementById("link-back") must haveHref(
@@ -97,14 +97,14 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
         }
 
         "standard declaration without containers" in {
-          val model = aDeclaration(withChoice(Choice.AllowedChoiceValues.StandardDec))
+          val model = aDeclaration(withType(DeclarationType.STANDARD))
           val document = view(Mode.Normal, model)
           document must containElementWithID("link-back")
           document.getElementById("link-back") must haveHref(controllers.declaration.routes.BorderTransportController.displayPage(Mode.Normal))
         }
 
         "supplementary declaration with containers" in {
-          val model = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withContainerData(Container("1234", Seq.empty)))
+          val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withContainerData(Container("1234", Seq.empty)))
           val document = view(Mode.Normal, model)
           document must containElementWithID("link-back")
           document.getElementById("link-back") must haveHref(
@@ -113,7 +113,7 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
         }
 
         "supplementary declaration without containers" in {
-          val model = aDeclaration(withChoice(Choice.AllowedChoiceValues.SupplementaryDec), withoutContainerData())
+          val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withoutContainerData())
           val document = view(Mode.Normal, model)
           document must containElementWithID("link-back")
           document.getElementById("link-back") must haveHref(controllers.declaration.routes.BorderTransportController.displayPage(Mode.Normal))


### PR DESCRIPTION
Currently the `ExportsDeclaration` model has a choice field which is a `String`.
Given the many extra dec types we have to add over the next few months we should make this easy to expand. 

`choice` seems the wrong name for this & `String` seems the wrong `type`. 
Choice also represents irrelevant options such as "view submissions", "cancel dec". 

With this PR I propose we have a separate `DeclarationType`


What this PR changes:
- Replace `choice: String` on `ExportsDeclaration` with `type: DeclarationType`
- Use an Enum for DeclarationType which only allows `STANDARD`, `SUPPLEMENTARY` (for now)