### PR TITLE
CEDS-1853 Skip 'Nature of Transaction' for Simplified Journey

### DIFF
--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -19,6 +19,7 @@
 @import forms.declaration.Document.AllowedValues._
 @import uk.gov.hmrc.play.views.html._
 @import views.components.inputs.RadioOption
+@import models.requests.JourneyRequest
 @import services.DocumentType
 @import services.view.AutoCompleteItem
 @import views.Title
@@ -26,13 +27,20 @@
 
 @this(main_template: views.html.main_template)
 
-@(mode: Mode, form: Form[Document], documents: Seq[Document])(implicit request: Request[_], messages: Messages)
+@(mode: Mode, form: Form[Document], documents: Seq[Document])(implicit request: JourneyRequest[_], messages: Messages)
 
 @main_template(
     title = Title("supplementary.previousDocuments.title", "supplementary.consignmentReferences.heading")
 ) {
 
-    @components.back_link(controllers.declaration.routes.NatureOfTransactionController.displayPage(mode), mode)
+    @{
+        request.declarationType match {
+            case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD =>
+                components.back_link(controllers.declaration.routes.NatureOfTransactionController.displayPage(mode), mode)
+            case DeclarationType.SIMPLIFIED =>
+                components.back_link(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode), mode)
+        }
+    }
 
     @components.error_summary(form.errors)
 

--- a/test/unit/controllers/declaration/DestinationCountriesControllerSpec.scala
+++ b/test/unit/controllers/declaration/DestinationCountriesControllerSpec.scala
@@ -18,7 +18,6 @@ package unit.controllers.declaration
 
 import controllers.declaration.DestinationCountriesController
 import controllers.util.Remove
-import forms.Choice.AllowedChoiceValues.{StandardDec, SupplementaryDec}
 import forms.declaration.destinationCountries.DestinationCountries
 import models.{DeclarationType, Mode}
 import play.api.libs.json.Json

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -17,7 +17,8 @@
 package views.declaration
 import base.Injector
 import forms.declaration.Document
-import models.Mode
+import models.DeclarationType.DeclarationType
+import models.{DeclarationType, Mode}
 import org.jsoup.nodes.{Document => JsonDocument}
 import play.api.data.Form
 import play.api.i18n.{Messages, MessagesApi}
@@ -37,9 +38,10 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
     mode: Mode = Mode.Normal,
     form: Form[Document] = form,
     documents: Seq[Document] = Seq.empty,
-    messages: Messages = stubMessages()
+    messages: Messages = stubMessages(),
+    declarationType: DeclarationType = DeclarationType.STANDARD
   ): JsonDocument =
-    page(mode, form, documents)(journeyRequest(), messages)
+    page(mode, form, documents)(journeyRequest(declarationType), messages)
 
   "Previous Documents View on empty page" should {
     val view = createView()
@@ -107,12 +109,22 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
       view.getElementById("goodsItemIdentifier").attr("value") mustBe empty
     }
 
-    "display 'Back' button that links to 'Transaction Type' page" in {
+    "display 'Back' button that links to 'Transaction Type' page" when {
+      "on the Standard journey" in {
 
-      val backButton = view.getElementById("link-back")
+        val backButton = view.getElementById("link-back")
 
-      backButton.text() must be("site.back")
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+        backButton.text() must be("site.back")
+        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+      }
+
+      "on the Simplified journey" in {
+
+        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("link-back")
+
+        backButton.text() must be("site.back")
+        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(Mode.Normal))
+      }
     }
 
     "display both 'Add' and 'Save and continue' button on page" in {


### PR DESCRIPTION
A Simplified Declaration requires fewer data elements to be completed
than a Standard Declaration.
This change captures the requirement to skip the 'Nature of Transaction'
page, which is not relevant to Simplified Declaration.