### PR TITLE
CEDS-2099 - container-change link on summary screen align with prototype

### DIFF
--- a/app/views/declaration/summary/transport_section.scala.html
+++ b/app/views/declaration/summary/transport_section.scala.html
@@ -96,15 +96,14 @@
             ))
         )
 
-        @declarationData.transport.containers.map(_ =>
-            components.table_row("containers", HtmlTableRow(
-                label = messages("declaration.summary.transport.containers"),
-                value = messages(if(declarationData.transport.hasContainers) "site.yes" else "site.no"),
-                call = Some(controllers.declaration.routes.TransportContainerController.displayContainerSummary()),
-                changeLabel = Some(messages("declaration.summary.transport.containers.change"))
+        @if(declarationData.transport.containers.exists(_.isEmpty)){
+            @components.table_row("containers", HtmlTableRow(
+              label = messages("declaration.summary.transport.containers"),
+              value = messages("site.no"),
+              call = Some(controllers.declaration.routes.TransportContainerController.displayContainerSummary()),
+              changeLabel = Some(messages("declaration.summary.transport.containers.change"))
             ))
-
-        )
+        }
 
         @declarationData.transport.containers.map(containerSeq =>
             containers(containerSeq)

--- a/test/views/declaration/summary/TransportSectionViewSpec.scala
+++ b/test/views/declaration/summary/TransportSectionViewSpec.scala
@@ -27,7 +27,7 @@ class TransportSectionViewSpec extends UnitViewSpec with ExportsTestData {
   val data = aDeclaration(
     withDepartureTransport("1", "10", "identifier"),
     withBorderTransport(Some("United Kingdom"), "11", "borderId"),
-    withContainerData(Container("123", Seq.empty)),
+    withContainerData(Seq.empty),
     withTransportPayment(Some(TransportPayment(Some("A"))))
   )
 
@@ -105,11 +105,11 @@ class TransportSectionViewSpec extends UnitViewSpec with ExportsTestData {
       view.getElementById("transport-payment-change") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage())
     }
 
-    "display information about containers with change button" in {
+    "display information about containers when user said 'No' with change button" in {
       val view = transport_section(data)(messages, journeyRequest())
 
       view.getElementById("containers-label").text() mustBe messages("declaration.summary.transport.containers")
-      view.getElementById("containers").text() mustBe "site.yes"
+      view.getElementById("containers").text() mustBe "site.no"
 
       val List(change, accessibleChange) = view.getElementById("containers-change").text().split(" ").toList
 

--- a/test/views/declaration/summary/TransportSectionViewSpec.scala
+++ b/test/views/declaration/summary/TransportSectionViewSpec.scala
@@ -168,11 +168,14 @@ class TransportSectionViewSpec extends UnitViewSpec with ExportsTestData {
       view.getElementById("container") mustBe null
     }
 
-    "display containers section if containers are not empty" in {
+    "display containers section (but not yes/no answer) if containers are not empty" in {
 
       val view = transport_section(aDeclaration(withContainerData(Container("123", Seq.empty))))(messages, journeyRequest())
 
       view.getElementById("container").text() mustNot be(empty)
+
+      view.getElementById("containers-label") mustBe null
+      view.getElementById("containers-change") mustBe null
     }
   }
 }


### PR DESCRIPTION
Removes the containers yes/no question when the answer is "yes".  The container summary section contains all links required to modify the containers/seals.  This solves the problem and is in line with the latest (v.29) prototype.