### PR TITLE
CEDS-1909 commodity details page split

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -58,6 +58,9 @@ class AppConfig @Inject()(
   lazy val serviceAvailabilityUrl = loadConfig("urls.serviceAvailability")
   lazy val customsMovementsFrontendUrl = loadConfig("urls.customsMovementsFrontend")
 
+  lazy val tradeTariffUrl = loadConfig("urls.tradeTariff")
+  lazy val classificationHelpUrl = loadConfig("urls.classificationHelp")
+
   lazy val customsDeclareExports = servicesConfig.baseUrl("customs-declare-exports")
 
   lazy val declarations = servicesConfig.getConfString(

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -86,8 +86,8 @@ class AdditionalFiscalReferencesController @Inject()(
         updatedCache =>
           if (updatedCache != cachedData.references)
             updateExportsCache(itemId, AdditionalFiscalReferencesData(updatedCache))
-              .map(_ => navigator.continueTo(routes.ItemTypeController.displayPage(mode, itemId)))
-          else Future.successful(navigator.continueTo(routes.ItemTypeController.displayPage(mode, itemId)))
+              .map(_ => navigator.continueTo(routes.CommodityDetailsController.displayPage(mode, itemId)))
+          else Future.successful(navigator.continueTo(routes.CommodityDetailsController.displayPage(mode, itemId)))
       )
 
   def removeReference(mode: Mode, itemId: String, value: String) = itemAction(itemId).async { implicit request =>

--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -63,13 +63,9 @@ class CommodityDetailsController @Inject()(
   }
 
   private def updateExportsCache(itemId: String, updatedItem: CommodityDetails)(
-    implicit r: JourneyRequest[AnyContent]
+    implicit request: JourneyRequest[AnyContent]
   ): Future[Option[ExportsDeclaration]] =
-    updateExportsDeclarationSyncDirect(model => {
-      val itemList = model.items
-        .find(item => item.id.equals(itemId))
-        .map(_.copy(commodityDetails = Some(updatedItem)))
-        .fold(model.items)(model.items.filter(item => !item.id.equals(itemId)) + _)
-      model.copy(items = itemList)
-    })
+    updateExportsDeclarationSyncDirect { model =>
+      model.updatedItem(itemId, item => item.copy(commodityDetails = Some(updatedItem)))
+    }
 }

--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declaration
+
+import controllers.actions.{AuthAction, JourneyAction}
+import controllers.navigation.Navigator
+import forms.declaration.CommodityDetails
+import forms.declaration.CommodityDetails.form
+import javax.inject.Inject
+import models.requests.JourneyRequest
+import models.{ExportsDeclaration, Mode}
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.cache.ExportsCacheService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.declaration.commodity_details
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class CommodityDetailsController @Inject()(
+  authenticate: AuthAction,
+  journeyType: JourneyAction,
+  override val exportsCacheService: ExportsCacheService,
+  navigator: Navigator,
+  mcc: MessagesControllerComponents,
+  commodityDetailsPage: commodity_details
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable {
+
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.itemBy(itemId).flatMap(_.commodityDetails) match {
+      case Some(commodityDetails) => Ok(commodityDetailsPage(mode, itemId, form(request.declarationType).fill(commodityDetails)))
+      case _                      => Ok(commodityDetailsPage(mode, itemId, form(request.declarationType)))
+    }
+  }
+
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    form(request.declarationType)
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[CommodityDetails]) => Future.successful(BadRequest(commodityDetailsPage(mode, itemId, formWithErrors))),
+        validForm =>
+          updateExportsCache(itemId, validForm).map { _ =>
+            navigator
+              .continueTo(controllers.declaration.routes.ItemTypeController.displayPage(mode, itemId))
+        }
+      )
+  }
+
+  private def updateExportsCache(itemId: String, updatedItem: CommodityDetails)(
+    implicit r: JourneyRequest[AnyContent]
+  ): Future[Option[ExportsDeclaration]] =
+    updateExportsDeclarationSyncDirect(model => {
+      val itemList = model.items
+        .find(item => item.id.equals(itemId))
+        .map(_.copy(commodityDetails = Some(updatedItem)))
+        .fold(model.items)(model.items.filter(item => !item.id.equals(itemId)) + _)
+      model.copy(items = itemList)
+    })
+}

--- a/app/controllers/declaration/FiscalInformationController.scala
+++ b/app/controllers/declaration/FiscalInformationController.scala
@@ -43,7 +43,9 @@ class FiscalInformationController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
   def displayPage(mode: Mode, itemId: String, fastForward: Boolean): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    if (fastForward && request.cacheModel.itemBy(itemId).exists(_.additionalFiscalReferencesData.exists(_.references.nonEmpty))) {
+    def cacheContainsFiscalReferenceData = request.cacheModel.itemBy(itemId).exists(_.additionalFiscalReferencesData.exists(_.references.nonEmpty))
+
+    if (fastForward && cacheContainsFiscalReferenceData) {
       navigator.continueTo(routes.AdditionalFiscalReferencesController.displayPage(mode, itemId))
     } else {
       request.cacheModel.itemBy(itemId).flatMap(_.fiscalInformation) match {

--- a/app/controllers/declaration/ItemTypeController.scala
+++ b/app/controllers/declaration/ItemTypeController.scala
@@ -140,10 +140,8 @@ class ItemTypeController @Inject()(
     }
 
     ItemType(
-      combinedNomenclatureCode = itemTypeInput.combinedNomenclatureCode,
       taricAdditionalCodes = updatedTaricCodes,
       nationalAdditionalCodes = updatedNationalCodes,
-      descriptionOfGoods = itemTypeInput.descriptionOfGoods,
       cusCode = itemTypeInput.cusCode,
       unDangerousGoodsCode = itemTypeInput.unDangerousGoodsCode,
       statisticalValue = itemTypeInput.statisticalValue

--- a/app/forms/declaration/CommodityDetails.scala
+++ b/app/forms/declaration/CommodityDetails.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.declaration
+import forms.DeclarationFieldCompanion
+import models.DeclarationType
+import models.DeclarationType.DeclarationType
+import play.api.data.Forms.{optional, text}
+import play.api.data.{Form, Forms, Mapping}
+import play.api.libs.json.Json
+import utils.validators.forms.FieldValidator._
+
+case class CommodityDetails(combinedNomenclatureCode: Option[String], descriptionOfGoods: String)
+
+object CommodityDetails extends DeclarationFieldCompanion {
+
+  implicit val format = Json.format[CommodityDetails]
+
+  val combinedNomenclatureCodeKey = "combinedNomenclatureCode"
+  val descriptionOfGoodsKey = "descriptionOfGoods"
+
+  val id = "CommodityDetails"
+
+  private val combinedNomenclatureCodeMaxLength = 8
+  private val descriptionOfGoodsMaxLength = 280
+
+  private def mappingCombinedNomenclatureCodeRequired: Mapping[Option[String]] =
+    optional(
+      text()
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.empty", nonEmpty)
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.length", isEmpty or noLongerThan(combinedNomenclatureCodeMaxLength))
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.specialCharacters", isEmpty or isNumeric)
+    ).verifying("declaration.commodityDetails.combinedNomenclatureCode.error.empty", isPresent)
+
+  private def mappingCombinedNomenclatureCodeOptional: Mapping[Option[String]] =
+    optional(
+      text()
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.empty", nonEmpty)
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.length", isEmpty or noLongerThan(combinedNomenclatureCodeMaxLength))
+        .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.specialCharacters", isEmpty or isNumeric)
+    )
+
+  private val mappingDescriptionOfGoods = text()
+    .verifying("declaration.commodityDetails.description.error.empty", nonEmpty)
+    .verifying("declaration.commodityDetails.description.error.length", isEmpty or noLongerThan(descriptionOfGoodsMaxLength))
+
+  private val mappingRequiredCode: Mapping[CommodityDetails] =
+    Forms.mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeRequired, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
+      CommodityDetails.apply
+    )(CommodityDetails.unapply)
+
+  private val mappingOptionalCode: Mapping[CommodityDetails] =
+    Forms.mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeOptional, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
+      CommodityDetails.apply
+    )(CommodityDetails.unapply)
+
+  def form(declarationType: DeclarationType): Form[CommodityDetails] = declarationType match {
+    case DeclarationType.SIMPLIFIED => Form(mappingOptionalCode)
+    case _                          => Form(mappingRequiredCode)
+  }
+}

--- a/app/forms/declaration/CommodityDetails.scala
+++ b/app/forms/declaration/CommodityDetails.scala
@@ -15,7 +15,7 @@
  */
 
 package forms.declaration
-import forms.DeclarationFieldCompanion
+import forms.DeclarationPage
 import models.DeclarationType
 import models.DeclarationType.DeclarationType
 import play.api.data.Forms.{mapping, optional, text}
@@ -25,7 +25,7 @@ import utils.validators.forms.FieldValidator._
 
 case class CommodityDetails(combinedNomenclatureCode: Option[String], descriptionOfGoods: String)
 
-object CommodityDetails extends DeclarationFieldCompanion {
+object CommodityDetails extends DeclarationPage {
 
   implicit val format = Json.format[CommodityDetails]
 

--- a/app/forms/declaration/CommodityDetails.scala
+++ b/app/forms/declaration/CommodityDetails.scala
@@ -18,8 +18,8 @@ package forms.declaration
 import forms.DeclarationFieldCompanion
 import models.DeclarationType
 import models.DeclarationType.DeclarationType
-import play.api.data.Forms.{optional, text}
-import play.api.data.{Form, Forms, Mapping}
+import play.api.data.Forms.{mapping, optional, text}
+import play.api.data.{Form, Mapping}
 import play.api.libs.json.Json
 import utils.validators.forms.FieldValidator._
 
@@ -31,8 +31,6 @@ object CommodityDetails extends DeclarationFieldCompanion {
 
   val combinedNomenclatureCodeKey = "combinedNomenclatureCode"
   val descriptionOfGoodsKey = "descriptionOfGoods"
-
-  val id = "CommodityDetails"
 
   private val combinedNomenclatureCodeMaxLength = 8
   private val descriptionOfGoodsMaxLength = 280
@@ -58,12 +56,12 @@ object CommodityDetails extends DeclarationFieldCompanion {
     .verifying("declaration.commodityDetails.description.error.length", isEmpty or noLongerThan(descriptionOfGoodsMaxLength))
 
   private val mappingRequiredCode: Mapping[CommodityDetails] =
-    Forms.mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeRequired, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
+    mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeRequired, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
       CommodityDetails.apply
     )(CommodityDetails.unapply)
 
   private val mappingOptionalCode: Mapping[CommodityDetails] =
-    Forms.mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeOptional, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
+    mapping(combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCodeOptional, descriptionOfGoodsKey -> mappingDescriptionOfGoods)(
       CommodityDetails.apply
     )(CommodityDetails.unapply)
 

--- a/app/forms/declaration/ItemTypeForm.scala
+++ b/app/forms/declaration/ItemTypeForm.scala
@@ -16,17 +16,13 @@
 
 package forms.declaration
 
-import models.DeclarationType
-import models.DeclarationType.DeclarationType
 import models.declaration.ItemType
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms, Mapping}
 
 case class ItemTypeForm(
-  combinedNomenclatureCode: Option[String],
   taricAdditionalCode: Option[String],
   nationalAdditionalCode: Option[String],
-  descriptionOfGoods: String,
   cusCode: Option[String],
   unDangerousGoodsCode: Option[String],
   statisticalValue: String
@@ -34,19 +30,15 @@ case class ItemTypeForm(
 
 object ItemTypeForm {
 
-  val combinedNomenclatureCodeKey = "combinedNomenclatureCode"
   val taricAdditionalCodeKey = "taricAdditionalCode"
   val nationalAdditionalCodeKey = "nationalAdditionalCode"
-  val descriptionOfGoodsKey = "descriptionOfGoods"
   val cusCodeKey = "cusCode"
   val unDangerousGoodsCodeKey = "unDangerousGoodsCode"
   val statisticalValueKey = "statisticalValue"
 
   private val mapping: Mapping[ItemTypeForm] = Forms.mapping(
-    combinedNomenclatureCodeKey -> optional(text()),
     taricAdditionalCodeKey -> optional(text()),
     nationalAdditionalCodeKey -> optional(text()),
-    descriptionOfGoodsKey -> text(),
     cusCodeKey -> optional(text()),
     unDangerousGoodsCodeKey -> optional(text()),
     statisticalValueKey -> text()
@@ -56,16 +48,8 @@ object ItemTypeForm {
 
   def form(): Form[ItemTypeForm] = Form(mapping)
 
-  val empty: ItemTypeForm = ItemTypeForm(None, None, None, "", None, None, "")
+  val empty: ItemTypeForm = ItemTypeForm(None, None, None, None, "")
 
   def fromItemType(model: ItemType) =
-    ItemTypeForm(
-      model.combinedNomenclatureCode,
-      None,
-      None,
-      model.descriptionOfGoods,
-      model.cusCode,
-      model.unDangerousGoodsCode,
-      model.statisticalValue
-    )
+    ItemTypeForm(None, None, model.cusCode, model.unDangerousGoodsCode, model.statisticalValue)
 }

--- a/app/models/declaration/ExportItem.scala
+++ b/app/models/declaration/ExportItem.scala
@@ -16,7 +16,7 @@
 
 package models.declaration
 
-import forms.declaration.{AdditionalFiscalReferencesData, CommodityMeasure, FiscalInformation, PackageInformation}
+import forms.declaration._
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers.yes
 import models.DeclarationType
 import models.DeclarationType.DeclarationType
@@ -29,6 +29,7 @@ case class ExportItem(
   fiscalInformation: Option[FiscalInformation] = None,
   additionalFiscalReferencesData: Option[AdditionalFiscalReferencesData] = None,
   itemType: Option[ItemType] = None,
+  commodityDetails: Option[CommodityDetails] = None,
   packageInformation: List[PackageInformation] = Nil,
   commodityMeasure: Option[CommodityMeasure] = None,
   additionalInformation: Option[AdditionalInformationData] = None,

--- a/app/models/declaration/ItemType.scala
+++ b/app/models/declaration/ItemType.scala
@@ -19,10 +19,8 @@ import play.api.libs.functional.syntax.{unlift, _}
 import play.api.libs.json.{JsPath, Reads, Writes}
 
 case class ItemType(
-  combinedNomenclatureCode: Option[String],
   taricAdditionalCodes: Seq[String],
   nationalAdditionalCodes: Seq[String],
-  descriptionOfGoods: String,
   cusCode: Option[String],
   unDangerousGoodsCode: Option[String],
   statisticalValue: String
@@ -31,24 +29,20 @@ case class ItemType(
 object ItemType {
 
   implicit val reads: Reads[ItemType] = (
-    (JsPath \ "combinedNomenclatureCode").readNullable[String] and
-      (JsPath \ "taricAdditionalCode").read[Seq[String]] and
+    (JsPath \ "taricAdditionalCode").read[Seq[String]] and
       (JsPath \ "nationalAdditionalCode").read[Seq[String]] and
-      (JsPath \ "descriptionOfGoods").read[String] and
       (JsPath \ "cusCode").readNullable[String] and
       (JsPath \ "unDangerousGoodsCode").readNullable[String] and
       (JsPath \ "statisticalValue").read[String]
   )(ItemType.apply _)
 
   implicit val writes: Writes[ItemType] = (
-    (JsPath \ "combinedNomenclatureCode").writeNullable[String] and
-      (JsPath \ "taricAdditionalCode").write[Seq[String]] and
+    (JsPath \ "taricAdditionalCode").write[Seq[String]] and
       (JsPath \ "nationalAdditionalCode").write[Seq[String]] and
-      (JsPath \ "descriptionOfGoods").write[String] and
       (JsPath \ "cusCode").writeNullable[String] and
       (JsPath \ "unDangerousGoodsCode").writeNullable[String] and
       (JsPath \ "statisticalValue").write[String]
   )(unlift(ItemType.unapply))
 
-  val empty: ItemType = ItemType(None, Nil, Nil, "", None, None, "")
+  val empty: ItemType = ItemType(Nil, Nil, None, None, "")
 }

--- a/app/utils/validators/forms/supplementary/ItemTypeValidator.scala
+++ b/app/utils/validators/forms/supplementary/ItemTypeValidator.scala
@@ -17,11 +17,10 @@
 package utils.validators.forms.supplementary
 
 import forms.declaration.ItemTypeForm._
-import models.DeclarationType
 import models.declaration.ItemType
 import models.requests.JourneyRequest
 import play.api.data.Forms.{optional, seq, text}
-import play.api.data.{Form, Forms, Mapping}
+import play.api.data.{Form, Forms}
 import play.api.mvc.AnyContent
 import services.NationalAdditionalCode
 import utils.validators.forms.FieldValidator._
@@ -29,12 +28,10 @@ import utils.validators.forms.{Invalid, Valid, ValidationResult, Validator}
 
 object ItemTypeValidator extends Validator[ItemType] {
 
-  private val combinedNomenclatureCodeMaxLength = 8
   private val taricAdditionalCodeLength = 4
   private val taricAdditionalCodesMaxAmount = 99
   private val nationalAdditionalCodeMaxLength = 4
   private val nationalAdditionalCodesMaxAmount = 99
-  private val descriptionOfGoodsMaxLength = 280
   private val cusCodeLength = 8
   private val unDangerousGoodsCodeLength = 4
   private val statisticalValueMaxLength = 15
@@ -50,14 +47,6 @@ object ItemTypeValidator extends Validator[ItemType] {
       .fillAndValidate(element)
       .fold[ValidationResult](formWithErrors => Invalid(formWithErrors.errors), _ => Valid)
 
-  private def mappingCombinedNomenclatureCode(implicit request: JourneyRequest[AnyContent]): Mapping[Option[String]] =
-    optional(
-      text()
-        .verifying("declaration.itemType.combinedNomenclatureCode.error.empty", when(request.declarationType != DeclarationType.SIMPLIFIED)(nonEmpty))
-        .verifying("declaration.itemType.combinedNomenclatureCode.error.length", isEmpty or noLongerThan(combinedNomenclatureCodeMaxLength))
-        .verifying("declaration.itemType.combinedNomenclatureCode.error.specialCharacters", isEmpty or isAlphanumeric)
-    ).verifying("declaration.itemType.combinedNomenclatureCode.error.empty", when(request.declarationType != DeclarationType.SIMPLIFIED)(isPresent))
-
   private val mappingTARICAdditionalCode = seq(
     text()
       .verifying("declaration.itemType.taricAdditionalCodes.error.length", hasSpecificLength(taricAdditionalCodeLength))
@@ -70,10 +59,6 @@ object ItemTypeValidator extends Validator[ItemType] {
       .verifying("declaration.itemType.nationalAdditionalCode.error.invalid", isContainedIn(NationalAdditionalCode.all.map(_.value)))
   ).verifying("declaration.itemType.nationalAdditionalCode.error.maxAmount", codes => codes.size <= nationalAdditionalCodesMaxAmount)
     .verifying("declaration.itemType.nationalAdditionalCode.error.duplicate", areAllElementsUnique)
-
-  private val mappingDescriptionOfGoods = text()
-    .verifying("declaration.itemType.description.error.empty", nonEmpty)
-    .verifying("declaration.itemType.description.error.length", isEmpty or noLongerThan(descriptionOfGoodsMaxLength))
 
   private val mappingCUSCode = optional(
     text()
@@ -99,10 +84,8 @@ object ItemTypeValidator extends Validator[ItemType] {
     )
 
   private val addValidation = Forms.mapping(
-    combinedNomenclatureCodeKey -> optional(text()),
     taricAdditionalCodeKey -> mappingTARICAdditionalCode,
     nationalAdditionalCodeKey -> mappingNationalAdditionalCode,
-    descriptionOfGoodsKey -> text(),
     cusCodeKey -> optional(text()),
     unDangerousGoodsCodeKey -> optional(text()),
     statisticalValueKey -> text()
@@ -110,10 +93,8 @@ object ItemTypeValidator extends Validator[ItemType] {
 
   private def submitValidation(implicit request: JourneyRequest[AnyContent]) =
     Forms.mapping(
-      combinedNomenclatureCodeKey -> mappingCombinedNomenclatureCode,
       taricAdditionalCodeKey -> mappingTARICAdditionalCode,
       nationalAdditionalCodeKey -> mappingNationalAdditionalCode,
-      descriptionOfGoodsKey -> mappingDescriptionOfGoods,
       cusCodeKey -> mappingCUSCode,
       unDangerousGoodsCodeKey -> mappingUNDangerousGoodsCode,
       statisticalValueKey -> mappingStatisticalValue

--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -77,7 +77,7 @@
     title = Title("declaration.additionalFiscalReferences.title", "declaration.fiscalInformation.header")
 ) {
 
-    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
+    @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId, fastForward = false), mode)
 
     @components.error_summary(form.errors)
 

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -1,0 +1,93 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.declaration.routes
+@import controllers.util.SaveAndContinue
+@import forms.Choice.AllowedChoiceValues
+@import forms.declaration.CommodityDetails
+@import forms.declaration.CommodityDetails._
+@import models.requests.JourneyRequest
+@import uk.gov.hmrc.play.views.html._
+@import services.NationalAdditionalCode
+@import services.view.AutoCompleteItem
+@import forms.declaration.AdditionalFiscalReference
+@import models.declaration.ExportItem
+@import views.Title
+
+@this(main_template: views.html.main_template)
+
+@(
+        mode: Mode,
+        itemId: String,
+        form: Form[CommodityDetails]
+)(implicit request: JourneyRequest[_], messages: Messages)
+
+@main_template(
+    title = Title("declaration.commodityDetails.title", "supplementary.items")
+) {
+
+    @helper.form(routes.CommodityDetailsController.submitForm(mode, itemId), 'autocomplete -> "off") {
+        @helper.CSRF.formField
+
+        @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
+
+        @components.error_summary(form.errors)
+
+        @components.heading(
+            sectionHeader = messages("supplementary.items"),
+            title = messages("declaration.commodityDetails.title")
+        )
+
+        @components.fields.field_text(
+            field = form(CommodityDetails.combinedNomenclatureCodeKey),
+            label = messages("declaration.commodityDetails.combinedNomenclatureCode.header"),
+            hint = Some(messages("declaration.commodityDetails.combinedNomenclatureCode.header.hint")),
+            labelClass = Some("bold-small")
+        )
+
+        @components.fields.field_textarea(
+            field = form(CommodityDetails.descriptionOfGoodsKey),
+            label = messages("declaration.commodityDetails.description.header"),
+            hint = Some(messages("declaration.commodityDetails.description.header.hint")),
+            labelClass = Some("bold-small"),
+            inputClass = Some("form-control--full-width")
+        )
+
+        <details class="govuk-details" role="group">
+            <summary class="govuk-details__summary" role="button" aria-controls="details-content" aria-expanded="false">
+                <span class="govuk-details__summary-text">
+                @messages("declaration.commodityDetails.how.header")
+                </span>
+            </summary>
+            <div class="grey-border-left">
+                <ol class="list list-number">
+                @*<ol class="govuk-list ">*@
+                    <li>@Html(messages("declaration.commodityDetails.how.step1"))</li>
+                    <li>@Html(messages("declaration.commodityDetails.how.step2"))</li>
+                    <li>@Html(messages("declaration.commodityDetails.how.step3"))</li>
+                    <li>@Html(messages("declaration.commodityDetails.how.step4"))</li>
+                    <li>@Html(messages("declaration.commodityDetails.how.step5"))</li>
+                </ol>
+                <p>@Html(messages("declaration.commodityDetails.how.summary"))</p>
+            </div>
+        </details>
+
+
+        @components.submit_button()
+        @components.buttons.save_and_return_later_button()
+    }
+
+}

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -18,16 +18,12 @@
 @import controllers.util.SaveAndContinue
 @import forms.Choice.AllowedChoiceValues
 @import forms.declaration.CommodityDetails
-@import forms.declaration.CommodityDetails._
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.play.views.html._
-@import services.NationalAdditionalCode
-@import services.view.AutoCompleteItem
-@import forms.declaration.AdditionalFiscalReference
-@import models.declaration.ExportItem
 @import views.Title
+@import config.AppConfig
 
-@this(main_template: views.html.main_template)
+@this(main_template: views.html.main_template, appConfig: AppConfig)
 
 @(
         mode: Mode,
@@ -74,13 +70,18 @@
             </summary>
             <div class="grey-border-left">
                 <ol class="list list-number">
-                    <li>@Html(messages("declaration.commodityDetails.how.step1"))</li>
-                    <li>@Html(messages("declaration.commodityDetails.how.step2"))</li>
-                    <li>@Html(messages("declaration.commodityDetails.how.step3"))</li>
-                    <li>@Html(messages("declaration.commodityDetails.how.step4"))</li>
-                    <li>@Html(messages("declaration.commodityDetails.how.step5"))</li>
+                    <li>@messages("declaration.commodityDetails.how.step1")
+                        <a href="@appConfig.tradeTariffUrl" target="_blank">@messages("declaration.commodityDetails.how.tradeTariff")</a>
+                    </li>
+                    <li>@messages("declaration.commodityDetails.how.step2")</li>
+                    <li>@messages("declaration.commodityDetails.how.step3")</li>
+                    <li>@messages("declaration.commodityDetails.how.step4")</li>
+                    <li>@messages("declaration.commodityDetails.how.step5")</li>
                 </ol>
-                <p>@Html(messages("declaration.commodityDetails.how.summary"))</p>
+                <p>
+                    @messages("declaration.commodityDetails.how.summary")
+                    <a href="@appConfig.classificationHelpUrl" target="_blank">@messages("declaration.commodityDetails.how.classificationTeam")</a>
+                </p>
             </div>
         </details>
 

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -74,7 +74,6 @@
             </summary>
             <div class="grey-border-left">
                 <ol class="list list-number">
-                @*<ol class="govuk-list ">*@
                     <li>@Html(messages("declaration.commodityDetails.how.step1"))</li>
                     <li>@Html(messages("declaration.commodityDetails.how.step2"))</li>
                     <li>@Html(messages("declaration.commodityDetails.how.step3"))</li>

--- a/app/views/declaration/item_type.scala.html
+++ b/app/views/declaration/item_type.scala.html
@@ -44,24 +44,13 @@
     @helper.form(routes.ItemTypeController.submitItemType(mode, item.id), 'autocomplete -> "off") {
         @helper.CSRF.formField
 
-        @{
-          if(item.hasFiscalReferences) components.back_link(routes.AdditionalFiscalReferencesController.displayPage(mode, item.id), mode)
-          else components.back_link(routes.FiscalInformationController.displayPage(mode, item.id), mode)
-        }
-
+        @components.back_link(routes.CommodityDetailsController.displayPage(mode, item.id), mode)
 
         @components.error_summary(form.errors)
 
         @components.heading(
             sectionHeader = messages("supplementary.items"),
             title = messages("declaration.itemType.title", item.sequenceId)
-        )
-
-        @components.fields.field_text(
-            field = form(combinedNomenclatureCodeKey),
-            label = messages("declaration.itemType.combinedNomenclatureCode.header"),
-            hint = Some(messages("declaration.itemType.combinedNomenclatureCode.header.hint")),
-            labelClass = Some("bold-small")
         )
 
         @components.fields.field_text_multiple_values(
@@ -97,13 +86,6 @@
             field = form("statisticalValue"),
             label = messages("declaration.itemType.statisticalValue.header"),
             hint = Some(messages("declaration.itemType.statisticalValue.header.hint")),
-            labelClass = Some("bold-small")
-        )
-
-        @components.fields.field_textarea(
-            field = form("descriptionOfGoods"),
-            label = messages("declaration.itemType.description.header"),
-            hint = Some(messages("declaration.itemType.description.header.hint")),
             labelClass = Some("bold-small")
         )
 

--- a/app/views/declaration/items_summary.scala.html
+++ b/app/views/declaration/items_summary.scala.html
@@ -60,7 +60,7 @@
                 <tr id="item_@index">
                     <td id="item_@index--sequence_id" scope="row">@item.sequenceId</td>
                     <td id="item_@index--procedure_code" scope="row">@item.procedureCodes.map(_.procedureCode).getOrElse("") </td>
-                    <td id="item_@index--item_type" scope="row">@item.itemType.map(_.combinedNomenclatureCode) </td>
+                    <td id="item_@index--item_type" scope="row">@item.commodityDetails.map(_.combinedNomenclatureCode) </td>
                     <td id="item_@index--package_count" scope="row">
                         <ol type="1">@item.packageInformation.map(a =>
                             <li>{a.numberOfPackages}</li>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -141,6 +141,8 @@ urls {
   relevantLicenses = "https://www.gov.uk/starting-to-export/licences"
   serviceAvailability = "https://www.gov.uk/guidance/customs-declaration-service-service-availability-and-issues"
   customsMovementsFrontend = "http://localhost:6796/customs-movements/start"
+  tradeTariff = "https://www.gov.uk/trade-tariff"
+  classificationHelp = "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods"
 }
 
 whitelist {

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -130,7 +130,7 @@ POST        /items/:itemId/procedure-codes        controllers.declaration.Proced
 
 # Fiscal Information
 
-GET          /items/:itemId/fiscal-information    controllers.declaration.FiscalInformationController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId)
+GET          /items/:itemId/fiscal-information    controllers.declaration.FiscalInformationController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId, fastForward: Boolean ?= true)
 
 POST         /items/:itemId/fiscal-information   controllers.declaration.FiscalInformationController.saveFiscalInformation(mode: models.Mode ?= models.Mode.Normal, itemId)
 
@@ -148,6 +148,12 @@ POST        /items/:itemId/additional-fiscal-references/:reference  controllers.
 GET         /items/:itemId/item-type                           controllers.declaration.ItemTypeController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId)
 
 POST        /items/:itemId/item-type                           controllers.declaration.ItemTypeController.submitItemType(mode: models.Mode ?= models.Mode.Normal, itemId)
+
+# Commodity Details
+
+GET         /items/:itemId/commodity-details                   controllers.declaration.CommodityDetailsController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId)
+
+POST        /items/:itemId/commodity-details                   controllers.declaration.CommodityDetailsController.submitForm(mode: models.Mode ?= models.Mode.Normal, itemId)
 
 # Package Information
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -583,11 +583,6 @@ supplementary.goodItemNumber.error = Incorrect item number
 supplementary.goodItemNumber.hint = The number assigned to the item in the declaration
 
 declaration.itemType.title = Details of declaration item {0}
-declaration.itemType.combinedNomenclatureCode.header = What is the Commodity Code for this item?
-declaration.itemType.combinedNomenclatureCode.header.hint = Up to 8 digits
-declaration.itemType.combinedNomenclatureCode.error.empty = Combined Nomenclature Commodity Code cannot be empty
-declaration.itemType.combinedNomenclatureCode.error.length = Combined Nomenclature Commodity Code cannot be longer than 8 characters
-declaration.itemType.combinedNomenclatureCode.error.specialCharacters = Combined Nomenclature Commodity Code cannot contain special characters
 declaration.itemType.taricAdditionalCodes.header = Do you need to enter any TARIC additional codes?
 declaration.itemType.taricAdditionalCodes.header.hint = This is 4 digits. If no additional code is required, leave blank
 declaration.itemType.taricAdditionalCodes.error.length = TARIC additional code must be exactly 4 characters long
@@ -603,10 +598,6 @@ declaration.itemType.nationalAdditionalCode.error.maxAmount = You cannot add mor
 declaration.itemType.nationalAdditionalCode.error.duplicate = National Additional Codes cannot contain duplicates
 declaration.itemType.nationalAdditionalCode.add.hint = Add National Additional Code
 declaration.itemType.nationalAdditionalCode.remove.hint = Remove National Additional Code {0}
-declaration.itemType.description.header = Enter the trade description of the goods
-declaration.itemType.description.header.hint = Include information on size, weight or other physical criteria where this is required by the commodity code
-declaration.itemType.description.error.empty = Description cannot be empty
-declaration.itemType.description.error.length = Description cannot be longer than 280 characters
 declaration.itemType.cusCode.header = What is the CUS Code for this item?
 declaration.itemType.cusCode.header.hint = A customs union and statistics number (CUS code) is required for chemicals classified in chapters 28, 29 and some in chapter 38 of the UK Trade Tariff. You can find this using the <a href="https://ec.europa.eu/taxation_customs/dds2/ecics/chemicalsubstance_consultation.jsp" target="blank">ECICS chemical substance information tool.</a>
 declaration.itemType.cusCode.error.length = CUS Code must be exactly 8 characters long
@@ -620,6 +611,24 @@ declaration.itemType.statisticalValue.header.hint = The approximate value of the
 declaration.itemType.statisticalValue.error.empty = The statistical value cannot be empty
 declaration.itemType.statisticalValue.error.length = Entered statistical value is too long
 declaration.itemType.statisticalValue.error.wrongFormat = Format of this value is incorrect
+
+declaration.commodityDetails.title = Commodity details
+declaration.commodityDetails.combinedNomenclatureCode.header = What is the commodity code?
+declaration.commodityDetails.combinedNomenclatureCode.header.hint = A commodity code is an eight digit number specifically allocated to goods to classify them when moved outside the EU.  For example, 12345678.
+declaration.commodityDetails.combinedNomenclatureCode.error.empty = Commodity code cannot be empty
+declaration.commodityDetails.combinedNomenclatureCode.error.length = Enter a valid commodity code
+declaration.commodityDetails.combinedNomenclatureCode.error.specialCharacters = Commodity code cannot contain special characters
+declaration.commodityDetails.description.header = Describe the goods
+declaration.commodityDetails.description.header.hint = Try to be as specific as you can. For example, 'Copper pipe 15mm x 3m'
+declaration.commodityDetails.description.error.empty = Description cannot be empty
+declaration.commodityDetails.description.error.length = Description cannot be longer than 280 characters
+declaration.commodityDetails.how.header = How do I find a commodity code?
+declaration.commodityDetails.how.step1 = Go to the <a href='https://www.gov.uk/trade-tariff' target='_blank'>UK Trade Tariff</a>.
+declaration.commodityDetails.how.step2 = Type your goods into the search bar. It will present you with multiple options. Select the one that most closely resembles your goods.
+declaration.commodityDetails.how.step3 = This will take you to a table with more options. Select 'open all headings' (top left of the table) and browse through the list to find the description that most closely resembles your goods.
+declaration.commodityDetails.how.step4 = Keep selecting options until you have a full ten-digit number in the right-hand column. (Note, at this point it will tell you if the goods require a supplementary unit in the column next to it).
+declaration.commodityDetails.how.step5 = This number is your commodity code. Click on it and click on the exports tab halfway down the page. This will give you specific information such as licences, quota tariff, and CUS codes.
+declaration.commodityDetails.how.summary = It is important to get it right. If you need help confirming your commodity code, you can contact the <a href='https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods' target='_blank'>classification team</a>.
 
 supplementary.previousDocuments = Previous documents
 supplementary.previousDocuments.title = Add any documents or MUCRs and DUCRs to this declaration

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -623,12 +623,14 @@ declaration.commodityDetails.description.header.hint = Try to be as specific as 
 declaration.commodityDetails.description.error.empty = Description cannot be empty
 declaration.commodityDetails.description.error.length = Description cannot be longer than 280 characters
 declaration.commodityDetails.how.header = How do I find a commodity code?
-declaration.commodityDetails.how.step1 = Go to the <a href='https://www.gov.uk/trade-tariff' target='_blank'>UK Trade Tariff</a>.
+declaration.commodityDetails.how.step1 = Go to the UK 
+declaration.commodityDetails.how.tradeTariff = Trade Tariff.
 declaration.commodityDetails.how.step2 = Type your goods into the search bar. It will present you with multiple options. Select the one that most closely resembles your goods.
 declaration.commodityDetails.how.step3 = This will take you to a table with more options. Select 'open all headings' (top left of the table) and browse through the list to find the description that most closely resembles your goods.
 declaration.commodityDetails.how.step4 = Keep selecting options until you have a full ten-digit number in the right-hand column. (Note, at this point it will tell you if the goods require a supplementary unit in the column next to it).
 declaration.commodityDetails.how.step5 = This number is your commodity code. Click on it and click on the exports tab halfway down the page. This will give you specific information such as licences, quota tariff, and CUS codes.
-declaration.commodityDetails.how.summary = It is important to get it right. If you need help confirming your commodity code, you can contact the <a href='https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods' target='_blank'>classification team</a>.
+declaration.commodityDetails.how.summary = It is important to get it right. If you need help confirming your commodity code, you can contact the
+declaration.commodityDetails.how.classificationTeam = classification team.
 
 supplementary.previousDocuments = Previous documents
 supplementary.previousDocuments.title = Add any documents or MUCRs and DUCRs to this declaration

--- a/docs/Customs Declare Exports AutoComplete.js
+++ b/docs/Customs Declare Exports AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Customs Declare Exports AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      0.9
+// @version      0.10
 // @description  try to take over the world!
 // @author       You
 // @match        http*://*/customs-declare-exports*
@@ -188,9 +188,7 @@ function completePage() {
         document.getElementsByClassName('button')[0].click()
     }
     if (currentPageIs('/customs-declare-exports/declaration/items/.*/item-type')) {
-        document.getElementById('combinedNomenclatureCode').value ='46021910';
         document.getElementById('statisticalValue').value ='1000';
-        document.getElementById('descriptionOfGoods').value ='Straw for bottles';
         document.getElementsByClassName('button')[0].click()
     }
     if (currentPageIs('/customs-declare-exports/declaration/items/.*/package-information')) {

--- a/test/forms/declaration/CommodityDetailsSpec.scala
+++ b/test/forms/declaration/CommodityDetailsSpec.scala
@@ -1,0 +1,111 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.declaration
+
+import forms.declaration.CommodityDetails._
+import models.DeclarationType
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.data.FormError
+import play.api.libs.json.{JsObject, JsString}
+
+class CommodityDetailsSpec extends WordSpec with MustMatchers {
+  import CommodityDetailsSpec._
+
+  "CommodityDetails mapping used for standard declaration" should {
+
+    "return form with errors" when {
+      "provided with invalid commodity code" in {
+        val form = CommodityDetails.form(DeclarationType.STANDARD).bind(formData("A1234", "description"))
+
+        form.errors mustBe Seq(
+          FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.specialCharacters")
+        )
+      }
+
+      "provided with commodity code too long" in {
+        val form = CommodityDetails.form(DeclarationType.STANDARD).bind(formData("1234567890", "description"))
+
+        form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
+      }
+
+      "provided with missing commodity code" in {
+        val form = CommodityDetails.form(DeclarationType.STANDARD).bind(formData("", "some text"))
+
+        form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.empty"))
+      }
+
+      "provided with missing description" in {
+        val form = CommodityDetails.form(DeclarationType.STANDARD).bind(formData("12345678", ""))
+
+        form.errors mustBe Seq(FormError(descriptionOfGoodsKey, "declaration.commodityDetails.description.error.empty"))
+      }
+    }
+
+    "return form without errors" when {
+      "provided with valid input" in {
+        val form = CommodityDetails.form(DeclarationType.STANDARD).bind(formData("12345678", "description"))
+
+        form.hasErrors must be(false)
+      }
+
+    }
+  }
+
+  "CommodityDetails mapping used for simplified declaration" should {
+
+    "return form with errors" when {
+      "provided with invalid commodity code" in {
+        val form = CommodityDetails.form(DeclarationType.SIMPLIFIED).bind(formData("#1234", "description"))
+
+        form.errors mustBe Seq(
+          FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.specialCharacters")
+        )
+      }
+
+      "provided with commodity code too long" in {
+        val form = CommodityDetails.form(DeclarationType.SIMPLIFIED).bind(formData("1234567890", "description"))
+
+        form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
+      }
+
+      "provided with missing description" in {
+        val form = CommodityDetails.form(DeclarationType.SIMPLIFIED).bind(formData("12345678", ""))
+
+        form.errors mustBe Seq(FormError(descriptionOfGoodsKey, "declaration.commodityDetails.description.error.empty"))
+      }
+    }
+
+    "return form without errors" when {
+      "provided with valid input" in {
+        val form = CommodityDetails.form(DeclarationType.SIMPLIFIED).bind(formData("12345678", "description"))
+
+        form.hasErrors must be(false)
+      }
+
+      "provided with missing commodity code" in {
+        val form = CommodityDetails.form(DeclarationType.SIMPLIFIED).bind(formData("", "description"))
+
+        form.hasErrors must be(false)
+      }
+    }
+  }
+}
+
+object CommodityDetailsSpec {
+  def formData(code: String, description: String) =
+    JsObject(Map(combinedNomenclatureCodeKey -> JsString(code), descriptionOfGoodsKey -> JsString(description)))
+}

--- a/test/forms/declaration/ItemTypeFormSpec.scala
+++ b/test/forms/declaration/ItemTypeFormSpec.scala
@@ -18,7 +18,6 @@ package forms.declaration
 
 import forms.declaration.ItemTypeForm._
 import forms.declaration.ItemTypeFormSpec.correctItemTypeMap
-import models.DeclarationType
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.data.FormError
 
@@ -36,12 +35,6 @@ class ItemTypeFormSpec extends WordSpec with MustMatchers {
 
     "return form with errors" when {
 
-      "descriptionOfGoods is missing" in {
-        val form = ItemTypeForm.form().bind(correctItemTypeMap - "descriptionOfGoods")
-
-        form.errors mustBe Seq(FormError("descriptionOfGoods", "error.required"))
-      }
-
       "statisticalValue is missing" in {
         val form = ItemTypeForm.form().bind(correctItemTypeMap - "statisticalValue")
 
@@ -53,20 +46,16 @@ class ItemTypeFormSpec extends WordSpec with MustMatchers {
 }
 
 object ItemTypeFormSpec {
-  private val combinedNomenclatureCode = "ABCD1234"
   private val taricAdditionalCode = "AB12"
   private val nationalAdditionalCode = "VATE"
-  private val descriptionOfGoods = "Description of goods."
   private val cusCode = "QWER0987"
   private val unDangerousGoodsCode = "12CD"
   private val statisticalValue = "1234567890123.45"
 
   val correctItemTypeMap: Map[String, String] =
     Map(
-      combinedNomenclatureCodeKey -> combinedNomenclatureCode,
       taricAdditionalCodeKey -> taricAdditionalCode,
       nationalAdditionalCodeKey -> nationalAdditionalCode,
-      descriptionOfGoodsKey -> descriptionOfGoods,
       cusCodeKey -> cusCode,
       statisticalValueKey -> statisticalValue,
       unDangerousGoodsCodeKey -> unDangerousGoodsCode

--- a/test/forms/declaration/validators/ItemTypeValidatorSpec.scala
+++ b/test/forms/declaration/validators/ItemTypeValidatorSpec.scala
@@ -18,10 +18,10 @@ package forms.declaration.validators
 
 import base.TestHelper
 import forms.declaration.ItemTypeForm._
-import models.{DeclarationType, IdentityData, SignedInUser}
 import models.DeclarationType.DeclarationType
 import models.declaration.ItemType
 import models.requests.{AuthenticatedRequest, JourneyRequest}
+import models.{DeclarationType, IdentityData, SignedInUser}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.data.FormError
 import play.api.mvc.AnyContent
@@ -147,30 +147,6 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
 
     "return Failure result with errors" when {
 
-      "Combined Nomenclature Code is empty" in {
-        val itemType = buildItemType(combinedNomenclatureCode = None)
-        val expectedValidationResult =
-          Invalid(errors = Seq(FormError(combinedNomenclatureCodeKey, "declaration.itemType.combinedNomenclatureCode.error.empty")))
-
-        testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
-      }
-
-      "Combined Nomenclature Code is longer than 8 characters" in {
-        val itemType = buildItemType(combinedNomenclatureCode = Some("ABCD12345"))
-        val expectedValidationResult =
-          Invalid(errors = Seq(FormError(combinedNomenclatureCodeKey, "declaration.itemType.combinedNomenclatureCode.error.length")))
-
-        testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
-      }
-
-      "Combined Nomenclature Code contains special characters" in {
-        val itemType = buildItemType(combinedNomenclatureCode = Some("1234!@#$"))
-        val expectedValidationResult =
-          Invalid(errors = Seq(FormError(combinedNomenclatureCodeKey, "declaration.itemType.combinedNomenclatureCode.error.specialCharacters")))
-
-        testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
-      }
-
       "any TARIC additional code is not 4 characters long" in {
         val itemType = buildItemType(taricAdditionalCode = Seq("1111", "2222", "333", "4444"))
         val expectedValidationResult =
@@ -225,22 +201,6 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
         val itemType = buildItemType(nationalAdditionalCode = Seq("1111", "1111"))
         val expectedValidationResult =
           Invalid(errors = Seq(FormError(nationalAdditionalCodeKey, "declaration.itemType.nationalAdditionalCode.error.duplicate")))
-
-        testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
-      }
-
-      "Description of goods is empty" in {
-        val itemType = buildItemType()
-        val expectedValidationResult =
-          Invalid(errors = Seq(FormError(descriptionOfGoodsKey, "declaration.itemType.description.error.empty")))
-
-        testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
-      }
-
-      "Description of goods is longer than 280 characters" in {
-        val itemType = buildItemType(descriptionOfGoods = TestHelper.createRandomAlphanumericString(281))
-        val expectedValidationResult =
-          Invalid(errors = Seq(FormError(descriptionOfGoodsKey, "declaration.itemType.description.error.length")))
 
         testFailedValidationOnSaveAndContinue(itemType, expectedValidationResult)
       }
@@ -316,10 +276,8 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
 
       "Combined Nomenclature Code is empty for Simplified Dec" in {
         val itemType = ItemType(
-          combinedNomenclatureCode = Some(""),
           taricAdditionalCodes = Seq("11AA"),
           nationalAdditionalCodes = Seq("VATE"),
-          descriptionOfGoods = "Test description",
           cusCode = Some("12345678"),
           unDangerousGoodsCode = Some("1234"),
           statisticalValue = "1234567890.12"
@@ -330,10 +288,8 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
 
       "provided with correct data with single value for every field" in {
         val itemType = ItemType(
-          combinedNomenclatureCode = Some("12345678"),
           taricAdditionalCodes = Seq("11AA"),
           nationalAdditionalCodes = Seq("VATE"),
-          descriptionOfGoods = "Test description",
           cusCode = Some("12345678"),
           unDangerousGoodsCode = Some("1234"),
           statisticalValue = "1234567890.12"
@@ -344,10 +300,8 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
 
       "provided with correct data with multiple values where possible" in {
         val itemType = ItemType(
-          combinedNomenclatureCode = Some("12345678"),
           taricAdditionalCodes = Seq("11AA", "22BB", "33CC"),
           nationalAdditionalCodes = Seq("VATE", "VATR"),
-          descriptionOfGoods = "Test description",
           cusCode = Some("12345678"),
           unDangerousGoodsCode = Some("1234"),
           statisticalValue = "1234567890.12"
@@ -358,10 +312,8 @@ class ItemTypeValidatorSpec extends WordSpec with MustMatchers with ExportsDecla
 
       "provided with correct data for mandatory fields only" in {
         val itemType = ItemType(
-          combinedNomenclatureCode = Some("12345678"),
           taricAdditionalCodes = Seq.empty,
           nationalAdditionalCodes = Seq.empty,
-          descriptionOfGoods = "Test description",
           cusCode = None,
           unDangerousGoodsCode = None,
           statisticalValue = "1234567890.12"
@@ -395,10 +347,8 @@ object ItemTypeValidatorSpec {
     unDangerousGoodsCode: Option[String] = None,
     statisticalValue: String = ""
   ): ItemType = ItemType(
-    combinedNomenclatureCode = combinedNomenclatureCode,
     taricAdditionalCodes = taricAdditionalCode,
     nationalAdditionalCodes = nationalAdditionalCode,
-    descriptionOfGoods = descriptionOfGoods,
     cusCode = cusCode,
     unDangerousGoodsCode = unDangerousGoodsCode,
     statisticalValue = statisticalValue

--- a/test/models/declaration/SupplementaryDeclarationTestData.scala
+++ b/test/models/declaration/SupplementaryDeclarationTestData.scala
@@ -212,10 +212,8 @@ object SupplementaryDeclarationTestData {
         sequenceId = 1,
         itemType = Some(
           ItemType(
-            combinedNomenclatureCode = Some("classificationsId"),
             taricAdditionalCodes = Seq("taricAdditionalCodes"),
             nationalAdditionalCodes = Seq("nationalAdditionalCodes"),
-            descriptionOfGoods = "commodityDescription",
             cusCode = Some("cusCode"),
             unDangerousGoodsCode = Some("999"),
             statisticalValue = "100"

--- a/test/services/GoodsItemCachingData.scala
+++ b/test/services/GoodsItemCachingData.scala
@@ -57,10 +57,8 @@ trait GoodsItemCachingData {
     DocumentWriteOff(measurementUnit = Some(createRandomAlphanumericString(4)), documentQuantity = Some(BigDecimal(123)))
 
   def createItemType(): ItemType = ItemType(
-    Some(createRandomAlphanumericString(8)),
     getDataSeq(Random.nextInt(10), createRandomAlphanumericString, 4),
     getDataSeq(Random.nextInt(10), createRandomAlphanumericString, 4),
-    createRandomString(70),
     Some(createRandomAlphanumericString(8)),
     Some(createRandomAlphanumericString(4)),
     decimalString()

--- a/test/services/cache/ExportsItemBuilder.scala
+++ b/test/services/cache/ExportsItemBuilder.scala
@@ -66,6 +66,9 @@ trait ExportsItemBuilder {
 
   def withoutItemType(): ItemModifier = _.copy(itemType = None)
 
+  def withCommodityDetails(data: CommodityDetails): ItemModifier =
+    _.copy(commodityDetails = Some(data))
+
   def withItemType(
     combinedNomenclatureCode: Option[String] = None,
     taricAdditionalCodes: Seq[String] = Seq.empty,
@@ -75,17 +78,7 @@ trait ExportsItemBuilder {
     unDangerousGoodsCode: Option[String] = None,
     statisticalValue: String = ""
   ): ItemModifier =
-    withItemType(
-      ItemType(
-        combinedNomenclatureCode,
-        taricAdditionalCodes,
-        nationalAdditionalCodes,
-        descriptionOfGoods,
-        cusCode,
-        unDangerousGoodsCode,
-        statisticalValue
-      )
-    )
+    withItemType(ItemType(taricAdditionalCodes, nationalAdditionalCodes, cusCode, unDangerousGoodsCode, statisticalValue))
 
   def withItemType(data: ItemType): ItemModifier = _.copy(itemType = Some(data))
 

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesControllerSpec.scala
@@ -228,7 +228,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
           controller.saveReferences(Mode.Normal, item.id)(postRequestAsFormUrlEncoded(correctForm: _*))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe routes.ItemTypeController.displayPage(Mode.Normal, item.id)
+        thePageNavigatedTo mustBe routes.CommodityDetailsController.displayPage(Mode.Normal, item.id)
       }
 
       "user save correct data without new item" in new SetUp {
@@ -246,7 +246,7 @@ class AdditionalFiscalReferencesControllerSpec extends ControllerSpec with ItemA
           controller.saveReferences(Mode.Normal, itemCacheData.id)(postRequestAsFormUrlEncoded(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe routes.ItemTypeController.displayPage(Mode.Normal, "itemId")
+        thePageNavigatedTo mustBe routes.CommodityDetailsController.displayPage(Mode.Normal, "itemId")
       }
 
       "user remove existing item" in new SetUp {

--- a/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers.declaration
+
+import controllers.declaration.CommodityDetailsController
+import forms.declaration.CommodityDetails
+import models.{DeclarationType, Mode}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, times, verify, when}
+import org.scalatest.OptionValues
+import play.api.data.Form
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import unit.base.ControllerSpec
+import views.html.declaration.commodity_details
+
+class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
+
+  val mockCommodityDetailsPage = mock[commodity_details]
+
+  val controller = new CommodityDetailsController(
+    mockAuthAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    mockCommodityDetailsPage
+  )(ec)
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    authorizedUser()
+    withNewCaching(aDeclaration(withType(DeclarationType.STANDARD)))
+    when(mockCommodityDetailsPage.apply(any(), any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    super.afterEach()
+    reset(mockCommodityDetailsPage)
+  }
+
+  val itemId = "itemId"
+
+  def theResponseForm: Form[CommodityDetails] = {
+    val captor = ArgumentCaptor.forClass(classOf[Form[CommodityDetails]])
+    verify(mockCommodityDetailsPage).apply(any(), any(), captor.capture())(any(), any())
+    captor.getValue
+  }
+
+  "Commodity Details controller" should {
+
+    "return 200 (OK)" when {
+
+      "display page method is invoked and cache is empty" in {
+
+        val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+
+        status(result) mustBe OK
+        verify(mockCommodityDetailsPage, times(1)).apply(any(), any(), any())(any(), any())
+
+        theResponseForm.value mustBe empty
+      }
+
+      "display page method is invoked and cache contains data" in {
+        val details = CommodityDetails(Some("12345678"), "Description")
+        val item = anItem(withCommodityDetails(details))
+        withNewCaching(aDeclaration(withItems(item)))
+
+        val result = controller.displayPage(Mode.Normal, item.id)(getRequest())
+
+        status(result) mustBe OK
+        verify(mockCommodityDetailsPage, times(1)).apply(any(), any(), any())(any(), any())
+
+        theResponseForm.value mustBe Some(details)
+      }
+    }
+
+    "return 400 (BAD_REQUEST)" when {
+
+      "form is incorrect" in {
+
+        val incorrectForm = Json.toJson(CommodityDetails(None, "Description"))
+
+        val result = controller.submitForm(Mode.Normal, itemId)(postRequest(incorrectForm))
+
+        status(result) mustBe BAD_REQUEST
+        verify(mockCommodityDetailsPage, times(1)).apply(any(), any(), any())(any(), any())
+      }
+    }
+
+    "return 303 (SEE_OTHER)" when {
+
+      "valid data provided" in {
+
+        val correctForm = Json.toJson(CommodityDetails(Some("12345678"), "Description"))
+
+        val result = controller.submitForm(Mode.Normal, itemId)(postRequest(correctForm))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.ItemTypeController.displayPage(Mode.Normal, itemId)
+        verify(mockCommodityDetailsPage, times(0)).apply(any(), any(), any())(any(), any())
+      }
+
+      "valid data provided for simple declaration" in {
+        withNewCaching(aDeclaration(withType(DeclarationType.SIMPLIFIED)))
+        val correctForm = Json.toJson(CommodityDetails(None, "Description"))
+
+        val result = controller.submitForm(Mode.Normal, itemId)(postRequest(correctForm))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.ItemTypeController.displayPage(Mode.Normal, itemId)
+        verify(mockCommodityDetailsPage, times(0)).apply(any(), any(), any())(any(), any())
+      }
+    }
+  }
+}

--- a/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
@@ -70,7 +70,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
 
       "display page method is invoked and cache is empty" in {
 
-        val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+        val result = controller.displayPage(Mode.Normal, itemId, fastForward = true)(getRequest())
 
         status(result) mustBe OK
         verify(mockFiscalInformationPage, times(1)).apply(any(), any(), any())(any(), any())
@@ -82,7 +82,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
         val item = anItem(withFiscalInformation(FiscalInformation(yes)))
         withNewCaching(aDeclaration(withItems(item)))
 
-        val result = controller.displayPage(Mode.Normal, item.id)(getRequest())
+        val result = controller.displayPage(Mode.Normal, item.id, fastForward = true)(getRequest())
 
         status(result) mustBe OK
         verify(mockFiscalInformationPage, times(1)).apply(any(), any(), any())(any(), any())
@@ -125,7 +125,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
         val result = controller.saveFiscalInformation(Mode.Normal, itemId)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.ItemTypeController.displayPage(Mode.Normal, itemId)
+        thePageNavigatedTo mustBe controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId)
         verify(mockFiscalInformationPage, times(0)).apply(any(), any(), any())(any(), any())
       }
     }

--- a/test/unit/controllers/declaration/ItemTypeControllerSpec.scala
+++ b/test/unit/controllers/declaration/ItemTypeControllerSpec.scala
@@ -119,10 +119,8 @@ class ItemTypeControllerSpec extends ControllerSpec with ErrorHandlerMocks with 
 
         validateCache(
           ItemType(
-            combinedNomenclatureCode = Some("nomCode"),
             taricAdditionalCodes = Seq("1234"),
             nationalAdditionalCodes = Seq.empty, // NOT added to the cache model after an Add for TARIC codes - see bug CEDS-1094
-            descriptionOfGoods = "description",
             cusCode = Some("12345678"),
             unDangerousGoodsCode = Some("4321"),
             statisticalValue = "999"
@@ -135,10 +133,8 @@ class ItemTypeControllerSpec extends ControllerSpec with ErrorHandlerMocks with 
         withNewCaching(aDeclaration(withItem(anItem(withItemId(itemId)))))
 
         val correctForm = Seq(
-          ("combinedNomenclatureCode", "nomCode2"),
           ("taricAdditionalCode", "5356"),
           ("nationalAdditionalCode", "X611"),
-          ("descriptionOfGoods", "description2"),
           ("cusCode", "56353789"),
           ("unDangerousGoodsCode", "6468"),
           ("statisticalValue", "435"),
@@ -152,10 +148,8 @@ class ItemTypeControllerSpec extends ControllerSpec with ErrorHandlerMocks with 
 
         validateCache(
           ItemType(
-            combinedNomenclatureCode = Some("nomCode2"),
             taricAdditionalCodes = Seq.empty, // NOT added to the cache model after an Add for TARIC codes - see bug CEDS-1094
             nationalAdditionalCodes = Seq("X611"),
-            descriptionOfGoods = "description2",
             cusCode = Some("56353789"),
             unDangerousGoodsCode = Some("6468"),
             statisticalValue = "435"
@@ -171,7 +165,7 @@ class ItemTypeControllerSpec extends ControllerSpec with ErrorHandlerMocks with 
         withNewCaching(aDeclaration())
 
         val correctForm =
-          Json.toJson(ItemType(Some("code"), Seq("code"), Seq("code"), "description", Some("code"), Some("code"), "1234"))
+          Json.toJson(ItemType(Seq("code"), Seq("code"), Some("code"), Some("code"), "1234"))
 
         val result = controller.submitItemType(Mode.Normal, itemId)(postRequest(correctForm))
 
@@ -184,10 +178,8 @@ class ItemTypeControllerSpec extends ControllerSpec with ErrorHandlerMocks with 
         withNewCaching(aDeclaration(withItem(anItem(withItemId(itemId)))))
 
         val wrongAction = Seq(
-          ("combinedNomenclatureCode", "code"),
           ("taricAdditionalCode", ""),
           ("nationalAdditionalCode", ""),
-          ("descriptionOfGoods", "description"),
           ("cusCode", ""),
           ("unDangerousGoodsCode", ""),
           ("statisticalValue", "value"),

--- a/test/unit/tools/Stubs.scala
+++ b/test/unit/tools/Stubs.scala
@@ -67,6 +67,8 @@ trait Stubs {
       |draft.timeToLive=1d
       |list-of-available-journeys = "SMP,STD,CAN,SUB,CON"
       |microservice.services.features.use-improved-error-messages=true
+      |urls.tradeTariff=tradeTariff
+      |urls.classificationHelp=classificationHelp
     """.stripMargin)
 
   val minimalConfiguration = Configuration(minimalConfig)

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -67,7 +67,7 @@ class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with Ad
       val backButton = view.getElementById("link-back")
 
       backButton.text() mustBe backCaption
-      backButton must haveHref(controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId))
+      backButton must haveHref(controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId, fastForward = false))
     }
 
     "display 'Save and continue' button" in {

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -33,8 +33,8 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
   private val page = new commodity_details(mainTemplate, minimalAppConfig)
   private val itemId = "item1"
   private val realMessages = validatedMessages
-  private def createView(mode: Mode = Mode.Normal, itemId: String = itemId, declarationType: DeclarationType = DeclarationType.STANDARD): Document =
-    page(mode, itemId, CommodityDetails.form(declarationType))(journeyRequest(), realMessages)
+  private def createView(declarationType: DeclarationType = DeclarationType.STANDARD): Document =
+    page(Mode.Normal, itemId, CommodityDetails.form(declarationType))(journeyRequest(), realMessages)
 
   def commodityDetailsView(declarationType: DeclarationType): Unit = {
     val view = createView(declarationType = declarationType)

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration
+
+import forms.declaration.CommodityDetails
+import helpers.views.declaration.CommonMessages
+import models.{DeclarationType, Mode}
+import org.jsoup.nodes.Document
+import play.api.data.Form
+import services.cache.ExportsTestData
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.commodity_details
+import views.tags.ViewTest
+
+@ViewTest
+class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with Stubs with CommonMessages {
+
+  private val page = new commodity_details(mainTemplate)
+  private val form: Form[CommodityDetails] = CommodityDetails.form(DeclarationType.STANDARD)
+  private val itemId = "item1"
+  private val realMessages = validatedMessages
+  private def createView(mode: Mode = Mode.Normal, itemId: String = itemId, form: Form[CommodityDetails] = form): Document =
+    page(mode, itemId, form)(journeyRequest(), realMessages)
+
+  "Commodity Details View on empty page" should {
+
+    "display page title" in {
+
+      createView().getElementById("title").text() mustBe realMessages("declaration.commodityDetails.title")
+    }
+
+    "display 'Back' button that links to 'Package Information' page" in {
+      val backButton = createView().getElementById("link-back")
+
+      backButton.getElementById("link-back") must haveHref(
+        controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId)
+      )
+    }
+
+    "display 'Save and continue' button on page" in {
+
+      val view = createView()
+
+      val saveButton = view.select("#submit")
+      saveButton.text() mustBe realMessages(saveAndContinueCaption)
+    }
+  }
+}

--- a/test/views/declaration/ItemSummaryViewSpec.scala
+++ b/test/views/declaration/ItemSummaryViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import forms.declaration.PackageInformation
+import forms.declaration.{CommodityDetails, PackageInformation}
 import models.Mode
 import models.declaration.{ExportItem, ItemType, ProcedureCodesData}
 import org.jsoup.nodes.Document
@@ -85,14 +85,16 @@ class ItemSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
               "id2",
               sequenceId = 2,
               procedureCodes = Some(ProcedureCodesData(Some("procedure-code2"), Seq.empty)),
-              itemType = Some(ItemType(Some("item-type2"), Seq.empty, Seq.empty, "", None, None, "")),
+              itemType = Some(ItemType(Seq.empty, Seq.empty, None, None, "")),
+              commodityDetails = Some(CommodityDetails(Some("item-type2"), "")),
               packageInformation = List(PackageInformation("", 2, ""))
             ),
             ExportItem(
               "id1",
               sequenceId = 1,
               procedureCodes = Some(ProcedureCodesData(Some("procedure-code1"), Seq.empty)),
-              itemType = Some(ItemType(Some("item-type1"), Seq.empty, Seq.empty, "", None, None, "")),
+              itemType = Some(ItemType(Seq.empty, Seq.empty, None, None, "")),
+              commodityDetails = Some(CommodityDetails(Some("item-type1"), "")),
               packageInformation = List(PackageInformation("", 1, ""))
             )
           )

--- a/test/views/declaration/ItemTypeViewSpec.scala
+++ b/test/views/declaration/ItemTypeViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import forms.declaration.ItemTypeForm
-import models.{DeclarationType, Mode}
+import models.Mode
 import models.declaration.ExportItem
 import org.jsoup.nodes.Document
 import play.api.data.Form
@@ -52,16 +52,12 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
       messages must haveTranslationFor("declaration.itemType.title")
       messages must haveTranslationFor("supplementary.items")
       messages must haveTranslationFor("declaration.itemType.title")
-      messages must haveTranslationFor("declaration.itemType.combinedNomenclatureCode.header")
-      messages must haveTranslationFor("declaration.itemType.combinedNomenclatureCode.header.hint")
       messages must haveTranslationFor("declaration.itemType.taricAdditionalCodes.header")
       messages must haveTranslationFor("declaration.itemType.taricAdditionalCodes.header.hint")
       messages must haveTranslationFor("declaration.itemType.nationalAdditionalCode.header")
       messages must haveTranslationFor("declaration.itemType.nationalAdditionalCode.header.hint")
       messages must haveTranslationFor("declaration.itemType.statisticalValue.header")
       messages must haveTranslationFor("declaration.itemType.statisticalValue.header.hint")
-      messages must haveTranslationFor("declaration.itemType.description.header")
-      messages must haveTranslationFor("declaration.itemType.description.header.hint")
       messages must haveTranslationFor("declaration.itemType.cusCode.header")
       messages must haveTranslationFor("declaration.itemType.unDangerousGoodsCode.header")
       messages must haveTranslationFor("declaration.itemType.unDangerousGoodsCode.header.hint")
@@ -78,16 +74,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display section header" in {
         view.getElementById("section-header").text() must include("supplementary.items")
-      }
-
-      "display empty input with label for CNC" in {
-        view
-          .getElementById("combinedNomenclatureCode-label")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header"
-        view
-          .getElementById("combinedNomenclatureCode-hint")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header.hint"
-        view.getElementById("combinedNomenclatureCode").attr("value") mustBe empty
       }
 
       "display empty input with label for TARIC" in {
@@ -114,12 +100,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         view.getElementById("statisticalValue-label").text() mustBe "declaration.itemType.statisticalValue.header"
         view.getElementById("statisticalValue-hint").text() mustBe "declaration.itemType.statisticalValue.header.hint"
         view.getElementById("statisticalValue").attr("value") mustBe empty
-      }
-
-      "display empty input with label for Description" in {
-        view.getElementById("descriptionOfGoods-label").ownText() mustBe "declaration.itemType.description.header"
-        view.getElementById("descriptionOfGoods-hint").text() mustBe "declaration.itemType.description.header.hint"
-        view.getElementById("descriptionOfGoods").text() mustBe empty
       }
 
       "display empty input with label for CUS" in {
@@ -149,7 +129,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
         backButton.text() mustBe "site.back"
         backButton.getElementById("link-back") must haveHref(
-          controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId = "itemId")
+          controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }
 
@@ -179,16 +159,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         view.getElementById("section-header").text() must include("supplementary.items")
       }
 
-      "display empty input with label for CNC" in {
-        view
-          .getElementById("combinedNomenclatureCode-label")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header"
-        view
-          .getElementById("combinedNomenclatureCode-hint")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header.hint"
-        view.getElementById("combinedNomenclatureCode").attr("value") mustBe empty
-      }
-
       "display empty input with label for TARIC" in {
         view
           .getElementById("taricAdditionalCode-label")
@@ -215,12 +185,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         view.getElementById("statisticalValue").attr("value") mustBe empty
       }
 
-      "display empty input with label for Description" in {
-        view.getElementById("descriptionOfGoods-label").ownText() mustBe "declaration.itemType.description.header"
-        view.getElementById("descriptionOfGoods-hint").text() mustBe "declaration.itemType.description.header.hint"
-        view.getElementById("descriptionOfGoods").text() mustBe empty
-      }
-
       "display empty input with label for CUS" in {
         view.getElementById("cusCode-label").text() mustBe "declaration.itemType.cusCode.header"
         view.getElementById("cusCode-hint").text() mustBe "declaration.itemType.cusCode.header.hint"
@@ -242,13 +206,13 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         view.getElementsByAttributeValue("name", "AddField").size() must be(2)
       }
 
-      "display 'Back' button that links to 'fiscal-information' page" in {
+      "display 'Back' button that links to 'commodity-details' page" in {
 
         val backButton = createView().getElementById("link-back")
 
         backButton.text() mustBe "site.back"
         backButton.getElementById("link-back") must haveHref(
-          controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId = "itemId")
+          controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }
 
@@ -274,19 +238,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
           .text() mustBe "declaration.itemType.title"
       }
 
-      "display empty input with label for CNC" in {
-
-        val view = createView()
-
-        view
-          .getElementById("combinedNomenclatureCode-label")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header"
-        view
-          .getElementById("combinedNomenclatureCode-hint")
-          .text() mustBe "declaration.itemType.combinedNomenclatureCode.header.hint"
-        view.getElementById("combinedNomenclatureCode").attr("value") mustBe empty
-      }
-
       "display empty input with label for TARIC" in {
 
         val view = createView()
@@ -313,15 +264,6 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         view.getElementById("nationalAdditionalCode").attr("value") mustBe empty
       }
 
-      "display empty input with label for Description" in {
-
-        val view = createView()
-
-        view.getElementById("descriptionOfGoods-label").text() mustBe "declaration.itemType.description.header"
-        view.getElementById("descriptionOfGoods-hint").text() mustBe "declaration.itemType.description.header.hint"
-        view.getElementById("descriptionOfGoods").text() mustBe empty
-      }
-
       "display empty input with label for CUS" in {
 
         val view = createView()
@@ -345,14 +287,14 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
         createView().getElementsByAttributeValue("name", "AddField").size() must be(2)
       }
 
-      "display 'Back' button that links to 'fiscal-information' page" in {
+      "display 'Back' button that links to 'commodity-details' page" in {
 
         val backButton =
           createView().getElementById("link-back")
 
         backButton.text() mustBe "site.back"
         backButton.getElementById("link-back") must haveHref(
-          controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId = "itemId")
+          controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }
 
@@ -376,7 +318,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CNC input" in {
 
-        val itemType = ItemTypeForm(Some("12345"), None, None, "", None, None, "")
+        val itemType = ItemTypeForm(None, None, None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -384,7 +326,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Description input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "Description", None, None, "")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -392,7 +334,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CUS input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", Some("1234"), None, "")
+        val itemType = ItemTypeForm(None, Some(""), Some("1234"), None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -400,7 +342,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in UN Dangerous Goods Code input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", None, Some("1234"), "12345")
+        val itemType = ItemTypeForm(None, Some(""), None, Some("1234"), "12345")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -408,15 +350,13 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Statistical Value input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", None, None, "12345")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "12345")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
       }
 
       def assertViewDataEntered(view: Document, itemType: ItemTypeForm): Unit = {
-        view.getElementById("combinedNomenclatureCode").attr("value") must equal(itemType.combinedNomenclatureCode.getOrElse(""))
-        view.getElementById("descriptionOfGoods").text() must equal(itemType.descriptionOfGoods)
         view.getElementById("cusCode").attr("value") must equal(itemType.cusCode.getOrElse(""))
         view.getElementById("unDangerousGoodsCode").attr("value") must equal(itemType.unDangerousGoodsCode.getOrElse(""))
         view.getElementById("statisticalValue").attr("value") must equal(itemType.statisticalValue)
@@ -427,7 +367,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CNC input" in {
 
-        val itemType = ItemTypeForm(Some("12345"), None, None, "", None, None, "")
+        val itemType = ItemTypeForm(None, None, None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -435,7 +375,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Description input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "Description", None, None, "")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -443,7 +383,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CUS input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", Some("1234"), None, "")
+        val itemType = ItemTypeForm(None, Some(""), Some("1234"), None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -451,7 +391,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in UN Dangerous Goods Code input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", None, Some("1234"), "12345")
+        val itemType = ItemTypeForm(None, Some(""), None, Some("1234"), "12345")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -459,15 +399,13 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Statistical Value input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", None, None, "12345")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "12345")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
       }
 
       def assertViewDataEntered(view: Document, itemType: ItemTypeForm): Unit = {
-        view.getElementById("combinedNomenclatureCode").attr("value") must equal(itemType.combinedNomenclatureCode.getOrElse(""))
-        view.getElementById("descriptionOfGoods").text() must equal(itemType.descriptionOfGoods)
         view.getElementById("cusCode").attr("value") must equal(itemType.cusCode.getOrElse(""))
         view.getElementById("unDangerousGoodsCode").attr("value") must equal(itemType.unDangerousGoodsCode.getOrElse(""))
         view.getElementById("statisticalValue").attr("value") must equal(itemType.statisticalValue)
@@ -478,7 +416,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CNC input" in {
 
-        val itemType = ItemTypeForm(Some("12345"), None, None, "", None, None, "")
+        val itemType = ItemTypeForm(None, None, None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -486,7 +424,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Description input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "Description", None, None, "")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -494,7 +432,7 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in CUS input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", Some("1234"), None, "")
+        val itemType = ItemTypeForm(None, Some(""), Some("1234"), None, "")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
@@ -502,15 +440,13 @@ class ItemTypeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
 
       "display data in Statistical Value input" in {
 
-        val itemType = ItemTypeForm(None, None, Some(""), "", None, None, "12345")
+        val itemType = ItemTypeForm(None, Some(""), None, None, "12345")
         val view = createView(form = ItemTypeForm.form().fill(itemType))
 
         assertViewDataEntered(view, itemType)
       }
 
       def assertViewDataEntered(view: Document, itemType: ItemTypeForm): Unit = {
-        view.getElementById("combinedNomenclatureCode").attr("value") must equal(itemType.combinedNomenclatureCode.getOrElse(""))
-        view.getElementById("descriptionOfGoods").text() must equal(itemType.descriptionOfGoods)
         view.getElementById("cusCode").attr("value") must equal(itemType.cusCode.getOrElse(""))
         view.getElementById("statisticalValue").attr("value") must equal(itemType.statisticalValue)
       }

--- a/test/views/declaration/spec/UnitViewSpec.scala
+++ b/test/views/declaration/spec/UnitViewSpec.scala
@@ -68,9 +68,6 @@ object UnitViewSpec extends Injector {
   val realMessagesApi: MessagesApi = instanceOf[MessagesApi]
 }
 
-/*
-    Fails the test if a view is configured with a message key that doesnt exist in the messages file
- */
 private class AllMessageKeysAreMandatoryMessages(msg: Messages) extends Messages {
   override def messages: Messages = msg.messages
 


### PR DESCRIPTION
Removes the commodity code and description fields from the 'Item Type' screen.
Also includes small refactoring of FiscalReference controller to make "back" navigation easier - caller does not need to know logic about fiscal references 