### PR TITLE
CEDS-1843 Skip 'Enter Item Information' Page

### DIFF
--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -78,7 +78,7 @@ class OfficeOfExitController @Inject()(
         (formWithErrors: Form[OfficeOfExitSupplementary]) => Future.successful(BadRequest(officeOfExitSupplementaryPage(mode, formWithErrors))),
         form =>
           updateCache(form)
-            .map(_ => navigator.continueTo(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode)))
+            .map(_ => navigator.continueTo(nextPage(mode, request)))
       )
 
   private def saveStandardOffice(mode: Mode)(implicit request: JourneyRequest[AnyContent]): Future[Result] =
@@ -92,7 +92,7 @@ class OfficeOfExitController @Inject()(
         },
         form =>
           updateCache(form)
-            .map(_ => navigator.continueTo(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode)))
+            .map(_ => navigator.continueTo(nextPage(mode, request)))
       )
 
   private def updateCache(formData: OfficeOfExitSupplementary)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
@@ -100,4 +100,12 @@ class OfficeOfExitController @Inject()(
 
   private def updateCache(formData: OfficeOfExitStandard)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => model.copy(locations = model.locations.copy(officeOfExit = Some(OfficeOfExit.from(formData)))))
+
+  private def nextPage(mode: Mode, request: JourneyRequest[AnyContent]) =
+    request.declarationType match {
+      case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD =>
+        controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode)
+      case DeclarationType.SIMPLIFIED =>
+        controllers.declaration.routes.PreviousDocumentsController.displayPage(mode)
+    }
 }

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -19,10 +19,10 @@ package controllers.navigation
 import config.AppConfig
 import controllers.util.{FormAction, SaveAndReturn}
 import forms.DeclarationFieldCompanion
-import forms.declaration.BorderTransport
+import forms.declaration.{BorderTransport, PreviousDocumentsData}
 import javax.inject.Inject
-import models.{DeclarationType, Mode}
 import models.DeclarationType._
+import models.Mode
 import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys
 import play.api.mvc.{AnyContent, Call, Result, Results}
@@ -53,18 +53,21 @@ class Navigator @Inject()(appConfig: AppConfig, auditService: AuditService) {
 object Navigator {
 
   val standard: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport => controllers.declaration.routes.DepartureTransportController.displayPage
-    case _               => ???
+    case BorderTransport       => controllers.declaration.routes.DepartureTransportController.displayPage
+    case PreviousDocumentsData => controllers.declaration.routes.NatureOfTransactionController.displayPage
+    case _                     => ???
   }
 
   val supplementary: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport => controllers.declaration.routes.DepartureTransportController.displayPage
-    case _               => ???
+    case BorderTransport       => controllers.declaration.routes.DepartureTransportController.displayPage
+    case PreviousDocumentsData => controllers.declaration.routes.NatureOfTransactionController.displayPage
+    case _                     => ???
   }
 
   val simplified: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport => controllers.declaration.routes.WarehouseIdentificationController.displayPage
-    case _               => ???
+    case BorderTransport       => controllers.declaration.routes.WarehouseIdentificationController.displayPage
+    case PreviousDocumentsData => controllers.declaration.routes.OfficeOfExitController.displayPage
+    case _                     => ???
   }
 
   def backLink(page: DeclarationFieldCompanion)(implicit request: JourneyRequest[_]): Mode => Call =

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -18,8 +18,8 @@ package controllers.navigation
 
 import config.AppConfig
 import controllers.util.{FormAction, SaveAndReturn}
-import forms.DeclarationFieldCompanion
-import forms.declaration.{BorderTransport, PreviousDocumentsData}
+import forms.DeclarationPage
+import forms.declaration.{BorderTransport, Document}
 import javax.inject.Inject
 import models.DeclarationType._
 import models.Mode
@@ -52,25 +52,23 @@ class Navigator @Inject()(appConfig: AppConfig, auditService: AuditService) {
 
 object Navigator {
 
-  val standard: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport       => controllers.declaration.routes.DepartureTransportController.displayPage
-    case PreviousDocumentsData => controllers.declaration.routes.NatureOfTransactionController.displayPage
-    case _                     => ???
+  val standard: PartialFunction[DeclarationPage, Mode => Call] = {
+    case BorderTransport => controllers.declaration.routes.DepartureTransportController.displayPage
+    case Document        => controllers.declaration.routes.NatureOfTransactionController.displayPage
+    case _               => throw new IllegalArgumentException("Navigator back-link route not implemented")
+  }
+  val supplementary: PartialFunction[DeclarationPage, Mode => Call] = {
+    case BorderTransport => controllers.declaration.routes.DepartureTransportController.displayPage
+    case Document        => controllers.declaration.routes.NatureOfTransactionController.displayPage
+    case _               => throw new IllegalArgumentException("Navigator back-link route not implemented")
+  }
+  val simplified: PartialFunction[DeclarationPage, Mode => Call] = {
+    case BorderTransport => controllers.declaration.routes.WarehouseIdentificationController.displayPage
+    case Document        => controllers.declaration.routes.OfficeOfExitController.displayPage
+    case _               => throw new IllegalArgumentException("Navigator back-link route not implemented")
   }
 
-  val supplementary: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport       => controllers.declaration.routes.DepartureTransportController.displayPage
-    case PreviousDocumentsData => controllers.declaration.routes.NatureOfTransactionController.displayPage
-    case _                     => ???
-  }
-
-  val simplified: PartialFunction[DeclarationFieldCompanion, Mode => Call] = {
-    case BorderTransport       => controllers.declaration.routes.WarehouseIdentificationController.displayPage
-    case PreviousDocumentsData => controllers.declaration.routes.OfficeOfExitController.displayPage
-    case _                     => ???
-  }
-
-  def backLink(page: DeclarationFieldCompanion)(implicit request: JourneyRequest[_]): Mode => Call =
+  def backLink(page: DeclarationPage)(implicit request: JourneyRequest[_]): Mode => Call =
     request.declarationType match {
       case STANDARD      => standard(page)
       case SUPPLEMENTARY => supplementary(page)

--- a/app/forms/DeclarationPage.scala
+++ b/app/forms/DeclarationPage.scala
@@ -16,4 +16,4 @@
 
 package forms
 
-trait DeclarationFieldCompanion
+trait DeclarationPage

--- a/app/forms/declaration/BorderTransport.scala
+++ b/app/forms/declaration/BorderTransport.scala
@@ -15,7 +15,7 @@
  */
 
 package forms.declaration
-import forms.DeclarationFieldCompanion
+import forms.DeclarationPage
 import forms.Mapping.requiredRadio
 import forms.declaration.TransportCodes._
 import play.api.data.Forms.{boolean, mapping, optional, text}
@@ -32,7 +32,7 @@ case class BorderTransport(
   paymentMethod: Option[String] = None
 )
 
-object BorderTransport extends DeclarationFieldCompanion {
+object BorderTransport extends DeclarationPage {
 
   val formId = "TransportDetails"
 

--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -16,7 +16,7 @@
 
 package forms.declaration
 
-import forms.DeclarationFieldCompanion
+import forms.DeclarationPage
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms}
 import play.api.libs.json.{JsValue, Json}
@@ -27,7 +27,7 @@ case class Document(documentCategory: String, documentType: String, documentRefe
   def toJson: JsValue = Json.toJson(this)(Document.format)
 }
 
-object Document {
+object Document extends DeclarationPage {
   def fromJsonString(value: String): Option[Document] = Json.fromJson(Json.parse(value)).asOpt
 
   implicit val format = Json.format[Document]
@@ -63,7 +63,7 @@ object Document {
 
 case class PreviousDocumentsData(documents: Seq[Document])
 
-object PreviousDocumentsData extends DeclarationFieldCompanion {
+object PreviousDocumentsData {
   implicit val format = Json.format[PreviousDocumentsData]
 
   val maxAmountOfItems = 99

--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -16,6 +16,7 @@
 
 package forms.declaration
 
+import forms.DeclarationFieldCompanion
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms}
 import play.api.libs.json.{JsValue, Json}
@@ -62,7 +63,7 @@ object Document {
 
 case class PreviousDocumentsData(documents: Seq[Document])
 
-object PreviousDocumentsData {
+object PreviousDocumentsData extends DeclarationFieldCompanion {
   implicit val format = Json.format[PreviousDocumentsData]
 
   val maxAmountOfItems = 99

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -15,7 +15,9 @@
  *@
 
 @import controllers.declaration.routes._
+@import controllers.navigation.Navigator
 @import forms.declaration.Document
+@import forms.declaration.PreviousDocumentsData
 @import forms.declaration.Document.AllowedValues._
 @import uk.gov.hmrc.play.views.html._
 @import views.components.inputs.RadioOption
@@ -33,14 +35,7 @@
     title = Title("supplementary.previousDocuments.title", "supplementary.consignmentReferences.heading")
 ) {
 
-    @{
-        request.declarationType match {
-            case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD =>
-                components.back_link(controllers.declaration.routes.NatureOfTransactionController.displayPage(mode), mode)
-            case DeclarationType.SIMPLIFIED =>
-                components.back_link(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode), mode)
-        }
-    }
+    @components.back_link(Navigator.backLink(PreviousDocumentsData)(request)(mode), mode)
 
     @components.error_summary(form.errors)
 

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -17,7 +17,6 @@
 @import controllers.declaration.routes._
 @import controllers.navigation.Navigator
 @import forms.declaration.Document
-@import forms.declaration.PreviousDocumentsData
 @import forms.declaration.Document.AllowedValues._
 @import uk.gov.hmrc.play.views.html._
 @import views.components.inputs.RadioOption
@@ -35,7 +34,7 @@
     title = Title("supplementary.previousDocuments.title", "supplementary.consignmentReferences.heading")
 ) {
 
-    @components.back_link(Navigator.backLink(PreviousDocumentsData)(request)(mode), mode)
+    @components.back_link(Navigator.backLink(Document)(request)(mode), mode)
 
     @components.error_summary(form.errors)
 

--- a/app/views/declaration/summary/items_section.scala.html
+++ b/app/views/declaration/summary/items_section.scala.html
@@ -16,22 +16,27 @@
 
 @import models.declaration.Items
 @import models.viewmodels.HtmlTableRow
+@import models.DeclarationType.DeclarationType
 
-@(items: Option[Items])(implicit messages: Messages)
+@(items: Option[Items], declarationType: DeclarationType)(implicit messages: Messages)
+
+@journeysThatRequireItemInfo = @{Set(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)}
 
 @components.summary_list(Some(messages("declaration.itemType.title", 1))) {
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.items.amountInvoiced"),
-        value = items.flatMap(_.totalNumberOfItems).map(_.totalAmountInvoiced)
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.items.exchangeRate"),
-        value = items.flatMap(_.totalNumberOfItems).map(_.exchangeRate)
-    ))
-    @components.table_row_no_change_link(HtmlTableRow(
-        label = messages("supplementary.summary.items.numberOfPackages"),
-        value = items.flatMap(_.totalNumberOfItems).map(_.totalPackage)
-    ))
+    @if(journeysThatRequireItemInfo.contains(declarationType)) {
+        @components.table_row_no_change_link(HtmlTableRow(
+            label = messages("supplementary.summary.items.amountInvoiced"),
+            value = items.flatMap(_.totalNumberOfItems).map(_.totalAmountInvoiced)
+        ))
+        @components.table_row_no_change_link(HtmlTableRow(
+            label = messages("supplementary.summary.items.exchangeRate"),
+            value = items.flatMap(_.totalNumberOfItems).map(_.exchangeRate)
+        ))
+        @components.table_row_no_change_link(HtmlTableRow(
+            label = messages("supplementary.summary.items.numberOfPackages"),
+            value = items.flatMap(_.totalNumberOfItems).map(_.totalPackage)
+        ))
+    }
 
     @components.table_row_no_change_link(HtmlTableRow(
         label = messages("supplementary.summary.items.transactionType"),

--- a/app/views/declaration/summary/summary_page.scala.html
+++ b/app/views/declaration/summary/summary_page.scala.html
@@ -108,7 +108,7 @@
 
     @transport_containers_section(suppDecData.transportInformationContainerData)
 
-    @items_section(suppDecData.items)
+    @items_section(suppDecData.items, request.declarationType)
 
     @if(mode == Mode.Amend) {
         <br/>

--- a/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
+++ b/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
@@ -260,7 +260,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
         val result = controller.saveOffice(Mode.Normal)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.TotalNumberOfItemsController.displayPage()
+        thePageNavigatedTo mustBe controllers.declaration.routes.PreviousDocumentsController.displayPage()
         checkStandardViewInteractions(0)
       }
     }

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -118,12 +118,20 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
         backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
       }
 
+      "on the Supplementary journey" in {
+
+        val backButton = createView(declarationType = DeclarationType.SUPPLEMENTARY).getElementById("link-back")
+
+        backButton.text() must be("site.back")
+        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+      }
+
       "on the Simplified journey" in {
 
         val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("link-back")
 
         backButton.text() must be("site.back")
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(Mode.Normal))
+        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
       }
     }
 


### PR DESCRIPTION
A Simplified Declaration requires fewer data elements to be completed
than a Standard Declaration.
This change captures the requirement to skip the 'total-numbers-of-items'
page, which is not relevant to Simplified Declaration.