### PR TITLE
CEDS-1126 Associate Data Cells with appropriate headers

### DIFF
--- a/app/views/components/fields/removable_elements_table.scala.html
+++ b/app/views/components/fields/removable_elements_table.scala.html
@@ -40,7 +40,7 @@
           <tbody>
             @for((elem, index) <- elements.zipWithIndex) {
                 <tr id="@{id}__row@index">
-                    <td scope="row" id="@{id}-row@index-label">@{elem.label}</td>
+                    <th scope="row" id="@{id}-row@index-label">@{elem.label}</th>
                     <td id="@{id}-row@index-remove_button">
                         @remove_button(element = elem, buttonClass = removeButtonClass, hint = removeButtonHint)
                     </td>

--- a/app/views/declaration/additional_information.scala.html
+++ b/app/views/declaration/additional_information.scala.html
@@ -57,7 +57,7 @@
                     <tbody>
                     @for((elem, index) <- items.zipWithIndex) {
                         <tr id="removable_elements__row@index">
-                            <td class="code-row" id="removable_elements-row@index-code" scope="row">@{elem.code}</td>
+                            <th class="code-row" id="removable_elements-row@index-code" scope="row">@{elem.code}</th>
                             <td class="description-row" id="removable_elements-row@index-info">@{elem.description}</td>
                             <td id="removable_elements-row@index-remove_button">
                                 @remove_button(element = LabelledValue(elem.toString))

--- a/app/views/declaration/declaration_additional_actors.scala.html
+++ b/app/views/declaration/declaration_additional_actors.scala.html
@@ -58,7 +58,7 @@
                 @for(actor <- actors) {
                   @defining(messages(s"supplementary.partyType.${actor.partyType.getOrElse("error")}")) { partyType =>
                       <tr>
-                          <td scope="row">@actor.eori</td>
+                          <th scope="row">@actor.eori</th>
                           <td>@partyType</td>
                           <td>
                           @components.buttons.remove_button(

--- a/app/views/declaration/documents_produced.scala.html
+++ b/app/views/declaration/documents_produced.scala.html
@@ -60,7 +60,7 @@
                 <tbody>
                 @documents.zipWithIndex.map { case (item, index) =>
                     <tr>
-                        <td scope="row" class="document-type">@item.documentTypeCode</td>
+                        <th scope="row" class="document-type">@item.documentTypeCode</th>
                         <td class="document-identifier">@item.documentIdentifier</td>
                         <td class="document-status">@item.documentStatus</td>
                         <td class="document-status-reason">@item.documentStatusReason</td>

--- a/app/views/declaration/items_summary.scala.html
+++ b/app/views/declaration/items_summary.scala.html
@@ -58,7 +58,7 @@
 
          @items.zipWithIndex.map { case (item, index) =>
                 <tr id="item_@index">
-                    <td id="item_@index--sequence_id" scope="row">@item.sequenceId</td>
+                    <th id="item_@index--sequence_id" scope="row">@item.sequenceId</th>
                     <td id="item_@index--procedure_code" scope="row">@item.procedureCodes.map(_.procedureCode).getOrElse("") </td>
                     <td id="item_@index--item_type" scope="row">@item.commodityDetails.map(_.combinedNomenclatureCode) </td>
                     <td id="item_@index--package_count" scope="row">
@@ -67,18 +67,18 @@
                         )
                         </ol>
                     </td>
-                    <td scope="row">
+                    <th scope="row">
                         <a id="item_@index--change" href="@routes.ProcedureCodesController.displayPage(mode, item.id)">
                             <span aria-hidden="true">@messages("site.change")</span>
                             <span class="visuallyhidden">@{messages("supplementary.itemsAdd.change.hint", item.sequenceId)}</span>
                         </a>
-                    </td>
-                    <td scope="row">
+                    </th>
+                    <th scope="row">
                         <a id="item_@index--remove" class="button button--gray" href="@routes.ItemsSummaryController.removeItem(mode, item.id)">
                             <span aria-hidden="true">@messages("site.remove")</span>
                             <span class="visuallyhidden">@{messages("supplementary.itemsAdd.remove.hint", item.sequenceId)}</span>
                         </a>
-                    </td>
+                    </th>
                 </tr>
             }
 

--- a/app/views/declaration/package_information.scala.html
+++ b/app/views/declaration/package_information.scala.html
@@ -69,7 +69,7 @@
                 <tbody>
                 @packages.zipWithIndex.map { case (item, index) =>
                 <tr>
-                    <td scope="row">@item.typesOfPackages</td>
+                    <th scope="row">@item.typesOfPackages</th>
                     <td>@item.numberOfPackages</td>
                     <td>@item.shippingMarks</td>
                     <td>

--- a/app/views/declaration/previous_documents.scala.html
+++ b/app/views/declaration/previous_documents.scala.html
@@ -62,7 +62,7 @@
                 <tbody>
                 @documents.zipWithIndex.map { case (document, index) =>
                 <tr>
-                    <td scope="row">@messages("supplementary.previousDocuments." + document.documentCategory)</td>
+                    <th scope="row">@messages("supplementary.previousDocuments." + document.documentCategory)</th>
                     <td>@document.documentType</td>
                     <td>@document.documentReference</td>
                     <td>@document.goodsItemIdentifier.getOrElse("")</td>

--- a/app/views/declaration/transport_container_summary.scala.html
+++ b/app/views/declaration/transport_container_summary.scala.html
@@ -56,7 +56,7 @@
                   <tbody>
                   @for((container, index) <- containers.zipWithIndex) {
                     <tr id="containers-row@index">
-                        <td scope="row" id="containers-row@index-container">@{container.id}</td>
+                        <th scope="row" id="containers-row@index-container">@{container.id}</th>
                         @if(container.seals.isEmpty){
                             <td id="containers-row@index-seals">@messages("standard.seal.summary.noSeals")</td>
                         } else {

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -50,13 +50,13 @@
 
         @for( (submission, notifications) <- submissions ){
             <tr class="table-row">
-                <td class="table-cell" scope="row">
+                <th class="table-cell" scope="row">
                     @if(notifications.exists(_.isStatusRejected)) {
                         <a href="@routes.RejectedNotificationsController.displayPage(submission.uuid)">@submission.ducr</a>
                     } else {
                         @submission.ducr
                     }
-                </td>
+                </th>
                 <td class="table-cell">@submission.lrn</td>
                 <td class="table-cell">@submission.mrn</td>
                 <td class="table-cell">@{submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.formatter.withZone(ZoneId.systemDefault()).format(_))}</td>

--- a/test/controllers/actions/JourneyActionSpec.scala
+++ b/test/controllers/actions/JourneyActionSpec.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2019 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package controllers.actions
 
 import models.requests.{AuthenticatedRequest, JourneyRequest}

--- a/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
@@ -250,7 +250,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe "Party’s EORI number"
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe "Party type"
 
-        view.select("table>tbody>tr>td:nth-child(1)").text() mustBe "12345"
+        view.select("table>tbody>tr>th:nth-child(1)").text() mustBe "12345"
         view.select("table>tbody>tr>td:nth-child(2)").text() mustBe "Consolidator"
 
         val removeButton = view.select("table>tbody>tr>td:nth-child(3)>button")

--- a/test/views/declaration/PackageInformationViewSpec.scala
+++ b/test/views/declaration/PackageInformationViewSpec.scala
@@ -166,7 +166,7 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
       view.select("form>table>thead>tr>td").text() must be("")
 
       // check row
-      view.select("table>tbody>tr>td:nth-child(1)").text() mustBe "PA"
+      view.select("table>tbody>tr>th:nth-child(1)").text() mustBe "PA"
       view.select("table>tbody>tr>td:nth-child(2)").text() mustBe "100"
       view.select("table>tbody>tr>td:nth-child(3)").text() mustBe "Shipping Mark"
     }
@@ -184,11 +184,11 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
       view.select("form>table>thead>tr>td").text() must be("")
 
       // check rows
-      view.select("table>tbody>tr>td:nth-child(1)").text() must include("PA")
+      view.select("table>tbody>tr>th:nth-child(1)").text() must include("PA")
       view.select("table>tbody>tr>td:nth-child(2)").text() must include("100")
       view.select("table>tbody>tr>td:nth-child(3)").text() must include("Shipping Mark")
 
-      view.select("table>tbody>tr:nth-child(2)>td:nth-child(1)").text() must include("PB")
+      view.select("table>tbody>tr:nth-child(2)>th:nth-child(1)").text() must include("PB")
       view.select("table>tbody>tr:nth-child(2)>td:nth-child(2)").text() must include("101")
       view.select("table>tbody>tr:nth-child(2)>td:nth-child(3)").text() must include("Shipping Mark")
     }

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -253,7 +253,7 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
       view.select("form>table>thead>tr>td").text() must be("")
 
       // row
-      view.select("form>table>tbody>tr>td:nth-child(1)").text() must be("supplementary.previousDocuments.X")
+      view.select("form>table>tbody>tr>th:nth-child(1)").text() must be("supplementary.previousDocuments.X")
       view.select("form>table>tbody>tr>td:nth-child(2)").text() must be("1")
       view.select("form>table>tbody>tr>td:nth-child(3)").text() must be("A")
       view.select("form>table>tbody>tr>td:nth-child(4)").text() must be("1")


### PR DESCRIPTION
As per https://webaim.org/techniques/tables/data#headers:

The scope attribute tells the browser and screen reader that everything
within a column that is associated to the header with scope="col" in
that column, and that a cell with scope="row" is a header for all
cells in that row.

All <th> elements should generally always have a scope attribute.