### PR TITLE
CEDS-1851 Items summary page allows a Simplified journey item

### DIFF
--- a/app/controllers/declaration/ItemsSummaryController.scala
+++ b/app/controllers/declaration/ItemsSummaryController.scala
@@ -22,6 +22,7 @@ import controllers.util.{Add, FormAction, SaveAndContinue, SaveAndReturn}
 import javax.inject.Inject
 import models.Mode
 import models.declaration.ExportItem
+import models.requests.JourneyRequest
 import play.api.data.FormError
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -49,7 +50,7 @@ class ItemsSummaryController @Inject()(
   //TODO Should we add validation for POST without items?
   def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val action = FormAction.bindFromRequest()
-    val incorrectItems = buildIncorrectItemsErrors(request.cacheModel.items.toSeq)
+    val incorrectItems = buildIncorrectItemsErrors(request)
 
     action match {
       case Add =>
@@ -67,8 +68,8 @@ class ItemsSummaryController @Inject()(
     }
   }
 
-  private def buildIncorrectItemsErrors(items: Seq[ExportItem]): Seq[FormError] =
-    items.zipWithIndex.filterNot { case (item, _) => item.isCompleted }.map {
+  private def buildIncorrectItemsErrors(request: JourneyRequest[AnyContent]): Seq[FormError] =
+    request.cacheModel.items.toSeq.zipWithIndex.filterNot { case (item, _) => item.isCompleted(request.declarationType) }.map {
       case (item, index) =>
         FormError("item_" + index, "declaration.itemsSummary.item.incorrect", Seq(item.sequenceId.toString))
     }

--- a/app/models/declaration/ExportItem.scala
+++ b/app/models/declaration/ExportItem.scala
@@ -18,6 +18,8 @@ package models.declaration
 
 import forms.declaration.{AdditionalFiscalReferencesData, CommodityMeasure, FiscalInformation, PackageInformation}
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers.yes
+import models.DeclarationType
+import models.DeclarationType.DeclarationType
 import play.api.libs.json.Json
 
 case class ExportItem(
@@ -35,9 +37,15 @@ case class ExportItem(
   def hasFiscalReferences: Boolean =
     fiscalInformation.exists(_.onwardSupplyRelief == FiscalInformation.AllowedFiscalInformationAnswers.yes)
 
-  def isCompleted: Boolean =
-    procedureCodes.isDefined && isFiscalInformationCompleted && itemType.isDefined &&
-      packageInformation.nonEmpty && commodityMeasure.isDefined && additionalInformation.isDefined
+  val isCompleted: PartialFunction[DeclarationType, Boolean] = {
+    case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
+      procedureCodes.isDefined && isFiscalInformationCompleted && itemType.isDefined &&
+        packageInformation.nonEmpty && commodityMeasure.isDefined && additionalInformation.isDefined
+
+    case DeclarationType.SIMPLIFIED =>
+      procedureCodes.isDefined && isFiscalInformationCompleted && itemType.isDefined &&
+        packageInformation.nonEmpty && additionalInformation.isDefined
+  }
 
   private def isFiscalInformationCompleted: Boolean =
     if (fiscalInformation.exists(_.onwardSupplyRelief == yes)) additionalFiscalReferencesData.isDefined

--- a/test/services/cache/ExportItemSpec.scala
+++ b/test/services/cache/ExportItemSpec.scala
@@ -16,8 +16,9 @@
 
 package services.cache
 
-import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData, CommodityMeasure, FiscalInformation}
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers
+import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData, CommodityMeasure, FiscalInformation}
+import models.DeclarationType
 import unit.base.UnitSpec
 
 class ExportItemSpec extends UnitSpec with ExportsItemBuilder {
@@ -42,58 +43,98 @@ class ExportItemSpec extends UnitSpec with ExportsItemBuilder {
     }
 
     "return correct information about item completeness" when {
+      "on Standard or Supplementary journey" when {
 
-      "item is not completed" in {
+        "item is not completed" in {
 
-        val notCompletedItem = anItem(withItemId("id"))
+          val notCompletedItem = anItem(withItemId("id"))
 
-        notCompletedItem.isCompleted mustBe false
+          notCompletedItem.isCompleted(DeclarationType.STANDARD) mustBe false
+        }
+
+        "item contain Yes in fiscal information but without additional fiscal references" in {
+
+          val completedItem = anItem(
+            withItemId("id"),
+            withProcedureCodes(),
+            withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
+            withItemType(),
+            withPackageInformation(),
+            withCommodityMeasure(CommodityMeasure(None, "100", "100")),
+            withAdditionalInformation("code", "description")
+          ).copy(additionalFiscalReferencesData = None)
+
+          completedItem.isCompleted(DeclarationType.STANDARD) mustBe false
+        }
+
+        "item contain No in fiscal information and doesn't contain additional fiscal references" in {
+
+          val completedItem = anItem(
+            withItemId("id"),
+            withProcedureCodes(),
+            withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.no)),
+            withItemType(),
+            withPackageInformation(),
+            withCommodityMeasure(CommodityMeasure(None, "100", "100")),
+            withAdditionalInformation("code", "description")
+          )
+
+          completedItem.isCompleted(DeclarationType.STANDARD) mustBe true
+        }
+
+        "item is completed" in {
+
+          val completedItem = anItem(
+            withItemId("id"),
+            withProcedureCodes(),
+            withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
+            withAdditionalFiscalReferenceData(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("GB", "12")))),
+            withItemType(),
+            withPackageInformation(),
+            withCommodityMeasure(CommodityMeasure(None, "100", "100")),
+            withAdditionalInformation("code", "description")
+          )
+
+          completedItem.isCompleted(DeclarationType.STANDARD) mustBe true
+        }
       }
+      "on Simplified journey" when {
 
-      "item contain Yes in fiscal information but without additional fiscal references" in {
+        "item is not completed" in {
 
-        val completedItem = anItem(
-          withItemId("id"),
-          withProcedureCodes(),
-          withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
-          withItemType(),
-          withPackageInformation(),
-          withCommodityMeasure(CommodityMeasure(None, "100", "100")),
-          withAdditionalInformation("code", "description")
-        ).copy(additionalFiscalReferencesData = None)
+          val notCompletedItem = anItem(withItemId("id"))
 
-        completedItem.isCompleted mustBe false
-      }
+          notCompletedItem.isCompleted(DeclarationType.SIMPLIFIED) mustBe false
+        }
 
-      "item contain No in fiscal information and doesn't contain additional fiscal references" in {
+        "item contain Yes in fiscal information but without additional fiscal references" in {
 
-        val completedItem = anItem(
-          withItemId("id"),
-          withProcedureCodes(),
-          withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.no)),
-          withItemType(),
-          withPackageInformation(),
-          withCommodityMeasure(CommodityMeasure(None, "100", "100")),
-          withAdditionalInformation("code", "description")
-        )
+          val completedItem = anItem(
+            withItemId("id"),
+            withProcedureCodes(),
+            withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
+            withItemType(),
+            withPackageInformation(),
+            withAdditionalInformation("code", "description")
+          ).copy(additionalFiscalReferencesData = None)
 
-        completedItem.isCompleted mustBe true
-      }
+          completedItem.isCompleted(DeclarationType.SIMPLIFIED) mustBe false
+        }
 
-      "item is completed" in {
+        "item is completed" in {
 
-        val completedItem = anItem(
-          withItemId("id"),
-          withProcedureCodes(),
-          withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
-          withAdditionalFiscalReferenceData(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("GB", "12")))),
-          withItemType(),
-          withPackageInformation(),
-          withCommodityMeasure(CommodityMeasure(None, "100", "100")),
-          withAdditionalInformation("code", "description")
-        )
+          val completedItem = anItem(
+            withItemId("id"),
+            withProcedureCodes(),
+            withFiscalInformation(FiscalInformation(AllowedFiscalInformationAnswers.yes)),
+            withAdditionalFiscalReferenceData(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("GB", "12")))),
+            withItemType(),
+            withPackageInformation(),
+            withAdditionalInformation("code", "description")
+          )
 
-        completedItem.isCompleted mustBe true
+          completedItem.isCompleted(DeclarationType.SIMPLIFIED) mustBe true
+        }
       }
     }
   }


### PR DESCRIPTION
As part of the Simplified journey, we had to remove the commodity
measurements page from the item journey.
This change implies a change on the Items Summary validation rules for
the journey in question.