### PR TITLE
CEDS-1953 Keep the data previously entered when clicking back button

### DIFF
--- a/app/controllers/declaration/WarehouseDetailsController.scala
+++ b/app/controllers/declaration/WarehouseDetailsController.scala
@@ -75,16 +75,11 @@ class WarehouseDetailsController @Inject()(
           dbWarehouseDetails =>
             WarehouseDetails(
               identificationNumber = dbWarehouseDetails.identificationNumber,
-              supervisingCustomsOffice = formData.supervisingCustomsOffice,
+              supervisingCustomsOffice = dbWarehouseDetails.supervisingCustomsOffice,
               inlandModeOfTransportCode = formData.inlandModeOfTransportCode
           )
         )
-        .getOrElse(
-          WarehouseDetails(
-            supervisingCustomsOffice = formData.supervisingCustomsOffice,
-            inlandModeOfTransportCode = formData.inlandModeOfTransportCode
-          )
-        )
+        .getOrElse(WarehouseDetails(inlandModeOfTransportCode = formData.inlandModeOfTransportCode))
       model.copy(locations = model.locations.copy(warehouseIdentification = Some(warehouseDetails)))
     }
 }

--- a/test/unit/controllers/declaration/WarehouseDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseDetailsControllerSpec.scala
@@ -22,7 +22,7 @@ import helpers.views.declaration.WarehouseIdentificationMessages
 import models.{DeclarationType, Mode}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito
-import org.mockito.Mockito.{times, verify, when}
+import org.mockito.Mockito.{verify, when}
 import org.scalatest.{BeforeAndAfterEach, OptionValues}
 import play.api.libs.json.Json
 import play.api.test.Helpers._
@@ -106,12 +106,7 @@ class WarehouseDetailsControllerSpec extends ControllerSpec with BeforeAndAfterE
   }
   "Warehouse Identification Controller on POST" when {
 
-    val body = Json.obj(
-      "supervisingCustomsOffice" -> exampleCustomsOfficeIdentifier,
-      "identificationType" -> exampleWarehouseIdentificationType,
-      "identificationNumber" -> exampleWarehouseIdentificationNumber,
-      "inlandModeOfTransportCode" -> exampleTransportMode
-    )
+    val body = Json.obj("inlandModeOfTransportCode" -> exampleTransportMode)
 
     "we are on standard declaration journey" should {
 
@@ -194,7 +189,5 @@ class WarehouseDetailsControllerSpec extends ControllerSpec with BeforeAndAfterE
         status(result) mustBe BAD_REQUEST
       }
     }
-
   }
-
 }


### PR DESCRIPTION
This is due to trying to maintain the same model, which with hindsight
was a bad idea. After @janeturner completes the screen-splitting we will
come back to clean the model and the cache updates functions.