### PR TITLE
CEDS-2097 Word and paragraph wrap for key and value

### DIFF
--- a/app/assets/stylesheets/partials/_base.scss
+++ b/app/assets/stylesheets/partials/_base.scss
@@ -71,14 +71,16 @@ Styling for tables on "Check Your Answers Page"
   width: 30%;
   font-weight: bold;
   vertical-align: top;
+  word-break: break-word;
 }
 
 .exports-summary-list__value {
-  width: 50%;
+  width: 60%;
+  word-break: break-all;
 }
 
 .exports-summary-list__actions {
-  width: 20%;
+  width: 10%;
   padding-right: 0;
   text-align: right;
 }


### PR DESCRIPTION
This prevents the table `Change` link from missaligning on the summary
page if long words or long sentences are used.