### PR TITLE
CEDS-1976 Change back button id

### DIFF
--- a/app/views/components/back_link.scala.html
+++ b/app/views/components/back_link.scala.html
@@ -21,5 +21,5 @@
 @(href: Call, mode: Mode = Mode.Normal, backMessage: String = "site.back")(implicit messages: Messages)
 
 <div class="js-visible">
-    <a id="link-back" class="link-back" href="@href">@messages(backMessage)</a>
+    <a id="back-link" class="link-back" href="@href">@messages(backMessage)</a>
 </div>

--- a/test/views/RejectedNotificationErrorsViewSpec.scala
+++ b/test/views/RejectedNotificationErrorsViewSpec.scala
@@ -62,7 +62,7 @@ class RejectedNotificationErrorsViewSpec extends UnitViewSpec with Stubs with In
 
     "have correct back link" in {
 
-      val backLink = defaultView.getElementById("link-back")
+      val backLink = defaultView.getElementById("back-link")
 
       backLink.text() mustBe messages("site.back")
       backLink.attr("href") mustBe routes.SubmissionsController.displayListOfSubmissions().url

--- a/test/views/SavedDeclarationsViewSpec.scala
+++ b/test/views/SavedDeclarationsViewSpec.scala
@@ -123,7 +123,7 @@ class SavedDeclarationsViewSpec extends UnitViewSpec with CommonMessages with St
     }
 
     "display 'Back' button that links to 'Choice' page with 'Continue saved declarations' selected" in {
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton must containText("site.back")
       backButton must haveHref(routes.ChoiceController.displayPage(Some(Choice(ContinueDec))))

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -154,7 +154,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
     }
 
     "display 'Back' button that links to 'Choice' page with Submissions selected" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton must containText("site.back")
       backButton must haveHref(routes.ChoiceController.displayPage(Some(Choice(Submissions))))

--- a/test/views/cancellation/CancelDeclarationViewSpec.scala
+++ b/test/views/cancellation/CancelDeclarationViewSpec.scala
@@ -128,7 +128,7 @@ class CancelDeclarationViewSpec extends UnitViewSpec with CommonMessages with St
     }
 
     "display 'Back' button that links to 'Choice' page with Cancel declaration selected" in {
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton must containText("site.back")
       backButton must haveHref(routes.ChoiceController.displayPage(Some(Choice(CancelDec))))

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -64,7 +64,7 @@ class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with Ad
 
     "display 'Back' button to Fiscal Information page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe backCaption
       backButton must haveHref(controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId, fastForward = false))

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -93,7 +93,7 @@ class AdditionalInformationViewSpec
     "display 'Back' button that links to 'Commodity measure' page" when {
       "on the Standard journey" in {
 
-        val backButton = createView().getElementById("link-back")
+        val backButton = createView().getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") must endWith(s"/items/$itemId/commodity-measure")
@@ -101,7 +101,7 @@ class AdditionalInformationViewSpec
 
       "on the Simplified journey" in {
 
-        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("link-back")
+        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") must endWith(s"/items/$itemId/package-information")

--- a/test/views/declaration/BorderTransportViewSpec.scala
+++ b/test/views/declaration/BorderTransportViewSpec.scala
@@ -149,10 +149,10 @@ class BorderTransportViewSpec extends UnitViewSpec with ExportsTestData with Stu
 
       val view = createView(request = requrestOnStandard)
       "display 'Back' button that links to 'Departure' page" in {
-        val backButton = view.getElementById("link-back")
+        val backButton = view.getElementById("back-link")
 
         backButton must containText(realMessages(backCaption))
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.DepartureTransportController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.DepartureTransportController.displayPage(Mode.Normal))
       }
 
       behave like borderView(view)
@@ -164,10 +164,10 @@ class BorderTransportViewSpec extends UnitViewSpec with ExportsTestData with Stu
       val view = createView(request = requrestOnSupplementary)
 
       "display 'Back' button that links to 'Departure' page" in {
-        val backButton = view.getElementById("link-back")
+        val backButton = view.getElementById("back-link")
 
         backButton must containText(realMessages(backCaption))
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.DepartureTransportController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.DepartureTransportController.displayPage(Mode.Normal))
       }
 
       behave like havingMeansOfTransport(view)
@@ -180,10 +180,10 @@ class BorderTransportViewSpec extends UnitViewSpec with ExportsTestData with Stu
 
       "display 'Back' button that links to 'Supervising Customs Office' page" in {
         val viewForStandard = view
-        val backButton = viewForStandard.getElementById("link-back")
+        val backButton = viewForStandard.getElementById("back-link")
 
         backButton must containText(realMessages(backCaption))
-        backButton.getElementById("link-back") must haveHref(
+        backButton.getElementById("back-link") must haveHref(
           controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(Mode.Normal)
         )
       }

--- a/test/views/declaration/CUSCodeViewSpec.scala
+++ b/test/views/declaration/CUSCodeViewSpec.scala
@@ -56,9 +56,9 @@ class CUSCodeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with 
     }
 
     "display 'Back' button that links to 'UN Dangerous Goods Code' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
-      backButton.getElementById("link-back") must haveHref(
+      backButton.getElementById("back-link") must haveHref(
         controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage(Mode.Normal, itemId)
       )
     }

--- a/test/views/declaration/CarrierDetailsViewSpec.scala
+++ b/test/views/declaration/CarrierDetailsViewSpec.scala
@@ -115,7 +115,7 @@ class CarrierDetailsViewSpec extends UnitViewSpec with CarrierDetailsMessages wi
 
     "display 'Back' button that links to 'Representative Details' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.RepresentativeDetailsController.displayPage().url

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -59,8 +59,8 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
     }
 
     "display 'Back' button that links to 'Package Information' page" in {
-      val backButton = view.getElementById("link-back")
-      backButton.getElementById("link-back") must haveHref(
+      val backButton = view.getElementById("back-link")
+      backButton.getElementById("back-link") must haveHref(
         controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId)
       )
     }

--- a/test/views/declaration/CommodityMeasureViewSpec.scala
+++ b/test/views/declaration/CommodityMeasureViewSpec.scala
@@ -97,7 +97,7 @@ class CommodityMeasureViewSpec extends UnitViewSpec with CommodityMeasureMessage
 
     "display 'Back' button that links to 'Package Information' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") must endWith(s"/items/$itemId/package-information")

--- a/test/views/declaration/ConsigneeDetailsViewSpec.scala
+++ b/test/views/declaration/ConsigneeDetailsViewSpec.scala
@@ -109,7 +109,7 @@ class ConsigneeDetailsViewSpec extends UnitViewSpec with ConsigneeDetailsMessage
 
     "display 'Back' button that links to 'Exporter Details' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.ExporterDetailsController.displayPage().url

--- a/test/views/declaration/ConsignmentReferencesViewSpec.scala
+++ b/test/views/declaration/ConsignmentReferencesViewSpec.scala
@@ -92,7 +92,7 @@ class ConsignmentReferencesViewSpec extends UnitViewSpec with ConsignmentReferen
 
     "display 'Back' button that links to 'Declaration Type' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.AdditionalDeclarationTypeController.displayPage().url

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -63,7 +63,7 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with De
     "display 'Back' button that links to 'Consignee Details' page" in {
 
       val view = declarantDetailsPage(Mode.Normal, form)(journeyRequest(), messages)
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.ConsigneeDetailsController.displayPage().url

--- a/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
@@ -116,7 +116,7 @@ class DeclarationAdditionalActorsViewSpec
 
       val view = declarationAdditionalActorsPage(Mode.Normal, form, Seq())(journeyRequest(DeclarationType.SUPPLEMENTARY), messages)
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.RepresentativeDetailsController.displayPage().url
@@ -125,7 +125,7 @@ class DeclarationAdditionalActorsViewSpec
     "display 'Back' button that links to 'Carrier Details' page if on Standard Journey" in {
 
       val view = declarationAdditionalActorsPage(Mode.Normal, form, Seq())(journeyRequest(DeclarationType.STANDARD), messages)
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.CarrierDetailsController.displayPage().url
@@ -134,7 +134,7 @@ class DeclarationAdditionalActorsViewSpec
     "display 'Back' button that links to 'Carrier Details' page if on Simplified Journey" in {
 
       val view = declarationAdditionalActorsPage(Mode.Normal, form, Seq())(journeyRequest(DeclarationType.SIMPLIFIED), messages)
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.CarrierDetailsController.displayPage().url

--- a/test/views/declaration/DeclarationChoiceViewSpec.scala
+++ b/test/views/declaration/DeclarationChoiceViewSpec.scala
@@ -60,10 +60,10 @@ class DeclarationChoiceViewSpec extends UnitViewSpec with ChoiceMessages with Co
 
     "display 'Back' button that links to 'Choice' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
-      backButton.getElementById("link-back") must haveHref(controllers.routes.ChoiceController.displayPage(Some(Choice(CreateDec))))
+      backButton.getElementById("back-link") must haveHref(controllers.routes.ChoiceController.displayPage(Some(Choice(CreateDec))))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/DeclarationHolderViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderViewSpec.scala
@@ -87,7 +87,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with DeclarationHolderMessa
 
     "display 'Back' button that links to 'Additional Information' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.DeclarationAdditionalActorsController.displayPage().url

--- a/test/views/declaration/DepartureTransportViewSpec.scala
+++ b/test/views/declaration/DepartureTransportViewSpec.scala
@@ -83,7 +83,7 @@ class DepartureTransportViewSpec extends UnitViewSpec with CommonMessages with S
     }
 
     "display 'Back' button that links to 'Inland Transport Details' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
       backButton.text() mustBe messages(backCaption)
       backButton must haveHref(routes.InlandTransportDetailsController.displayPage())
     }

--- a/test/views/declaration/DispatchLocationViewSpec.scala
+++ b/test/views/declaration/DispatchLocationViewSpec.scala
@@ -83,21 +83,21 @@ class DispatchLocationViewSpec extends UnitViewSpec with DispatchLocationMessage
 
     "display 'Back' button" when {
       "normal mode" in {
-        val backButton = createView(mode = Mode.Normal).getElementById("link-back")
+        val backButton = createView(mode = Mode.Normal).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe controllers.declaration.routes.DeclarationChoiceController.displayPage().url
       }
 
       "draft mode" in {
-        val backButton = createView(mode = Mode.Draft).getElementById("link-back")
+        val backButton = createView(mode = Mode.Draft).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Draft).url
       }
 
       "amend mode" in {
-        val backButton = createView(mode = Mode.Amend).getElementById("link-back")
+        val backButton = createView(mode = Mode.Amend).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe controllers.declaration.routes.SummaryController.displayPage(Mode.Amend).url

--- a/test/views/declaration/DocumentsProducedViewSpec.scala
+++ b/test/views/declaration/DocumentsProducedViewSpec.scala
@@ -137,7 +137,7 @@ class DocumentsProducedViewSpec
 
     "display 'Back' button that links to 'Additional Information' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messagesKey(backCaption)
       backButton must haveHref(routes.AdditionalInformationController.displayPage(mode, itemId))

--- a/test/views/declaration/ExporterDetailsViewSpec.scala
+++ b/test/views/declaration/ExporterDetailsViewSpec.scala
@@ -102,7 +102,7 @@ class ExporterDetailsViewSpec extends UnitViewSpec with ExporterDetailsMessages 
 
     "display 'Back' button that links to 'Consignment References' page" in {
 
-      val backButton = createView().getElementById("link-back")
+      val backButton = createView().getElementById("back-link")
 
       backButton.text() mustBe messages(backCaption)
       backButton.attr("href") mustBe routes.ConsignmentReferencesController.displayPage().url

--- a/test/views/declaration/FiscalInformationViewSpec.scala
+++ b/test/views/declaration/FiscalInformationViewSpec.scala
@@ -84,10 +84,10 @@ class FiscalInformationViewSpec extends UnitViewSpec with ExportsTestData with S
 
     "display 'Back' button that links to 'Warehouse' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.ProcedureCodesController.displayPage(Mode.Normal, "itemId"))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.ProcedureCodesController.displayPage(Mode.Normal, "itemId"))
     }
 
     "display 'Save and continue' button" in {

--- a/test/views/declaration/InlandTransportDetailsViewSpec.scala
+++ b/test/views/declaration/InlandTransportDetailsViewSpec.scala
@@ -54,10 +54,10 @@ class InlandTransportDetailsViewSpec extends UnitViewSpec with ExportsTestData w
     }
 
     "display 'Back' button that links to 'Supervising Customs Office' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/ItemSummaryViewSpec.scala
+++ b/test/views/declaration/ItemSummaryViewSpec.scala
@@ -53,7 +53,7 @@ class ItemSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
 
     "render back button" in {
 
-      view.getElementById("link-back") must haveAttribute("href", routes.PreviousDocumentsController.displayPage().url)
+      view.getElementById("back-link") must haveAttribute("href", routes.PreviousDocumentsController.displayPage().url)
     }
 
     "render title" when {

--- a/test/views/declaration/LocationViewSpec.scala
+++ b/test/views/declaration/LocationViewSpec.scala
@@ -126,10 +126,10 @@ class LocationViewSpec extends UnitViewSpec with ExportsTestData with Stubs with
     }
 
     "display 'Back' button that links to 'Destination Countries' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.RoutingCountriesSummaryController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.RoutingCountriesSummaryController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button" in {

--- a/test/views/declaration/NactCodesViewSpec.scala
+++ b/test/views/declaration/NactCodesViewSpec.scala
@@ -70,9 +70,9 @@ class NactCodesViewSpec extends UnitViewSpec with ExportsTestData with Stubs wit
     }
 
     "display 'Back' button that links to 'TARIC Code' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.TaricCodeController.displayPage(Mode.Normal, itemId))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.TaricCodeController.displayPage(Mode.Normal, itemId))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/NatureOfTransactionViewSpec.scala
+++ b/test/views/declaration/NatureOfTransactionViewSpec.scala
@@ -96,10 +96,10 @@ class NatureOfTransactionViewSpec extends UnitViewSpec with ExportsTestData with
 
     "display 'Back' button that links to 'Total Number Of Items' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be("site.back")
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.TotalNumberOfItemsController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/NotEligibleViewSpec.scala
+++ b/test/views/declaration/NotEligibleViewSpec.scala
@@ -69,7 +69,7 @@ class NotEligibleViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
     }
 
     "display 'Back' button that links to 'Make declaration' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
       backButton must haveHref(controllers.routes.StartController.displayStartPage())

--- a/test/views/declaration/OfficeOfExitStandardViewSpec.scala
+++ b/test/views/declaration/OfficeOfExitStandardViewSpec.scala
@@ -77,10 +77,10 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
 
       "display 'Back' button that links to 'Location of Goods' page" in {
 
-        val backButton = view.getElementById("link-back")
+        val backButton = view.getElementById("back-link")
 
         backButton.text() mustBe "site.back"
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.LocationController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.LocationController.displayPage(Mode.Normal))
       }
 
       "display 'Save and continue' button" in {

--- a/test/views/declaration/OfficeOfExitSupplementaryViewSpec.scala
+++ b/test/views/declaration/OfficeOfExitSupplementaryViewSpec.scala
@@ -64,10 +64,10 @@ class OfficeOfExitSupplementaryViewSpec extends UnitViewSpec with ExportsTestDat
 
     "display 'Back' button that links to 'Location of Goods' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.LocationController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.LocationController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button" in {

--- a/test/views/declaration/PackageInformationViewSpec.scala
+++ b/test/views/declaration/PackageInformationViewSpec.scala
@@ -61,20 +61,20 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
 
     "display back link for Standard declaration" in {
       val view = createView(decType = DeclarationType.STANDARD)
-      view must containElementWithID("link-back")
-      view.getElementById("link-back") must haveHref(controllers.declaration.routes.StatisticalValueController.displayPage(Mode.Normal, "itemId"))
+      view must containElementWithID("back-link")
+      view.getElementById("back-link") must haveHref(controllers.declaration.routes.StatisticalValueController.displayPage(Mode.Normal, "itemId"))
     }
 
     "display back link for Supplementary declaration" in {
       val view = createView(decType = DeclarationType.SUPPLEMENTARY)
-      view must containElementWithID("link-back")
-      view.getElementById("link-back") must haveHref(controllers.declaration.routes.StatisticalValueController.displayPage(Mode.Normal, "itemId"))
+      view must containElementWithID("back-link")
+      view.getElementById("back-link") must haveHref(controllers.declaration.routes.StatisticalValueController.displayPage(Mode.Normal, "itemId"))
     }
 
     "display back link for Simplified declaration" in {
       val view = createView(decType = DeclarationType.SIMPLIFIED)
-      view must containElementWithID("link-back")
-      view.getElementById("link-back") must haveHref(controllers.declaration.routes.NactCodeController.displayPage(Mode.Normal, "itemId"))
+      view must containElementWithID("back-link")
+      view.getElementById("back-link") must haveHref(controllers.declaration.routes.NactCodeController.displayPage(Mode.Normal, "itemId"))
     }
   }
 

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -112,26 +112,26 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
     "display 'Back' button that links to 'Transaction Type' page" when {
       "on the Standard journey" in {
 
-        val backButton = view.getElementById("link-back")
+        val backButton = view.getElementById("back-link")
 
         backButton.text() must be("site.back")
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
       }
 
       "on the Supplementary journey" in {
 
-        val backButton = createView(declarationType = DeclarationType.SUPPLEMENTARY).getElementById("link-back")
+        val backButton = createView(declarationType = DeclarationType.SUPPLEMENTARY).getElementById("back-link")
 
         backButton.text() must be("site.back")
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
       }
 
       "on the Simplified journey" in {
 
-        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("link-back")
+        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("back-link")
 
         backButton.text() must be("site.back")
-        backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
+        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
       }
     }
 

--- a/test/views/declaration/ProcedureCodesViewSpec.scala
+++ b/test/views/declaration/ProcedureCodesViewSpec.scala
@@ -76,10 +76,10 @@ class ProcedureCodesViewSpec extends UnitViewSpec with ExportsTestData with Stub
 
     "display 'Back' button that links to 'Export Items' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.ItemsSummaryController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.ItemsSummaryController.displayPage(Mode.Normal))
     }
 
     "display both 'Add' and 'Save and continue' button on page" in {

--- a/test/views/declaration/RepresentativeDetailsViewSpec.scala
+++ b/test/views/declaration/RepresentativeDetailsViewSpec.scala
@@ -116,10 +116,10 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
 
     "display 'Back' button that links to 'Declarant Details' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be("site.back")
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.DeclarantDetailsController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.DeclarantDetailsController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/SealAddViewSpec.scala
+++ b/test/views/declaration/SealAddViewSpec.scala
@@ -44,10 +44,10 @@ class SealAddViewSpec extends UnitViewSpec with Stubs with MustMatchers with Com
     }
 
     "display 'Back' button that links to 'seals summary' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer.text() must be(messages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(
+      backLinkContainer.getElementById("back-link") must haveHref(
         controllers.declaration.routes.SealController.displaySealSummary(Mode.Normal, containerId)
       )
     }

--- a/test/views/declaration/SealRemoveViewSpec.scala
+++ b/test/views/declaration/SealRemoveViewSpec.scala
@@ -54,10 +54,10 @@ class SealRemoveViewSpec extends UnitViewSpec with Stubs with MustMatchers with 
     }
 
     "display 'Back' button that links to 'seal summary' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer.text() must be(messages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(
+      backLinkContainer.getElementById("back-link") must haveHref(
         controllers.declaration.routes.SealController.displaySealSummary(Mode.Normal, containerId)
       )
     }

--- a/test/views/declaration/SealSummaryViewSpec.scala
+++ b/test/views/declaration/SealSummaryViewSpec.scala
@@ -53,10 +53,10 @@ class SealSummaryViewSpec extends UnitViewSpec with Stubs with MustMatchers with
     }
 
     "display 'Back' button that links to 'containers summary' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer.text() must be(messages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(
+      backLinkContainer.getElementById("back-link") must haveHref(
         controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
       )
     }

--- a/test/views/declaration/StatisticalValueViewSpec.scala
+++ b/test/views/declaration/StatisticalValueViewSpec.scala
@@ -72,10 +72,10 @@ class StatisticalValueViewSpec extends UnitViewSpec with ExportsTestData with St
 
       "display 'Back' button that links to 'TARIC Codes' page" in {
 
-        val backButton = createView().getElementById("link-back")
+        val backButton = createView().getElementById("back-link")
 
         backButton.text() mustBe "site.back"
-        backButton.getElementById("link-back") must haveHref(
+        backButton.getElementById("back-link") must haveHref(
           controllers.declaration.routes.NactCodeController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }
@@ -113,10 +113,10 @@ class StatisticalValueViewSpec extends UnitViewSpec with ExportsTestData with St
 
       "display 'Back' button that links to 'TARIC Codes' page" in {
 
-        val backButton = createView().getElementById("link-back")
+        val backButton = createView().getElementById("back-link")
 
         backButton.text() mustBe "site.back"
-        backButton.getElementById("link-back") must haveHref(
+        backButton.getElementById("back-link") must haveHref(
           controllers.declaration.routes.NactCodeController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }
@@ -154,10 +154,10 @@ class StatisticalValueViewSpec extends UnitViewSpec with ExportsTestData with St
       "display 'Back' button that links to 'TARIC Codes' page" in {
 
         val backButton =
-          createView().getElementById("link-back")
+          createView().getElementById("back-link")
 
         backButton.text() mustBe "site.back"
-        backButton.getElementById("link-back") must haveHref(
+        backButton.getElementById("back-link") must haveHref(
           controllers.declaration.routes.NactCodeController.displayPage(Mode.Normal, itemId = "itemId")
         )
       }

--- a/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
+++ b/test/views/declaration/SupervisingCustomsOfficeViewSpec.scala
@@ -55,10 +55,10 @@ class SupervisingCustomsOfficeViewSpec extends UnitViewSpec with ExportsTestData
     }
 
     "display 'Back' button that links to 'Warehouse Identification Number' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.WarehouseIdentificationController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.WarehouseIdentificationController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/TaricCodesViewSpec.scala
+++ b/test/views/declaration/TaricCodesViewSpec.scala
@@ -70,9 +70,9 @@ class TaricCodesViewSpec extends UnitViewSpec with ExportsTestData with Stubs wi
     }
 
     "display 'Back' button that links to 'CUS Code' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.CUSCodeController.displayPage(Mode.Normal, itemId))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.CUSCodeController.displayPage(Mode.Normal, itemId))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/TotalNumberOfItemsViewSpec.scala
+++ b/test/views/declaration/TotalNumberOfItemsViewSpec.scala
@@ -86,10 +86,10 @@ class TotalNumberOfItemsViewSpec extends UnitViewSpec with ExportsTestData with 
     }
 
     "display 'Back' button that links to 'Transport Information' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() must be("site.back")
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/TransportContainerAddFirstViewSpec.scala
+++ b/test/views/declaration/TransportContainerAddFirstViewSpec.scala
@@ -46,9 +46,9 @@ class TransportContainerAddFirstViewSpec extends UnitViewSpec with ExportsTestDa
     }
 
     "display 'Back' button that links to 'transport payment' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
-      backLinkContainer.getElementById("link-back") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage(Mode.Normal))
+      backLinkContainer.getElementById("back-link") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/TransportContainerAddViewSpec.scala
+++ b/test/views/declaration/TransportContainerAddViewSpec.scala
@@ -46,9 +46,9 @@ class TransportContainerAddViewSpec extends UnitViewSpec with ExportsTestData wi
     }
 
     "display 'Back' button that links to 'containers summary' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
-      backLinkContainer.getElementById("link-back") must haveHref(
+      backLinkContainer.getElementById("back-link") must haveHref(
         controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
       )
     }

--- a/test/views/declaration/TransportContainerRemoveViewSpec.scala
+++ b/test/views/declaration/TransportContainerRemoveViewSpec.scala
@@ -55,10 +55,10 @@ class TransportContainerRemoveViewSpec extends UnitViewSpec with Stubs with Must
     }
 
     "display 'Back' button that links to 'container summary' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer must containText(realMessages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(
+      backLinkContainer.getElementById("back-link") must haveHref(
         controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
       )
     }

--- a/test/views/declaration/TransportContainerSummaryViewSpec.scala
+++ b/test/views/declaration/TransportContainerSummaryViewSpec.scala
@@ -70,10 +70,10 @@ class TransportContainerSummaryViewSpec extends UnitViewSpec with ExportsTestDat
     }
 
     "display 'Back' button that links to 'transport payment' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer.text() must be(realMessages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage(Mode.Normal))
+      backLinkContainer.getElementById("back-link") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/TransportPaymentViewSpec.scala
+++ b/test/views/declaration/TransportPaymentViewSpec.scala
@@ -44,10 +44,10 @@ class TransportPaymentViewSpec extends UnitViewSpec with ExportsTestData with St
     }
 
     "display 'Back' button that links to 'border transport' page" in {
-      val backLinkContainer = view.getElementById("link-back")
+      val backLinkContainer = view.getElementById("back-link")
 
       backLinkContainer must containText(realMessages(backCaption))
-      backLinkContainer.getElementById("link-back") must haveHref(controllers.declaration.routes.BorderTransportController.displayPage(Mode.Normal))
+      backLinkContainer.getElementById("back-link") must haveHref(controllers.declaration.routes.BorderTransportController.displayPage(Mode.Normal))
     }
 
     "display choices for payment method" in {

--- a/test/views/declaration/UNDangerousGoodsCodeViewSpec.scala
+++ b/test/views/declaration/UNDangerousGoodsCodeViewSpec.scala
@@ -56,9 +56,9 @@ class UNDangerousGoodsCodeViewSpec extends UnitViewSpec with ExportsTestData wit
     }
 
     "display 'Back' button that links to 'Package Information' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.CommodityDetailsController.displayPage(Mode.Normal, itemId))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/WarehouseIdentificationViewSpec.scala
+++ b/test/views/declaration/WarehouseIdentificationViewSpec.scala
@@ -68,10 +68,10 @@ class WarehouseIdentificationViewSpec extends UnitViewSpec with ExportsTestData 
     }
 
     "display 'Back' button that links to 'Items Summary' page" in {
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe "site.back"
-      backButton.getElementById("link-back") must haveHref(controllers.declaration.routes.ItemsSummaryController.displayPage(Mode.Normal))
+      backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.ItemsSummaryController.displayPage(Mode.Normal))
     }
 
     "display 'Save and continue' button on page" in {

--- a/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
+++ b/test/views/declaration/additionaldeclarationtype/DeclarationTypeViewSpec.scala
@@ -72,7 +72,7 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
     "display 'Back' button that links to 'Dispatch Location' page" when {
 
       "used for Standard Declaration journey" in {
-        val backButton = createView(formStandard, DeclarationType.STANDARD).getElementById("link-back")
+        val backButton = createView(formStandard, DeclarationType.STANDARD).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe routes.DispatchLocationController.displayPage().url
@@ -80,14 +80,14 @@ class DeclarationTypeViewSpec extends UnitViewSpec with ExportsTestData with Dec
 
       "used for Supplementary Declaration journey" in {
 
-        val backButton = createView(formSupplementary, DeclarationType.SUPPLEMENTARY).getElementById("link-back")
+        val backButton = createView(formSupplementary, DeclarationType.SUPPLEMENTARY).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe routes.DispatchLocationController.displayPage().url
       }
 
       "used for Simplified Declaration journey" in {
-        val backButton = createView(formSimplified, DeclarationType.SIMPLIFIED).getElementById("link-back")
+        val backButton = createView(formSimplified, DeclarationType.SIMPLIFIED).getElementById("back-link")
 
         backButton.text() mustBe messages(backCaption)
         backButton.attr("href") mustBe routes.DispatchLocationController.displayPage().url

--- a/test/views/declaration/destinationCountries/ChangeRoutingCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/ChangeRoutingCountryViewSpec.scala
@@ -56,7 +56,7 @@ class ChangeRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display back button that links to 'Countries summary' for first routing country page" in {
 
-      val backButton = firstRoutingView.getElementById("link-back")
+      val backButton = firstRoutingView.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.RoutingCountriesSummaryController.displayPage())
@@ -64,7 +64,7 @@ class ChangeRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display back button that links to 'Countries summary' for next routing country page" in {
 
-      val backButton = firstRoutingView.getElementById("link-back")
+      val backButton = firstRoutingView.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.RoutingCountriesSummaryController.displayPage())

--- a/test/views/declaration/destinationCountries/CountryOfRoutingViewSpec.scala
+++ b/test/views/declaration/destinationCountries/CountryOfRoutingViewSpec.scala
@@ -51,7 +51,7 @@ class CountryOfRoutingViewSpec extends UnitViewSpec with Stubs with ExportsTestD
 
     "display back button that links to 'Country of Routing question' page" in {
 
-      val backButton = firstRoutingView.getElementById("link-back")
+      val backButton = firstRoutingView.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.RoutingCountriesController.displayRoutingQuestion(fastForward = true))

--- a/test/views/declaration/destinationCountries/DestinationCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/DestinationCountryViewSpec.scala
@@ -60,7 +60,7 @@ class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
       "user is during Standard journey" in {
 
         val standardView = destinationCountryPage(Mode.Normal, form)(journeyRequest(DeclarationType.STANDARD), messages)
-        val backButton = standardView.getElementById("link-back")
+        val backButton = standardView.getElementById("back-link")
 
         backButton.text() mustBe messages("site.back")
         backButton must haveHref(routes.OriginationCountryController.displayPage())
@@ -69,7 +69,7 @@ class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
       "user is during Supplementary journey" in {
 
         val supplementaryView = destinationCountryPage(Mode.Normal, form)(journeyRequest(DeclarationType.SUPPLEMENTARY), messages)
-        val backButton = supplementaryView.getElementById("link-back")
+        val backButton = supplementaryView.getElementById("back-link")
 
         backButton.text() mustBe messages("site.back")
         backButton must haveHref(routes.OriginationCountryController.displayPage())
@@ -81,7 +81,7 @@ class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
       "user is during Simplified journey" in {
 
         val simplifiedView = destinationCountryPage(Mode.Normal, form)(journeyRequest(DeclarationType.SIMPLIFIED), messages)
-        val backButton = simplifiedView.getElementById("link-back")
+        val backButton = simplifiedView.getElementById("back-link")
 
         backButton.text() mustBe messages("site.back")
         backButton must haveHref(routes.DeclarationHolderController.displayPage())

--- a/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
@@ -57,7 +57,7 @@ class OriginationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
 
     "display back button that links to 'Declaration Holder' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.DeclarationHolderController.displayPage())

--- a/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
@@ -73,7 +73,7 @@ class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display back button that links to 'Countries summary' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.RoutingCountriesSummaryController.displayPage())

--- a/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
@@ -69,7 +69,7 @@ class RoutingCountriesSummaryViewSpec extends UnitViewSpec with Stubs with Expor
 
     "display back button that links to 'Destination country' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.DestinationCountryController.displayPage())

--- a/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
@@ -63,7 +63,7 @@ class RoutingCountryQuestionViewSpec extends UnitViewSpec with Stubs with Export
 
     "display back button that links to 'Declaration Holder' page" in {
 
-      val backButton = view.getElementById("link-back")
+      val backButton = view.getElementById("back-link")
 
       backButton.text() mustBe messages("site.back")
       backButton must haveHref(routes.DestinationCountryController.displayPage())

--- a/test/views/declaration/summary/SummaryPageViewSpec.scala
+++ b/test/views/declaration/summary/SummaryPageViewSpec.scala
@@ -56,18 +56,18 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
     "contain back button" when {
       "Draft Mode" in {
         val document = view(Mode.Draft)
-        document must containElementWithID("link-back")
-        document.getElementById("link-back") must haveHref(controllers.routes.SavedDeclarationsController.displayDeclarations())
-        document.getElementById("link-back") must containText("site.back")
+        document must containElementWithID("back-link")
+        document.getElementById("back-link") must haveHref(controllers.routes.SavedDeclarationsController.displayDeclarations())
+        document.getElementById("back-link") must containText("site.back")
       }
 
       "Amend Mode" when {
         "source id populated" in {
           val model = aDeclaration(withSourceId("source-id"))
           val document = view(Mode.Amend, model)
-          document must containElementWithID("link-back")
-          document.getElementById("link-back") must haveHref(controllers.routes.SubmissionsController.displayListOfSubmissions())
-          document.getElementById("link-back") must containText("supplementary.summary.back")
+          document must containElementWithID("back-link")
+          document.getElementById("back-link") must haveHref(controllers.routes.SubmissionsController.displayListOfSubmissions())
+          document.getElementById("back-link") must containText("supplementary.summary.back")
         }
       }
 
@@ -75,18 +75,18 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
         "standard declaration with containers links back to container summary" in {
           val model = aDeclaration(withType(DeclarationType.STANDARD), withContainerData(Container("1234", Seq.empty)))
           val document = view(Mode.Normal, model)
-          document must containElementWithID("link-back")
-          document.getElementById("link-back") must haveHref(
+          document must containElementWithID("back-link")
+          document.getElementById("back-link") must haveHref(
             controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
           )
-          document.getElementById("link-back") must containText("site.back")
+          document.getElementById("back-link") must containText("site.back")
         }
 
         "standard declaration without containers links back to container summary (which then re-directs to containers yes/no)" in {
           val model = aDeclaration(withType(DeclarationType.STANDARD))
           val document = view(Mode.Normal, model)
-          document must containElementWithID("link-back")
-          document.getElementById("link-back") must haveHref(
+          document must containElementWithID("back-link")
+          document.getElementById("back-link") must haveHref(
             controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
           )
         }
@@ -94,8 +94,8 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
         "supplementary declaration with containers links back to container summary" in {
           val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withContainerData(Container("1234", Seq.empty)))
           val document = view(Mode.Normal, model)
-          document must containElementWithID("link-back")
-          document.getElementById("link-back") must haveHref(
+          document must containElementWithID("back-link")
+          document.getElementById("back-link") must haveHref(
             controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
           )
         }
@@ -103,8 +103,8 @@ class SummaryPageViewSpec extends WordSpec with MustMatchers with ExportsDeclara
         "supplementary declaration without containers links back to container summary" in {
           val model = aDeclaration(withType(DeclarationType.SUPPLEMENTARY), withoutContainerData())
           val document = view(Mode.Normal, model)
-          document must containElementWithID("link-back")
-          document.getElementById("link-back") must haveHref(
+          document must containElementWithID("back-link")
+          document.getElementById("back-link") must haveHref(
             controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
           )
         }


### PR DESCRIPTION
Change back button HTML id from link-back to back-link
This is to align ourselves with the GDS design system compoenent.