### PR TITLE
CEDS-2084 - Change link for OSR should take the user to the correct page

### DIFF
--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -96,11 +96,7 @@ class AdditionalFiscalReferencesController @Inject()(
     val updatedCache = cacheModel.removeReference(value)
     updateExportsCache(itemId, updatedCache).map {
       case Some(_) =>
-        if (updatedCache.references.isEmpty) {
-          navigator.continueTo(routes.FiscalInformationController.displayPage(mode, itemId))
-        } else {
-          navigator.continueTo(routes.AdditionalFiscalReferencesController.displayPage(mode, itemId))
-        }
+        navigator.continueTo(routes.AdditionalFiscalReferencesController.displayPage(mode, itemId))
       case None => navigator.continueTo(routes.ItemsSummaryController.displayPage())
     }
   }

--- a/app/controllers/declaration/AdditionalFiscalReferencesController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesController.scala
@@ -96,7 +96,11 @@ class AdditionalFiscalReferencesController @Inject()(
     val updatedCache = cacheModel.removeReference(value)
     updateExportsCache(itemId, updatedCache).map {
       case Some(_) =>
-        navigator.continueTo(routes.AdditionalFiscalReferencesController.displayPage(mode, itemId))
+        if (updatedCache.references.isEmpty) {
+          navigator.continueTo(routes.FiscalInformationController.displayPage(mode, itemId))
+        } else {
+          navigator.continueTo(routes.AdditionalFiscalReferencesController.displayPage(mode, itemId))
+        }
       case None => navigator.continueTo(routes.ItemsSummaryController.displayPage())
     }
   }

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -41,7 +41,7 @@
     @helper.form(routes.CommodityDetailsController.submitForm(mode, itemId), 'autocomplete -> "off") {
         @helper.CSRF.formField
 
-        @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId), mode)
+        @components.back_link(routes.FiscalInformationController.displayPage(mode, itemId, fastForward = true), mode)
 
         @components.error_summary(form.errors)
 

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -165,7 +165,7 @@ POST        /items/:itemId/procedure-codes        controllers.declaration.Proced
 
 # Fiscal Information
 
-GET          /items/:itemId/fiscal-information    controllers.declaration.FiscalInformationController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId, fastForward: Boolean ?= true)
+GET          /items/:itemId/fiscal-information    controllers.declaration.FiscalInformationController.displayPage(mode: models.Mode ?= models.Mode.Normal, itemId, fastForward: Boolean ?= false)
 
 POST         /items/:itemId/fiscal-information   controllers.declaration.FiscalInformationController.saveFiscalInformation(mode: models.Mode ?= models.Mode.Normal, itemId)
 

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -58,10 +58,10 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
       view.getElementById(CommodityDetails.descriptionOfGoodsKey).text() mustBe expectedDescription
     }
 
-    "display 'Back' button that links to 'Package Information' page" in {
+    "display 'Back' button that links to 'Fiscal Information' page with 'fast-forward' enabled" in {
       val backButton = view.getElementById("back-link")
       backButton.getElementById("back-link") must haveHref(
-        controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId)
+        controllers.declaration.routes.FiscalInformationController.displayPage(Mode.Normal, itemId, fastForward = true)
       )
     }
 


### PR DESCRIPTION
This bug was due to the behaviour of the 'fast-forward' functionality on the fiscal references (yes/no) page.  The fix was to change the default behaviour of fast-forward from true to false - the only scenario that needs FF is when coming back from the next page (post additional fiscal references)