### PR TITLE
CEDS-1675 Change format of Audit declation dates

### DIFF
--- a/app/connectors/CustomsDeclareExportsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsConnector.scala
@@ -23,6 +23,7 @@ import connectors.exchange.ExportsDeclarationExchange
 import forms.CancelDeclaration
 import javax.inject.{Inject, Singleton}
 import models._
+import models.ExportsDeclaration.Mongo.format
 import models.declaration.notifications.Notification
 import models.declaration.submissions.Submission
 import play.api.Logger

--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -20,6 +20,7 @@ import com.google.inject.Inject
 import config.AppConfig
 import forms.CancelDeclaration
 import models.ExportsDeclaration
+import models.ExportsDeclaration.Audit.format
 import play.api.Logger
 import play.api.libs.json.{JsObject, Json}
 import services.audit.AuditTypes.Audit

--- a/test/services/audit/AuditServiceSpec.scala
+++ b/test/services/audit/AuditServiceSpec.scala
@@ -18,6 +18,7 @@ package services.audit
 
 import base.{Injector, TestHelper}
 import config.AppConfig
+import models.ExportsDeclaration.Audit.format
 import models.declaration.SupplementaryDeclarationTestData.{allRecordsXmlMarshallingTest, cancellationDeclarationTest}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any


### PR DESCRIPTION
After the last TxM review, we were asked not to audit the `createDateTime`
and `updateDateTime` in the following MongoDB format:

```
"createdDateTime": {
   "$date": 1571135745223
 }
```

The approach is to have a serialisation strategy for TxM audit and
another one for MongoDB