### PR TITLE
CEDS-1953 New 'Where is the supervising customs office?' page

### DIFF
--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -19,26 +19,25 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.WarehouseDetails
-import forms.declaration.WarehouseDetails.form
 import javax.inject.Inject
 import models.requests.JourneyRequest
-import models.{DeclarationType, ExportsDeclaration, Mode}
+import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.declaration.{supervising_customs_office, warehouse_identification}
+import views.html.declaration.supervising_customs_office
 
 import scala.concurrent.{ExecutionContext, Future}
 
 class SupervisingCustomsOfficeController @Inject()(
-                                                    authenticate: AuthAction,
-                                                    journeyType: JourneyAction,
-                                                    navigator: Navigator,
-                                                    override val exportsCacheService: ExportsCacheService,
-                                                    mcc: MessagesControllerComponents,
-                                                    supervisingCustomsOfficePage: supervising_customs_office
+  authenticate: AuthAction,
+  journeyType: JourneyAction,
+  navigator: Navigator,
+  override val exportsCacheService: ExportsCacheService,
+  mcc: MessagesControllerComponents,
+  supervisingCustomsOfficePage: supervising_customs_office
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
@@ -72,13 +71,9 @@ class SupervisingCustomsOfficeController @Inject()(
               identificationNumber = dbWarehouseDetails.identificationNumber,
               supervisingCustomsOffice = formData.supervisingCustomsOffice,
               inlandModeOfTransportCode = dbWarehouseDetails.inlandModeOfTransportCode
-            )
-        )
-        .getOrElse(
-          WarehouseDetails(
-            supervisingCustomsOffice = formData.supervisingCustomsOffice
           )
         )
+        .getOrElse(WarehouseDetails(supervisingCustomsOffice = formData.supervisingCustomsOffice))
       model.copy(locations = model.locations.copy(warehouseIdentification = Some(warehouseDetails)))
     }
 }

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -57,14 +57,8 @@ class SupervisingCustomsOfficeController @Inject()(
       .fold(
         (formWithErrors: Form[WarehouseDetails]) => Future.successful(BadRequest(supervisingCustomsOfficePage(mode, formWithErrors))),
         form => {
-          val nextStep = request.cacheModel.`type` match {
-            case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
-              controllers.declaration.routes.DepartureTransportController.displayPage(mode)
-            case DeclarationType.SIMPLIFIED =>
-              controllers.declaration.routes.BorderTransportController.displayPage(mode)
-          }
           updateCache(form)
-            .map(_ => navigator.continueTo(nextStep))
+            .map(_ => navigator.continueTo(controllers.declaration.routes.WarehouseDetailsController.displayPage(mode)))
         }
       )
   }

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.declaration
+
+import controllers.actions.{AuthAction, JourneyAction}
+import controllers.navigation.Navigator
+import forms.declaration.WarehouseDetails
+import forms.declaration.WarehouseDetails.form
+import javax.inject.Inject
+import models.requests.JourneyRequest
+import models.{DeclarationType, ExportsDeclaration, Mode}
+import play.api.data.Form
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.cache.ExportsCacheService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.html.declaration.{supervising_customs_office, warehouse_identification}
+
+import scala.concurrent.{ExecutionContext, Future}
+
+class SupervisingCustomsOfficeController @Inject()(
+                                                    authenticate: AuthAction,
+                                                    journeyType: JourneyAction,
+                                                    navigator: Navigator,
+                                                    override val exportsCacheService: ExportsCacheService,
+                                                    mcc: MessagesControllerComponents,
+                                                    supervisingCustomsOfficePage: supervising_customs_office
+)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport with ModelCacheable {
+
+  import forms.declaration.WarehouseDetails._
+
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    request.cacheModel.locations.warehouseIdentification match {
+      case Some(data) => Ok(supervisingCustomsOfficePage(mode, form().fill(data)))
+      case _          => Ok(supervisingCustomsOfficePage(mode, form()))
+    }
+  }
+
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    form()
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[WarehouseDetails]) => Future.successful(BadRequest(supervisingCustomsOfficePage(mode, formWithErrors))),
+        form => {
+          val nextStep = request.cacheModel.`type` match {
+            case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
+              controllers.declaration.routes.DepartureTransportController.displayPage(mode)
+            case DeclarationType.SIMPLIFIED =>
+              controllers.declaration.routes.BorderTransportController.displayPage(mode)
+          }
+          updateCache(form)
+            .map(_ => navigator.continueTo(nextStep))
+        }
+      )
+  }
+
+  private def updateCache(formData: WarehouseDetails)(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
+    updateExportsDeclarationSyncDirect { model =>
+      val warehouseDetails = model.locations.warehouseIdentification
+        .map(
+          dbWarehouseDetails =>
+            WarehouseDetails(
+              identificationNumber = dbWarehouseDetails.identificationNumber,
+              supervisingCustomsOffice = formData.supervisingCustomsOffice,
+              inlandModeOfTransportCode = formData.inlandModeOfTransportCode
+            )
+        )
+        .getOrElse(
+          WarehouseDetails(
+            supervisingCustomsOffice = formData.supervisingCustomsOffice,
+            inlandModeOfTransportCode = formData.inlandModeOfTransportCode
+          )
+        )
+      model.copy(locations = model.locations.copy(warehouseIdentification = Some(warehouseDetails)))
+    }
+}

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -71,13 +71,12 @@ class SupervisingCustomsOfficeController @Inject()(
             WarehouseDetails(
               identificationNumber = dbWarehouseDetails.identificationNumber,
               supervisingCustomsOffice = formData.supervisingCustomsOffice,
-              inlandModeOfTransportCode = formData.inlandModeOfTransportCode
+              inlandModeOfTransportCode = dbWarehouseDetails.inlandModeOfTransportCode
             )
         )
         .getOrElse(
           WarehouseDetails(
-            supervisingCustomsOffice = formData.supervisingCustomsOffice,
-            inlandModeOfTransportCode = formData.inlandModeOfTransportCode
+            supervisingCustomsOffice = formData.supervisingCustomsOffice
           )
         )
       model.copy(locations = model.locations.copy(warehouseIdentification = Some(warehouseDetails)))

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -54,7 +54,7 @@ class SupervisingCustomsOfficeController @Inject()(
     form()
       .bindFromRequest()
       .fold(
-        (formWithErrors: Form[WarehouseDetails]) => Future.successful(BadRequest(supervisingCustomsOfficePage(mode, formWithErrors))),
+        formWithErrors => Future.successful(BadRequest(supervisingCustomsOfficePage(mode, formWithErrors))),
         form => {
           updateCache(form)
             .map(_ => navigator.continueTo(controllers.declaration.routes.WarehouseDetailsController.displayPage(mode)))

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -57,7 +57,7 @@ class WarehouseIdentificationController @Inject()(
         (formWithErrors: Form[WarehouseDetails]) => Future.successful(BadRequest(warehouseIdentificationPage(mode, formWithErrors))),
         form => {
           updateCache(form)
-            .map(_ => navigator.continueTo(controllers.declaration.routes.WarehouseDetailsController.displayPage(mode)))
+            .map(_ => navigator.continueTo(controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(mode)))
         }
       )
   }

--- a/app/views/declaration/supervising_customs_office.scala.html
+++ b/app/views/declaration/supervising_customs_office.scala.html
@@ -1,0 +1,58 @@
+@*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.declaration.routes
+@import forms.declaration.TransportCodes._
+@import forms.declaration.WarehouseDetails
+@import services.CustomsOffices
+@import services.view.AutoCompleteItem
+@import uk.gov.hmrc.play.views.html._
+@import views.components.inputs.RadioOption
+@import views.Title
+
+@this(main_template: views.html.main_template)
+
+@(mode: Mode, form: Form[WarehouseDetails])(implicit request: Request[_], messages: Messages)
+
+    @main_template(
+        title = Title("declaration.warehouse.supervisingCustomsOffice.title")
+    ) {
+
+        @helper.form(routes.SupervisingCustomsOfficeController.submit(mode), 'autoComplete -> "off") {
+            @helper.CSRF.formField
+
+            @components.back_link(controllers.declaration.routes.WarehouseIdentificationController.displayPage(mode), mode)
+
+            @components.error_summary(form.errors)
+
+            @components.heading(
+                sectionHeader = messages("declaration.warehouse.supervisingCustomsOffice.sectionHeader"),
+                title = messages("declaration.warehouse.supervisingCustomsOffice.title"),
+                hint = messages("declaration.warehouse.supervisingCustomsOffice.hint")
+            )
+
+            @components.fields.field_autocomplete(
+                field = form("supervisingCustomsOffice"),
+                label = messages(""),
+                labelClass = Some("form-label-bold"),
+                hintText = None,
+                emptySelectValue = messages("supplementary.packageInformation.typesOfPackages.empty"),
+                items = AutoCompleteItem.fromSupervisingCustomsOffice(CustomsOffices.all))
+
+            @components.submit_button()
+            @components.buttons.save_and_return_later_button()
+        }
+    }

--- a/app/views/declaration/warehouse_details.scala.html
+++ b/app/views/declaration/warehouse_details.scala.html
@@ -43,13 +43,6 @@
                 title = messages("supplementary.warehouse.title")
             )
 
-            @components.fields.field_autocomplete(
-                field = form("supervisingCustomsOffice"),
-                label = messages("supplementary.warehouse.supervisingCustomsOffice"),
-                labelClass = Some("form-label-bold"),
-                hintText = None,
-                emptySelectValue = messages("supplementary.packageInformation.typesOfPackages.empty"),
-                items = AutoCompleteItem.fromSupervisingCustomsOffice(CustomsOffices.all))
 
             @components.fields.field_radio(
                 field = form("inlandModeOfTransportCode"),

--- a/app/views/declaration/warehouse_details.scala.html
+++ b/app/views/declaration/warehouse_details.scala.html
@@ -34,7 +34,7 @@
         @helper.form(routes.WarehouseDetailsController.saveWarehouse(mode), 'autoComplete -> "off") {
             @helper.CSRF.formField
 
-            @components.back_link(controllers.declaration.routes.WarehouseIdentificationController.displayPage(mode), mode)
+            @components.back_link(controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(mode), mode)
 
             @components.error_summary(form.errors)
 

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -91,6 +91,13 @@ GET         /warehouse-identification            controllers.declaration.Warehou
 
 POST        /warehouse-identification            controllers.declaration.WarehouseIdentificationController.saveIdentificationNumber(mode: models.Mode ?= models.Mode.Normal)
 
+# Supervising Customs Office
+
+GET         /supervising-customs-office          controllers.declaration.SupervisingCustomsOfficeController.displayPage(mode: models.Mode ?= models.Mode.Normal)
+
+POST        /supervising-customs-office          controllers.declaration.SupervisingCustomsOfficeController.submit(mode: models.Mode ?= models.Mode.Normal)
+
+
 # Details of a Warehouse
 
 GET         /warehouse                           controllers.declaration.WarehouseDetailsController.displayPage(mode: models.Mode ?= models.Mode.Normal)

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -97,7 +97,6 @@ GET         /supervising-customs-office          controllers.declaration.Supervi
 
 POST        /supervising-customs-office          controllers.declaration.SupervisingCustomsOfficeController.submit(mode: models.Mode ?= models.Mode.Normal)
 
-
 # Details of a Warehouse
 
 GET         /warehouse                           controllers.declaration.WarehouseDetailsController.displayPage(mode: models.Mode ?= models.Mode.Normal)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -432,12 +432,15 @@ declaration.warehouse.identification.hint = Because you entered 07, 71, or 78 in
 declaration.warehouse.identification.identificationNumber.error = Incorrect Identification Number
 declaration.warehouse.identification.identificationNumber.empty = Enter the warehouse identification number
 
+declaration.warehouse.supervisingCustomsOffice.sectionHeader = Locations
+declaration.warehouse.supervisingCustomsOffice.title = Where is the supervising customs office?
+declaration.warehouse.supervisingCustomsOffice.hint = If your goods have been altered or are being sent out to be altered, this is the office that gives authorisation for that procedure.
+declaration.warehouse.supervisingCustomsOffice.error = Supervising customs office is incorrect
+
 supplementary.warehouse.title =  Enter more details about the warehouse
 supplementary.warehouse.title.hint = Locations
 supplementary.warehouse.identificationType = Warehouse type
 supplementary.warehouse.identificationType.error = Please choose a valid warehouse type
-supplementary.warehouse.supervisingCustomsOffice = Where is the supervising customs office?
-supplementary.warehouse.supervisingCustomsOffice.error = Supervising customs office is incorrect
 supplementary.warehouse.inlandTransportMode.header = What is the inland mode of transport?
 supplementary.warehouse.inlandTransportMode.header.hint = The type of transport that will move the goods from a warehouse to the port where they will depart the EU.
 supplementary.warehouse.inlandTransportMode.error.incorrect = Please, choose valid inland mode of transport

--- a/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -36,7 +36,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
   val controller = new SupervisingCustomsOfficeController(
     authenticate = mockAuthAction,
     journeyType = mockJourneyAction,
-    navigator,
+    navigator = navigator,
     exportsCacheService = mockExportsCacheService,
     mcc = stubMessagesControllerComponents(),
     supervisingCustomsOfficePage = supervisingCustomsOfficeTemplate
@@ -47,32 +47,17 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
   private val standardCacheModel = aDeclaration(
     withType(DeclarationType.STANDARD),
-    withWarehouseIdentification(
-      Some(exampleCustomsOfficeIdentifier),
-      None,
-      Some(exampleWarehouseIdentificationNumber),
-      None
-    )
+    withWarehouseIdentification(Some(exampleCustomsOfficeIdentifier), None, Some(exampleWarehouseIdentificationNumber), None)
   )
 
   private val supplementaryCacheModel = aDeclaration(
     withType(DeclarationType.SUPPLEMENTARY),
-    withWarehouseIdentification(
-      Some(exampleCustomsOfficeIdentifier),
-      None,
-      Some(exampleWarehouseIdentificationNumber),
-      None
-    )
+    withWarehouseIdentification(Some(exampleCustomsOfficeIdentifier), None, Some(exampleWarehouseIdentificationNumber), None)
   )
 
   private val simplifiedCacheModel = aDeclaration(
     withType(DeclarationType.SIMPLIFIED),
-    withWarehouseIdentification(
-      Some(exampleCustomsOfficeIdentifier),
-      None,
-      Some(exampleWarehouseIdentificationNumber),
-      None
-    )
+    withWarehouseIdentification(Some(exampleCustomsOfficeIdentifier), None, Some(exampleWarehouseIdentificationNumber), None)
   )
 
   override protected def beforeEach(): Unit = {
@@ -87,47 +72,55 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
   }
 
   "Supervising Customs Office Controller on GET request" should {
+
     "return 200 OK" in {
       withNewCaching(supplementaryCacheModel)
+
       val response = controller.displayPage(Mode.Normal).apply(getRequest())
+
       status(response) must be(OK)
     }
 
     "read item from cache and display it" in {
       withNewCaching(supplementaryCacheModel)
+
       val result = controller.displayPage(Mode.Normal).apply(getRequest())
       await(result)
+
       verify(mockExportsCacheService).get(any())(any())
       verify(supervisingCustomsOfficeTemplate).apply(any(), any())(any(), any())
     }
   }
   "Supervising Customs Office Controller on POST" when {
 
-    val body = Json.obj(
-      "supervisingCustomsOffice" -> exampleCustomsOfficeIdentifier,
-      "identificationNumber" -> exampleWarehouseIdentificationNumber
-    )
+    val body = Json.obj("supervisingCustomsOffice" -> exampleCustomsOfficeIdentifier, "identificationNumber" -> exampleWarehouseIdentificationNumber)
 
     "we are on standard declaration journey" should {
 
       "redirect to Warehouse Details" in {
         withNewCaching(standardCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(standardCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
         await(result)
+
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+
         updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
         updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
       }
 
       "return Bad Request if payload is not compatible with model" in {
         withNewCaching(standardCacheModel)
+
         val body = Json.obj("supervisingCustomsOffice" -> "A")
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
 
@@ -136,24 +129,31 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
     }
 
     "we are on supplementary declaration journey" should {
+
       "redirect to Warehouse Details" in {
         withNewCaching(supplementaryCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(supplementaryCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
         await(result)
+
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+
         updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
         updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
       }
 
       "return Bad Request if payload is not compatible with model" in {
         withNewCaching(supplementaryCacheModel)
+
         val body = Json.obj("supervisingCustomsOffice" -> "A")
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
 
@@ -162,24 +162,31 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
     }
 
     "we are on simplified declaration journey" should {
+
       "redirect to Warehouse Details" in {
         withNewCaching(simplifiedCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(simplifiedCacheModel)
+
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
         await(result)
+
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+
         updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
         updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
       }
 
       "return Bad Request if payload is not compatible with model" in {
         withNewCaching(simplifiedCacheModel)
+
         val body = Json.obj("supervisingCustomsOffice" -> "A")
         val result = controller.submit(Mode.Normal).apply(postRequest(body))
 

--- a/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -31,9 +31,9 @@ import views.html.declaration.supervising_customs_office
 
 class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeAndAfterEach with WarehouseIdentificationMessages with OptionValues {
 
-  val supervisingCustomsOfficeTemplate: supervising_customs_office = mock[supervising_customs_office]
+  private val supervisingCustomsOfficeTemplate: supervising_customs_office = mock[supervising_customs_office]
 
-  val controller = new SupervisingCustomsOfficeController(
+  private val controller = new SupervisingCustomsOfficeController(
     authenticate = mockAuthAction,
     journeyType = mockJourneyAction,
     navigator = navigator,
@@ -42,8 +42,8 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
     supervisingCustomsOfficePage = supervisingCustomsOfficeTemplate
   )
 
-  val exampleCustomsOfficeIdentifier = "A1B2C3D4"
-  val exampleWarehouseIdentificationNumber = "SecretStash"
+  private val exampleCustomsOfficeIdentifier = "A1B2C3D4"
+  private val exampleWarehouseIdentificationNumber = "SecretStash"
 
   private val standardCacheModel = aDeclaration(
     withType(DeclarationType.STANDARD),
@@ -84,8 +84,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
     "read item from cache and display it" in {
       withNewCaching(supplementaryCacheModel)
 
-      val result = controller.displayPage(Mode.Normal).apply(getRequest())
-      await(result)
+      await(controller.displayPage(Mode.Normal)(getRequest()))
 
       verify(mockExportsCacheService).get(any())(any())
       verify(supervisingCustomsOfficeTemplate).apply(any(), any())(any(), any())
@@ -100,17 +99,16 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
       "redirect to Warehouse Details" in {
         withNewCaching(standardCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = await(controller.submit(Mode.Normal)(postRequest(body)))
 
-        await(result) mustBe aRedirectToTheNextPage
+        result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(standardCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
-        await(result)
+        await(controller.submit(Mode.Normal)(postRequest(body)))
 
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
 
@@ -122,7 +120,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         withNewCaching(standardCacheModel)
 
         val body = Json.obj("supervisingCustomsOffice" -> "A")
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = controller.submit(Mode.Normal)(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
       }
@@ -133,17 +131,16 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
       "redirect to Warehouse Details" in {
         withNewCaching(supplementaryCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = await(controller.submit(Mode.Normal)(postRequest(body)))
 
-        await(result) mustBe aRedirectToTheNextPage
+        result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(supplementaryCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
-        await(result)
+        await(controller.submit(Mode.Normal)(postRequest(body)))
 
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
 
@@ -155,7 +152,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         withNewCaching(supplementaryCacheModel)
 
         val body = Json.obj("supervisingCustomsOffice" -> "A")
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = controller.submit(Mode.Normal)(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
       }
@@ -166,17 +163,16 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
       "redirect to Warehouse Details" in {
         withNewCaching(simplifiedCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = await(controller.submit(Mode.Normal).apply(postRequest(body)))
 
-        await(result) mustBe aRedirectToTheNextPage
+        result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
       }
 
       "update cache after successful bind" in {
         withNewCaching(simplifiedCacheModel)
 
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
-        await(result)
+        await(controller.submit(Mode.Normal)(postRequest(body)))
 
         val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
 
@@ -188,7 +184,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         withNewCaching(simplifiedCacheModel)
 
         val body = Json.obj("supervisingCustomsOffice" -> "A")
-        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        val result = controller.submit(Mode.Normal)(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
       }

--- a/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -1,0 +1,192 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers.declaration
+
+import controllers.declaration.SupervisingCustomsOfficeController
+import helpers.views.declaration.WarehouseIdentificationMessages
+import models.{DeclarationType, Mode}
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito
+import org.mockito.Mockito.{verify, when}
+import org.scalatest.{BeforeAndAfterEach, OptionValues}
+import play.api.libs.json.Json
+import play.api.test.Helpers._
+import play.twirl.api.HtmlFormat
+import unit.base.ControllerSpec
+import views.html.declaration.supervising_customs_office
+
+class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeAndAfterEach with WarehouseIdentificationMessages with OptionValues {
+
+  val supervisingCustomsOfficeTemplate: supervising_customs_office = mock[supervising_customs_office]
+
+  val controller = new SupervisingCustomsOfficeController(
+    authenticate = mockAuthAction,
+    journeyType = mockJourneyAction,
+    navigator,
+    exportsCacheService = mockExportsCacheService,
+    mcc = stubMessagesControllerComponents(),
+    supervisingCustomsOfficePage = supervisingCustomsOfficeTemplate
+  )
+
+  val exampleCustomsOfficeIdentifier = "A1B2C3D4"
+  val exampleWarehouseIdentificationNumber = "SecretStash"
+
+  private val standardCacheModel = aDeclaration(
+    withType(DeclarationType.STANDARD),
+    withWarehouseIdentification(
+      Some(exampleCustomsOfficeIdentifier),
+      None,
+      Some(exampleWarehouseIdentificationNumber),
+      None
+    )
+  )
+
+  private val supplementaryCacheModel = aDeclaration(
+    withType(DeclarationType.SUPPLEMENTARY),
+    withWarehouseIdentification(
+      Some(exampleCustomsOfficeIdentifier),
+      None,
+      Some(exampleWarehouseIdentificationNumber),
+      None
+    )
+  )
+
+  private val simplifiedCacheModel = aDeclaration(
+    withType(DeclarationType.SIMPLIFIED),
+    withWarehouseIdentification(
+      Some(exampleCustomsOfficeIdentifier),
+      None,
+      Some(exampleWarehouseIdentificationNumber),
+      None
+    )
+  )
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+    authorizedUser()
+    when(supervisingCustomsOfficeTemplate.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  override protected def afterEach(): Unit = {
+    Mockito.reset(supervisingCustomsOfficeTemplate)
+    super.afterEach()
+  }
+
+  "Supervising Customs Office Controller on GET request" should {
+    "return 200 OK" in {
+      withNewCaching(supplementaryCacheModel)
+      val response = controller.displayPage(Mode.Normal).apply(getRequest())
+      status(response) must be(OK)
+    }
+
+    "read item from cache and display it" in {
+      withNewCaching(supplementaryCacheModel)
+      val result = controller.displayPage(Mode.Normal).apply(getRequest())
+      await(result)
+      verify(mockExportsCacheService).get(any())(any())
+      verify(supervisingCustomsOfficeTemplate).apply(any(), any())(any(), any())
+    }
+  }
+  "Supervising Customs Office Controller on POST" when {
+
+    val body = Json.obj(
+      "supervisingCustomsOffice" -> exampleCustomsOfficeIdentifier,
+      "identificationNumber" -> exampleWarehouseIdentificationNumber
+    )
+
+    "we are on standard declaration journey" should {
+
+      "redirect to Warehouse Details" in {
+        withNewCaching(standardCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+      }
+
+      "update cache after successful bind" in {
+        withNewCaching(standardCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result)
+        val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+        updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
+      }
+
+      "return Bad Request if payload is not compatible with model" in {
+        withNewCaching(standardCacheModel)
+        val body = Json.obj("supervisingCustomsOffice" -> "A")
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
+        status(result) mustBe BAD_REQUEST
+      }
+    }
+
+    "we are on supplementary declaration journey" should {
+      "redirect to Warehouse Details" in {
+        withNewCaching(supplementaryCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+      }
+
+      "update cache after successful bind" in {
+        withNewCaching(supplementaryCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result)
+        val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+        updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
+      }
+
+      "return Bad Request if payload is not compatible with model" in {
+        withNewCaching(supplementaryCacheModel)
+        val body = Json.obj("supervisingCustomsOffice" -> "A")
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
+        status(result) mustBe BAD_REQUEST
+      }
+    }
+
+    "we are on simplified declaration journey" should {
+      "redirect to Warehouse Details" in {
+        withNewCaching(simplifiedCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+      }
+
+      "update cache after successful bind" in {
+        withNewCaching(simplifiedCacheModel)
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+        await(result)
+        val updatedWarehouse = theCacheModelUpdated.locations.warehouseIdentification.value
+        updatedWarehouse.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
+      }
+
+      "return Bad Request if payload is not compatible with model" in {
+        withNewCaching(simplifiedCacheModel)
+        val body = Json.obj("supervisingCustomsOffice" -> "A")
+        val result = controller.submit(Mode.Normal).apply(postRequest(body))
+
+        status(result) mustBe BAD_REQUEST
+      }
+    }
+
+  }
+
+}

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -85,11 +85,11 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
 
     "we are on standard declaration journey" should {
 
-      "redirect to Warehouse Details page" in {
+      "redirect to Supervising Customs Office page" in {
         withNewCaching(standardCacheModel)
         val result = controller.saveIdentificationNumber(Mode.Normal).apply(postRequest(body))
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+        thePageNavigatedTo mustBe controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage()
       }
 
       "update cache after successful bind" in {
@@ -110,11 +110,11 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
     }
 
     "we are on supplementary declaration journey" should {
-      "redirect to Warehouse Details page" in {
+      "redirect to Supervising Customs Office page" in {
         withNewCaching(suplementaryCacheModel)
         val result = controller.saveIdentificationNumber(Mode.Normal).apply(postRequest(body))
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+        thePageNavigatedTo mustBe controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage()
       }
 
       "update cache after successful bind" in {
@@ -135,11 +135,11 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
     }
 
     "we are on simplified declaration journey" should {
-      "redirect to Warehouse Details page" in {
+      "redirect to Supervising Customs Office page" in {
         withNewCaching(simplifiedCacheModel)
         val result = controller.saveIdentificationNumber(Mode.Normal).apply(postRequest(body))
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.WarehouseDetailsController.displayPage()
+        thePageNavigatedTo mustBe controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage()
       }
 
       "update cache after successful bind" in {

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -100,7 +100,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec with BeforeAn
         updatedWarehouse.identificationNumber.value mustBe exampleWarehouseIdentificationNumber
       }
 
-      "return Bad Request if payload is not compatibile with model" in {
+      "return Bad Request if payload is not compatible with model" in {
         withNewCaching(standardCacheModel)
         val body = Json.obj("supervisingCustomsOffice" -> "A")
         val result = controller.saveIdentificationNumber(Mode.Normal).apply(postRequest(body))

--- a/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
+++ b/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
@@ -46,6 +46,8 @@ class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.sectionHeader")
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.title")
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.hint")
+      messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.error")
+
     }
 
     "display same page title as header" in {

--- a/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
+++ b/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
@@ -30,7 +30,7 @@ import views.html.declaration.supervising_customs_office
 import views.tags.ViewTest
 
 @ViewTest
-class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
+class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData with Stubs {
 
   private val page = new supervising_customs_office(mainTemplate)
   private val form: Form[WarehouseDetails] = WarehouseDetails.form()

--- a/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
+++ b/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
@@ -42,7 +42,7 @@ class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData
     val view = createView()
 
     "have proper messages for labels" in {
-      val messages = instanceOf[MessagesApi].preferred(journeyRequest())
+      val messages = realMessagesApi.preferred(journeyRequest())
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.sectionHeader")
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.title")
       messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.hint")

--- a/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
+++ b/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
@@ -1,0 +1,71 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration
+
+import base.Injector
+import forms.declaration.WarehouseDetails
+import models.Mode
+import org.jsoup.nodes.Document
+import play.api.data.Form
+import play.api.i18n.{Messages, MessagesApi}
+import play.api.test.Helpers.stubMessages
+import services.cache.ExportsTestData
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.supervising_customs_office
+import views.tags.ViewTest
+
+@ViewTest
+class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
+
+  private val page = new supervising_customs_office(mainTemplate)
+  private val form: Form[WarehouseDetails] = WarehouseDetails.form()
+
+  private def createView(mode: Mode = Mode.Normal, form: Form[WarehouseDetails] = form, messages: Messages = stubMessages()): Document =
+    page(mode, form)(journeyRequest(), messages)
+
+  "Supervising Customs Office View" should {
+    val view = createView()
+
+    "have proper messages for labels" in {
+      val messages = instanceOf[MessagesApi].preferred(journeyRequest())
+      messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.sectionHeader")
+      messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.title")
+      messages must haveTranslationFor("declaration.warehouse.supervisingCustomsOffice.hint")
+    }
+
+    "display same page title as header" in {
+      val viewWithMessage = createView(messages = realMessagesApi.preferred(request))
+      viewWithMessage.title() must include(viewWithMessage.getElementsByTag("h1").text())
+    }
+
+    "display 'Back' button that links to 'Warehouse Identification Number' page" in {
+      val backButton = view.getElementById("link-back")
+
+      backButton.text() mustBe "site.back"
+      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.WarehouseIdentificationController.displayPage(Mode.Normal))
+    }
+
+    "display 'Save and continue' button on page" in {
+      view.getElementById("submit").text() mustBe "site.save_and_continue"
+    }
+
+    "display 'Save and return' button on page" in {
+      view.getElementById("submit_and_return").text() mustBe "site.save_and_come_back_later"
+    }
+  }
+}

--- a/test/views/declaration/WarehouseDetailsViewSpec.scala
+++ b/test/views/declaration/WarehouseDetailsViewSpec.scala
@@ -45,10 +45,6 @@ class WarehouseDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
       val messages = instanceOf[MessagesApi].preferred(journeyRequest())
       messages must haveTranslationFor("supplementary.warehouse.title")
       messages must haveTranslationFor("supplementary.warehouse.title.hint")
-      messages must haveTranslationFor("supplementary.warehouse.identificationType")
-      messages must haveTranslationFor("supplementary.warehouse.identificationType.error")
-      messages must haveTranslationFor("supplementary.warehouse.supervisingCustomsOffice")
-      messages must haveTranslationFor("supplementary.warehouse.supervisingCustomsOffice.error")
       messages must haveTranslationFor("supplementary.warehouse.inlandTransportMode.header")
       messages must haveTranslationFor("supplementary.warehouse.inlandTransportMode.header.hint")
       messages must haveTranslationFor("supplementary.warehouse.inlandTransportMode.error.incorrect")
@@ -59,11 +55,11 @@ class WarehouseDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
       viewWithMessage.title() must include(viewWithMessage.getElementsByTag("h1").text())
     }
 
-    "display 'Back' button that links to 'Warehouse Identification Number' page" in {
+    "display 'Back' button that links to 'Supervising Customs Office' page" in {
       val backButton = view.getElementById("link-back")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.WarehouseIdentificationController.displayPage(Mode.Normal))
+      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/WarehouseIdentificationViewSpec.scala
+++ b/test/views/declaration/WarehouseIdentificationViewSpec.scala
@@ -46,6 +46,8 @@ class WarehouseIdentificationViewSpec extends UnitViewSpec with ExportsTestData 
       messages must haveTranslationFor("declaration.warehouse.identification.sectionHeader")
       messages must haveTranslationFor("declaration.warehouse.identification.title")
       messages must haveTranslationFor("declaration.warehouse.identification.hint")
+      messages must haveTranslationFor("declaration.warehouse.identification.identificationNumber.error")
+      messages must haveTranslationFor("declaration.warehouse.identification.identificationNumber.empty")
     }
 
     "display same page title as header" in {


### PR DESCRIPTION
Created new Supervising Customs Office controller and view.
Added endpoint to declaration.routes.
Removed the Supervising Customs Office field from Warehouse Details page.
Changed Back button on Warehouse Details page and 'Save and Continue' button on Warehouse Identification page to direct to Supervising Customs Office page.
Added View Spec and Controller Spec for Supervising Customs Office, and updated Warehouse Identification Controller spec and Warehouse Details View Spec.
