### PR TITLE
CEDS-2039 Skip 'Security Seals' page for Clearance Declarations

### DIFF
--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -24,6 +24,7 @@ import forms.common.YesNoAnswer.{form, YesNoAnswers}
 import forms.declaration.{ContainerAdd, ContainerFirst}
 import handlers.ErrorHandler
 import javax.inject.Inject
+import models.DeclarationType.CLEARANCE
 import models.declaration.Container
 import models.declaration.Container.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -33,7 +34,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
-import views.html.declaration.{transport_container_add, transport_container_add_first, transport_container_remove, transport_container_summary}
+import views.html.declaration._
 
 import scala.concurrent.{ExecutionContext, Future}
 
@@ -47,7 +48,9 @@ class TransportContainerController @Inject()(
   addFirstPage: transport_container_add_first,
   addPage: transport_container_add,
   summaryPage: transport_container_summary,
-  removePage: transport_container_remove
+  clearanceSummaryPage: transport_container_summary_clearance,
+  removePage: transport_container_remove,
+  clearanceRemovePage: transport_container_remove_clearance
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
@@ -76,7 +79,11 @@ class TransportContainerController @Inject()(
 
   def displayContainerSummary(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.containers match {
-      case containers if containers.nonEmpty => Ok(summaryPage(mode, YesNoAnswer.form(), containers))
+      case containers if containers.nonEmpty =>
+        request.declarationType match {
+          case CLEARANCE => Ok(clearanceSummaryPage(mode, YesNoAnswer.form(), containers))
+          case _         => Ok(summaryPage(mode, YesNoAnswer.form(), containers))
+        }
       case _ =>
         navigator.continueTo(mode, routes.TransportContainerController.displayAddContainer)
     }
@@ -93,8 +100,12 @@ class TransportContainerController @Inject()(
   def displayContainerRemove(mode: Mode, containerId: String): Action[AnyContent] =
     (authenticate andThen journeyType) { implicit request =>
       request.cacheModel.containerBy(containerId) match {
-        case Some(container) => Ok(removePage(mode, YesNoAnswer.form(), container))
-        case _               => navigator.continueTo(mode, routes.TransportContainerController.displayContainerSummary)
+        case Some(container) =>
+          request.declarationType match {
+            case CLEARANCE => Ok(clearanceRemovePage(mode, YesNoAnswer.form(), container))
+            case _         => Ok(removePage(mode, YesNoAnswer.form(), container))
+          }
+        case _ => navigator.continueTo(mode, routes.TransportContainerController.displayContainerSummary)
       }
     }
 
@@ -147,7 +158,13 @@ class TransportContainerController @Inject()(
     form()
       .bindFromRequest()
       .fold(
-        (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(summaryPage(mode, formWithErrors, request.cacheModel.containers))),
+        (formWithErrors: Form[YesNoAnswer]) =>
+          request.declarationType match {
+            case CLEARANCE =>
+              Future.successful(BadRequest(clearanceSummaryPage(mode, formWithErrors, request.cacheModel.containers)))
+            case _ =>
+              Future.successful(BadRequest(summaryPage(mode, formWithErrors, request.cacheModel.containers)))
+        },
         formData =>
           formData.answer match {
             case YesNoAnswers.yes =>
@@ -162,7 +179,12 @@ class TransportContainerController @Inject()(
       .bindFromRequest()
       .fold(
         (formWithErrors: Form[YesNoAnswer]) =>
-          Future.successful(BadRequest(removePage(mode, formWithErrors, request.cacheModel.containers.filter(_.id == containerId).head))),
+          request.declarationType match {
+            case CLEARANCE =>
+              Future.successful(BadRequest(clearanceRemovePage(mode, formWithErrors, request.cacheModel.containers.filter(_.id == containerId).head)))
+            case _ =>
+              Future.successful(BadRequest(removePage(mode, formWithErrors, request.cacheModel.containers.filter(_.id == containerId).head)))
+        },
         formData => {
           formData.answer match {
             case YesNoAnswers.yes =>
@@ -183,6 +205,8 @@ class TransportContainerController @Inject()(
     updateExportsDeclarationSyncDirect(_.updateContainers(updatedContainers))
 
   private def redirectAfterAdd(mode: Mode, containerId: String)(implicit request: JourneyRequest[AnyContent]) =
-    navigator.continueTo(mode, routes.SealController.displaySealSummary(_, containerId))
-
+    request.declarationType match {
+      case CLEARANCE => navigator.continueTo(mode, routes.TransportContainerController.displayContainerSummary)
+      case _         => navigator.continueTo(mode, routes.SealController.displaySealSummary(_, containerId))
+    }
 }

--- a/app/views/declaration/summary/clearance_containers.scala.html
+++ b/app/views/declaration/summary/clearance_containers.scala.html
@@ -1,0 +1,41 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import models.declaration.Container
+@import models.requests.JourneyRequest
+@import models.viewmodels.HtmlTableRow
+@import models.Mode
+
+@(mode: Mode, containers: Seq[Container])(implicit messages: Messages, journeyRequest: JourneyRequest[_])
+
+@if(containers.nonEmpty){
+    <caption class="heading-small"><span id="container">@messages("declaration.summary.container")</span></caption>
+    <tr class="section">
+        <td class="bold" colspan="2"><span id="container-id">@messages("declaration.summary.container.id")</span></td>
+        <td></td>
+    </tr>
+    @containers.zipWithIndex.map { case (container, index) =>
+        <tr class="section">
+            <td class="exports-summary-list__key_value" colspan="2"><span id="container-@index-id">@container.id</span></td>
+            <td class="exports-summary-list__actions">
+                <a href="@controllers.declaration.routes.TransportContainerController.displayContainerSummary(mode)" id="container-@index-change">
+                    <span aria-hidden="true">@messages("site.change")</span>
+                    <span class="visually-hidden">@messages("declaration.summary.container.change", container.id)</span>
+                </a>
+            </td>
+        </tr>
+    }
+}

--- a/app/views/declaration/summary/transport_section.scala.html
+++ b/app/views/declaration/summary/transport_section.scala.html
@@ -107,9 +107,11 @@
         }
 
         @declarationData.transport.containers.map(containerSeq =>
-            containers(mode, containerSeq)
+          journeyRequest.declarationType match {
+              case DeclarationType.CLEARANCE => clearance_containers(mode, containerSeq)
+              case _ => containers(mode, containerSeq)
+          }
         )
-
     }
     </div>
 }

--- a/app/views/declaration/transport_container_remove_clearance.scala.html
+++ b/app/views/declaration/transport_container_remove_clearance.scala.html
@@ -1,0 +1,72 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.declaration.routes._
+@import forms.common.YesNoAnswer
+@import forms.common.YesNoAnswer.YesNoAnswers._
+@import models.declaration.Container
+@import views.components.fields.LabelledValue
+@import views.components.inputs.RadioOption
+@import forms.declaration.Seal
+@import views.Title
+
+@this(main_template: views.html.main_template)
+
+@(mode: Mode, form: Form[YesNoAnswer], container: Container)(implicit request: Request[_], messages: Messages)
+
+
+@main_template(
+    title = Title("declaration.transportInformation.container.remove.title")
+) {
+
+    @components.back_link(controllers.declaration.routes.TransportContainerController.displayContainerSummary(mode), mode)
+
+    @components.error_summary(form.errors)
+
+    @components.heading(title = messages("declaration.transportInformation.container.remove.title"))
+
+    @helper.form(TransportContainerController.submitContainerRemove(mode, container.id), 'autoComplete -> "off") {
+        @helper.CSRF.formField
+
+        <div class="field-group mb-2">
+            <table id="container-table">
+                <thead>
+                    <tr>
+                        <th>@messages("declaration.transportInformation.containerId.title")</th>
+                    </tr>
+                </thead>
+                <tbody>
+                <tr>
+                    <td >@{container.id}</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
+
+        @components.fields.field_radio(
+            field = form("yesNo"),
+            legend = "",
+            inputs = Seq(
+                RadioOption("Yes", yes, messages("site.yes")),
+                RadioOption("No", no, messages("site.no"))
+            )
+        )
+
+        @components.submit_button()
+        @components.buttons.save_and_return_later_button()
+    }
+}
+

--- a/app/views/declaration/transport_container_summary_clearance.scala.html
+++ b/app/views/declaration/transport_container_summary_clearance.scala.html
@@ -1,0 +1,82 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import controllers.declaration.routes._
+@import controllers.navigation.Navigator
+@import forms.common.YesNoAnswer
+@import forms.common.YesNoAnswer.YesNoAnswers._
+@import forms.declaration.ContainerFirst
+@import models.declaration.Container
+@import models.requests.JourneyRequest
+@import views.Title
+@import views.components.fields.LabelledValue
+@import views.components.inputs.RadioOption
+@import views.html.components.buttons.remove_button
+
+@this(main_template: views.html.main_template)
+
+@(mode: Mode, form: Form[YesNoAnswer], containers: Seq[Container])(implicit request: JourneyRequest[_], messages: Messages)
+
+@main_template(
+    title = Title("declaration.transportInformation.containers.title")
+) {
+
+    @components.back_link(Navigator.backLink(ContainerFirst, mode))
+
+    @components.error_summary(form.errors)
+
+    @components.heading(title = messages("declaration.transportInformation.containers.title"))
+
+    @helper.form(TransportContainerController.submitSummaryAction(mode), 'autoComplete -> "off") {
+        @helper.CSRF.formField
+
+        @if(containers.nonEmpty) {
+
+            <div class="field-group mb-2">
+                <table id="container-table">
+                  <thead>
+                      <tr>
+                          <th scope="col" colspan="2">@messages("declaration.transportInformation.containerId.title")</th>
+                      </tr>
+                  </thead>
+                  <tbody>
+                  @for((container, index) <- containers.zipWithIndex) {
+                    <tr id="containers-row@index">
+                        <th scope="row" id="containers-row@index-container">@{container.id}</th>
+                        <td id="containers-row@index-remove_button">
+                            @remove_button(element = LabelledValue(container.id), buttonClass="button-link", label="declaration.transportInformation.containers.remove", hint="declaration.transportInformation.containers.remove.hint")
+                        </td>
+                    </tr>
+                  }
+                  </tbody>
+                </table>
+            </div>
+        }
+
+        @components.fields.field_radio(
+            field = form("yesNo"),
+            legend = messages("declaration.transportInformation.containers.add"),
+            inputs = Seq(
+                RadioOption("Yes", yes, messages("site.yes")),
+                RadioOption("No", no, messages("site.no"))
+            )
+        )
+
+        @components.submit_button()
+        @components.buttons.save_and_return_later_button()
+    }
+
+}

--- a/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
@@ -32,7 +32,9 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
     val transportContainersAddFirstPage = new transport_container_add_first(mainTemplate)
     val transportContainersAddPage = new transport_container_add(mainTemplate)
     val transportContainersRemovePage = new transport_container_remove(mainTemplate)
+    val transportClearanceContainersRemovePage = new transport_container_remove_clearance(mainTemplate)
     val transportContainersSummaryPage = new transport_container_summary(mainTemplate)
+    val transportClearanceContainersSummaryPage = new transport_container_summary_clearance(mainTemplate)
 
     val controller = new TransportContainerController(
       mockAuthAction,
@@ -44,7 +46,9 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
       transportContainersAddFirstPage,
       transportContainersAddPage,
       transportContainersSummaryPage,
-      transportContainersRemovePage
+      transportClearanceContainersSummaryPage,
+      transportContainersRemovePage,
+      transportClearanceContainersRemovePage
     )(ec)
 
     authorizedUser()
@@ -121,6 +125,23 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
   }
 
   "Transport Container submit add page" should {
+
+    "add first container and redirect to containers Summary page" when {
+
+      val requestBody = Seq(ContainerFirst.hasContainerKey -> "Yes", ContainerFirst.containerIdKey -> "value")
+
+      "working on clearance declaration with cache empty" in new SetUp {
+        withNewCaching(aDeclaration(withType(DeclarationType.CLEARANCE)))
+
+        val result = controller.submitAddContainer(Mode.Normal)(postRequestAsFormUrlEncoded(requestBody: _*))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.TransportContainerController
+          .displayContainerSummary(Mode.Normal)
+
+        theCacheModelUpdated.containers mustBe Seq(Container("value", Seq.empty))
+      }
+    }
 
     "add first container and redirect to add seal page" when {
 

--- a/test/views/declaration/TransportClearanceContainerRemoveViewSpec.scala
+++ b/test/views/declaration/TransportClearanceContainerRemoveViewSpec.scala
@@ -1,0 +1,86 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration
+
+import forms.common.YesNoAnswer
+import forms.declaration.Seal
+import helpers.views.declaration.CommonMessages
+import models.Mode
+import models.declaration.Container
+import org.jsoup.nodes.Document
+import org.scalatest.MustMatchers
+import play.api.data.Form
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.transport_container_remove
+import views.tags.ViewTest
+
+@ViewTest
+class TransportClearanceContainerRemoveViewSpec extends UnitViewSpec with Stubs with MustMatchers with CommonMessages {
+
+  val containerId = "434732435324"
+  val sealId = "934545754"
+  val container = Container(containerId, Seq(Seal(sealId)))
+  private val realMessages = validatedMessages
+  private val form: Form[YesNoAnswer] = YesNoAnswer.form()
+  private val page = new transport_container_remove(mainTemplate)
+
+  private def createView(form: Form[YesNoAnswer] = form, container: Container = container): Document =
+    page(Mode.Normal, form, container)(request, realMessages)
+
+  "Transport Containers Remove View" should {
+    val view = createView()
+
+    "display page title" in {
+      view.getElementById("title").text() must be(realMessages("declaration.transportInformation.container.remove.title"))
+    }
+
+    "display container and seal to remove" in {
+      view.getElementById("container-table").text() must include(containerId)
+      view.getElementById("container-table").text() must include(sealId)
+    }
+
+    "display 'Back' button that links to 'container summary' page" in {
+      val backLinkContainer = view.getElementById("back-link")
+
+      backLinkContainer must containText(realMessages(backCaption))
+      backLinkContainer.getElementById("back-link") must haveHref(
+        controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
+      )
+    }
+
+    "display 'Save and continue' button on page" in {
+      val saveButton = view.getElementById("submit")
+      saveButton must containText(realMessages(saveAndContinueCaption))
+    }
+
+    "display 'Save and return' button on page" in {
+      val saveAndReturnButton = view.getElementById("submit_and_return")
+      saveAndReturnButton must containText(realMessages(saveAndReturnCaption))
+    }
+  }
+
+  "Seal Remove View for invalid input" should {
+
+    "display error if nothing is entered" in {
+      val view = createView(YesNoAnswer.form().bind(Map[String, String]()))
+
+      view.select("#error-message-yesNo-input").text() must be(realMessages("error.yesNo.required"))
+    }
+
+  }
+}

--- a/test/views/declaration/TransportContainerRemoveClearanceViewSpec.scala
+++ b/test/views/declaration/TransportContainerRemoveClearanceViewSpec.scala
@@ -1,0 +1,83 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration
+
+import forms.common.YesNoAnswer
+import helpers.views.declaration.CommonMessages
+import models.Mode
+import models.declaration.Container
+import org.jsoup.nodes.Document
+import org.scalatest.MustMatchers
+import play.api.data.Form
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.transport_container_remove_clearance
+import views.tags.ViewTest
+
+@ViewTest
+class TransportContainerRemoveClearanceViewSpec extends UnitViewSpec with Stubs with MustMatchers with CommonMessages {
+
+  val containerId = "434732435324"
+  val container = Container(containerId, Seq.empty)
+  private val realMessages = validatedMessages
+  private val form: Form[YesNoAnswer] = YesNoAnswer.form()
+  private val page = new transport_container_remove_clearance(mainTemplate)
+
+  private def createView(form: Form[YesNoAnswer] = form, container: Container = container): Document =
+    page(Mode.Normal, form, container)(request, realMessages)
+
+  "Transport Containers Remove View" should {
+    val view = createView()
+
+    "display page title" in {
+      view.getElementById("title").text() must be(realMessages("declaration.transportInformation.container.remove.title"))
+    }
+
+    "display container to remove" in {
+      view.getElementById("container-table").text() must include(containerId)
+    }
+
+    "display 'Back' button that links to 'container summary' page" in {
+      val backLinkContainer = view.getElementById("back-link")
+
+      backLinkContainer must containText(realMessages(backCaption))
+      backLinkContainer.getElementById("back-link") must haveHref(
+        controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)
+      )
+    }
+
+    "display 'Save and continue' button on page" in {
+      val saveButton = view.getElementById("submit")
+      saveButton must containText(realMessages(saveAndContinueCaption))
+    }
+
+    "display 'Save and return' button on page" in {
+      val saveAndReturnButton = view.getElementById("submit_and_return")
+      saveAndReturnButton must containText(realMessages(saveAndReturnCaption))
+    }
+  }
+
+  "Remove View for invalid input" should {
+
+    "display error if nothing is entered" in {
+      val view = createView(YesNoAnswer.form().bind(Map[String, String]()))
+
+      view.select("#error-message-yesNo-input").text() must be(realMessages("error.yesNo.required"))
+    }
+
+  }
+}

--- a/test/views/declaration/TransportContainerSummaryClearanceViewSpec.scala
+++ b/test/views/declaration/TransportContainerSummaryClearanceViewSpec.scala
@@ -1,0 +1,77 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration
+
+import forms.common.YesNoAnswer
+import helpers.views.declaration.CommonMessages
+import models.Mode
+import models.declaration.Container
+import org.jsoup.nodes.Document
+import org.scalatest.MustMatchers
+import play.api.data.Form
+import services.cache.ExportsTestData
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.transport_container_summary_clearance
+import views.tags.ViewTest
+
+@ViewTest
+class TransportContainerSummaryClearanceViewSpec extends UnitViewSpec with ExportsTestData with Stubs with MustMatchers with CommonMessages {
+
+  private val containerId = "212374"
+  private val container = Container(containerId, Seq.empty)
+  private val realMessages = validatedMessages
+  private val form: Form[YesNoAnswer] = YesNoAnswer.form()
+  private val page = new transport_container_summary_clearance(mainTemplate)
+
+  private def createView(form: Form[YesNoAnswer] = form, containers: Seq[Container] = Seq(container)): Document =
+    page(Mode.Normal, form, containers)(journeyRequest(), realMessages)
+
+  "Transport Containers Summary View" should {
+    val view = createView()
+
+    "display page title" in {
+      view.getElementById("title").text() must be(realMessages("declaration.transportInformation.containers.title"))
+    }
+
+    "display 'Back' button that links to 'transport payment' page" in {
+      val backLinkContainer = view.getElementById("back-link")
+
+      backLinkContainer.text() must be(realMessages(backCaption))
+      backLinkContainer.getElementById("back-link") must haveHref(controllers.declaration.routes.TransportPaymentController.displayPage(Mode.Normal))
+    }
+
+    "display 'Save and continue' button on page" in {
+      val saveButton = view.getElementById("submit")
+      saveButton.text() must be(realMessages(saveAndContinueCaption))
+    }
+
+    "display 'Save and return' button on page" in {
+      val saveAndReturnButton = view.getElementById("submit_and_return")
+      saveAndReturnButton.text() must be(realMessages(saveAndReturnCaption))
+    }
+  }
+
+  "Transport Containers Summary View for invalid input" should {
+
+    "display error if nothing is entered" in {
+      val view = createView(YesNoAnswer.form().bind(Map[String, String]()))
+
+      view.select("#error-message-yesNo-input").text() must be(realMessages("error.yesNo.required"))
+    }
+  }
+}

--- a/test/views/declaration/summary/ClearanceContainersViewSpec.scala
+++ b/test/views/declaration/summary/ClearanceContainersViewSpec.scala
@@ -1,0 +1,64 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration.summary
+
+import models.Mode
+import models.declaration.Container
+import services.cache.ExportsTestData
+import views.declaration.spec.UnitViewSpec
+import views.html.declaration.summary
+
+class ClearanceContainersViewSpec extends UnitViewSpec with ExportsTestData {
+
+  val firstContainerID = "951357"
+  val secondContainerID = "456789"
+  val containerOne = Container(firstContainerID, Seq.empty)
+  val containerTwo = Container(secondContainerID, Seq.empty)
+  val containers = Seq(containerOne, containerTwo)
+
+  "Containers" should {
+
+    "display all containers and seals" in {
+
+      val view = summary.clearance_containers(Mode.Normal, containers)(messages, journeyRequest())
+
+      view.getElementById("container").text() mustBe messages("declaration.summary.container")
+      view.getElementById("container-id").text() mustBe messages("declaration.summary.container.id")
+      view.getElementById("container-0-id").text() mustBe firstContainerID
+      view.getElementById("container-1-id").text() mustBe secondContainerID
+    }
+
+    "display change buttons for every container" in {
+
+      val view = summary.clearance_containers(Mode.Normal, containers)(messages, journeyRequest())
+
+      val List(change1, accessibleChange1) = view.getElementById("container-0-change").text().split(" ").toList
+
+      change1 mustBe messages("site.change")
+      accessibleChange1 mustBe messages("declaration.summary.container.change", firstContainerID)
+
+      view.getElementById("container-0-change") must haveHref(controllers.declaration.routes.TransportContainerController.displayContainerSummary())
+
+      val List(change2, accessibleChange2) = view.getElementById("container-1-change").text().split(" ").toList
+
+      change2 mustBe messages("site.change")
+      accessibleChange2 mustBe messages("declaration.summary.container.change", secondContainerID)
+
+      view.getElementById("container-1-change") must haveHref(controllers.declaration.routes.TransportContainerController.displayContainerSummary())
+    }
+  }
+}


### PR DESCRIPTION
* Skip `containers/container-id/seals` page
 * The `back link` should not point to the seals page.
 * Remove the Security seals column and the Change Seals from the
   `/declaration/containers` page
 * Do not show Seals info in the Summary page