### PR TITLE
CEDS-1851 Skip 'Commodity measurements' for Simplified Journey

### DIFF
--- a/app/views/declaration/additional_information.scala.html
+++ b/app/views/declaration/additional_information.scala.html
@@ -19,19 +19,28 @@
 @import forms.declaration.AdditionalInformation
 @import uk.gov.hmrc.play.views.html._
 @import views.components.fields.LabelledValue
+@import models.requests.JourneyRequest
 
 @import forms.declaration.CommodityMeasure
 @import views.Title
 
 @this(main_template: views.html.main_template)
 
-@(mode: Mode, itemId: String, form: Form[AdditionalInformation], items: Seq[AdditionalInformation])(implicit request: Request[_], messages: Messages)
+
+@(mode: Mode, itemId: String, form: Form[AdditionalInformation], items: Seq[AdditionalInformation])(implicit request: JourneyRequest[_], messages: Messages)
 
 @main_template(
     title = Title("supplementary.additionalInformation.title", "supplementary.summary.yourReferences.header")
 ) {
 
-    @components.back_link(CommodityMeasureController.displayPage(mode, itemId), mode)
+    @{
+        request.declarationType match {
+            case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD =>
+                components.back_link(controllers.declaration.routes.CommodityMeasureController.displayPage(mode, itemId), mode)
+            case DeclarationType.SIMPLIFIED =>
+                components.back_link(controllers.declaration.routes.PackageInformationController.displayPage(mode, itemId), mode)
+        }
+    }
 
     @components.error_summary(form.errors)
 

--- a/test/unit/controllers/declaration/PackageInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/PackageInformationControllerSpec.scala
@@ -18,7 +18,6 @@ package unit.controllers.declaration
 
 import controllers.declaration.PackageInformationController
 import controllers.util.{Add, SaveAndContinue}
-import forms.Choice.AllowedChoiceValues.SupplementaryDec
 import forms.declaration.PackageInformation
 import models.{DeclarationType, Mode}
 import play.api.test.Helpers._
@@ -54,25 +53,49 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
   "Package Information Controller" should {
 
     "return 200 (OK)" when {
+      "on Supplementary journey" when {
 
-      "display page method is invoked and cache is empty" in new SetUp {
+        "display page method is invoked and cache is empty" in new SetUp {
 
-        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
+          withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
-        val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
 
-        status(result) must be(OK)
+          status(result) must be(OK)
+        }
+
+        "display page method is invoked and cache contain some data" in new SetUp {
+
+          val itemWithPackageInformation =
+            anItem(withPackageInformation(typesOfPackages = "12", numberOfPackages = 10, shippingMarks = "123"))
+          withNewCaching(aDeclaration(withItem(itemWithPackageInformation)))
+
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+
+          status(result) must be(OK)
+        }
       }
+      "on Simplified journey" when {
 
-      "display page method is invoked and cache contain some data" in new SetUp {
+        "display page method is invoked and cache is empty" in new SetUp {
 
-        val itemWithPackageInformation =
-          anItem(withPackageInformation(typesOfPackages = "12", numberOfPackages = 10, shippingMarks = "123"))
-        withNewCaching(aDeclaration(withItem(itemWithPackageInformation)))
+          withNewCaching(aDeclaration(withType(DeclarationType.SIMPLIFIED)))
 
-        val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
 
-        status(result) must be(OK)
+          status(result) must be(OK)
+        }
+
+        "display page method is invoked and cache contain some data" in new SetUp {
+
+          val itemWithPackageInformation =
+            anItem(withPackageInformation(typesOfPackages = "12", numberOfPackages = 10, shippingMarks = "123"))
+          withNewCaching(aDeclaration(withItem(itemWithPackageInformation), withType((DeclarationType.SIMPLIFIED))))
+
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+
+          status(result) must be(OK)
+        }
       }
     }
 
@@ -142,32 +165,62 @@ class PackageInformationControllerSpec extends ControllerSpec with ErrorHandlerM
     }
 
     "return 303 (SEE_OTHER)" when {
+      "on Supplementary journey" when {
 
-      "user added correct item" in new SetUp {
+        "user added correct item" in new SetUp {
 
-        withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
+          withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
 
-        val body =
-          Seq(("typesOfPackages", "NT"), ("numberOfPackages", "1"), ("shippingMarks", "value"), (Add.toString, ""))
+          val body =
+            Seq(("typesOfPackages", "NT"), ("numberOfPackages", "1"), ("shippingMarks", "value"), (Add.toString, ""))
 
-        val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body: _*))
+          val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body: _*))
 
-        status(result) must be(SEE_OTHER)
-        redirectLocation(result) must be(Some(controllers.declaration.routes.PackageInformationController.displayPage(Mode.Normal, itemId).url))
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result) must be(Some(controllers.declaration.routes.PackageInformationController.displayPage(Mode.Normal, itemId).url))
+        }
+
+        "user clicked continue with item in a cache" in new SetUp {
+
+          val item = anItem(withPackageInformation(typesOfPackages = "NT", numberOfPackages = 1, shippingMarks = "value"))
+          withNewCaching(aDeclaration(withItem(item)))
+
+          val body = (SaveAndContinue.toString, "")
+
+          val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body))
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.CommodityMeasureController
+            .displayPage(Mode.Normal, itemId)
+        }
       }
+      "on Simplified journey" when {
 
-      "user clicked continue with item in a cache" in new SetUp {
+        "user added correct item" in new SetUp {
 
-        val item = anItem(withPackageInformation(typesOfPackages = "NT", numberOfPackages = 1, shippingMarks = "value"))
-        withNewCaching(aDeclaration(withItem(item)))
+          withNewCaching(aDeclaration(withType(DeclarationType.SIMPLIFIED)))
 
-        val body = (SaveAndContinue.toString, "")
+          val body =
+            Seq(("typesOfPackages", "NT"), ("numberOfPackages", "1"), ("shippingMarks", "value"), (Add.toString, ""))
 
-        val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body))
+          val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body: _*))
 
-        await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.CommodityMeasureController
-          .displayPage(Mode.Normal, itemId)
+          status(result) must be(SEE_OTHER)
+          redirectLocation(result) must be(Some(controllers.declaration.routes.PackageInformationController.displayPage(Mode.Normal, itemId).url))
+        }
+
+        "user clicked continue with item in a cache" in new SetUp {
+
+          val item = anItem(withPackageInformation(typesOfPackages = "NT", numberOfPackages = 1, shippingMarks = "value"))
+          withNewCaching(aDeclaration(withItem(item), withType(DeclarationType.SIMPLIFIED)))
+
+          val body = (SaveAndContinue.toString, "")
+
+          val result = controller.submitForm(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(body))
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalInformationController.displayPage(Mode.Normal, itemId)
+        }
       }
     }
   }


### PR DESCRIPTION
A Simplified Declaration requires fewer data elements to be completed
than a Standard Declaration.
This change captures the requirement to skip the 'commodity-measure'
page, which is not relevant to Simplified Declaration.