### PR TITLE
CEDS-1760 - Country error link does not target country input box

### DIFF
--- a/app/assets/javascripts/autocomplete.js
+++ b/app/assets/javascripts/autocomplete.js
@@ -7,11 +7,11 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     .insertAfter(this.element);
 
                 this.element.hide();
-                this._createAutocomplete(this.element.attr("id"));
+                this._createAutocomplete();
                 this._createShowAllButton();
             },
 
-            _createAutocomplete: function (parentId) {
+            _createAutocomplete: function () {
                 var selected = this.element.children(":selected"),
                     value = selected.val() ? selected.text() : "";
 
@@ -27,7 +27,6 @@ document.addEventListener("DOMContentLoaded", function (event) {
                     .appendTo(this.comboBoxLabel)   
                     .val(value)
                     .attr("autocomplete", "off")
-                    .attr("id", parentId.replace(/\./g, "_"))
                     .addClass("custom-combobox-input ui-state-default ui-corner-left form-control")
                     .autocomplete({
                         delay: 0,

--- a/app/views/components/fields/field_autocomplete.scala.html
+++ b/app/views/components/fields/field_autocomplete.scala.html
@@ -24,7 +24,7 @@ JQuery treats [] as element's attribute and tried evaluated this.
 To avoid problems, we need to remove [] from field.
 *@
 @fieldNameWithoutBrackets = @{
-    field.name.replace("[]", "")
+    field.name.replace("[]", "").replace(".", "_")
 }
 
 @elements = @{

--- a/app/views/components/inputs/input_autocomplete.scala.html
+++ b/app/views/components/inputs/input_autocomplete.scala.html
@@ -24,7 +24,7 @@ JQuery treats [] as element's attribute and tried evaluated this.
 To avoid problems, we need to remove [] from field.
 *@
 @fieldNameWithoutBrackets = @{
-    field.name.replace("[]", "")
+    field.name.replace("[]", "").replace(".", "_")
 }
 
 @fieldNameForJQuery = @{

--- a/docs/Customs Declare Exports AutoComplete.js
+++ b/docs/Customs Declare Exports AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Customs Declare Exports AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      1.21
+// @version      1.22
 // @description  decs supported: (Std-Frontier A), (Occ-Frontier B), (Smp-Frontier C), (Std-PreLodged D), (Occ-PreLodged E), (Smp-PreLodged F), (Clr-Frontier J), (Clr-PreLodged K)
 // @author       You
 // @match        http*://*/customs-declare-exports*
@@ -224,7 +224,7 @@ function consigneeDetails(){
         document.getElementById('details_address_townOrCity').value = 'New York';
         document.getElementById('details_address_postCode').value = '10001';
 
-        selectFromAutoPredict(document.getElementById('details.address.country-container'), "United States of America");
+        selectFromAutoPredict(document.getElementById('details_address_country-container'), "United States of America");
         document.getElementsByClassName('button')[0].click()
     }
 }
@@ -278,7 +278,7 @@ function carrierDetails() {
         document.getElementById('details_address_addressLine').value = 'School Road';
         document.getElementById('details_address_townOrCity').value = 'London';
         document.getElementById('details_address_postCode').value = 'WS1 2AB';
-        selectFromAutoPredict(document.getElementById('details.address.country-container'), "United Kingdom");
+        selectFromAutoPredict(document.getElementById('details_address_country-container'), "United Kingdom");
         document.getElementsByClassName('button')[0].click()
     }
 }
@@ -339,7 +339,7 @@ function holderOfAuthorisation(){
             case 'K':
                 document.getElementsByClassName('button')[0].click();
                 break;
-       }
+        }
     }
 }
 
@@ -536,7 +536,7 @@ function commodityDetails(){
             case 'F':
                 document.getElementById('combinedNomenclatureCode').value ='84111100';
                 document.getElementById('descriptionOfGoods').value ='Aircraft engine';
-            break;
+                break;
             default:
                 document.getElementById('combinedNomenclatureCode').value ='46021910';
                 document.getElementById('descriptionOfGoods').value ='Straw for bottles';
@@ -556,7 +556,7 @@ function unDangerousGoodsCode(){
             case 'F':
             case 'K':
                 document.getElementById('code_no').checked = 'checked';
-            break;
+                break;
             default:
                 document.getElementById('code_yes').checked = 'checked';
                 document.getElementById('dangerousGoodsCode').value ='1234';
@@ -647,7 +647,7 @@ function additionalInformation(){
                 } else {
                     document.getElementsByClassName('button')[0].click()
                 }
-            break;
+                break;
             case 'K':
                 document.getElementById('code').value ='00600';
                 document.getElementById('description').value ='EXPORTER';
@@ -712,7 +712,7 @@ function addDocuments(){
                 document.getElementById('documentTypeCode').value ='C501';
                 document.getElementById('documentIdentifier').value ='GBAEOC717572504502811';
                 document.getElementsByClassName('button')[0].click()
-       }
+        }
     }
 }
 

--- a/test/views/declaration/CarrierDetailsViewSpec.scala
+++ b/test/views/declaration/CarrierDetailsViewSpec.scala
@@ -100,8 +100,8 @@ class CarrierDetailsViewSpec extends UnitViewSpec with CommonMessages with Stubs
 
       "display empty input with label for Country" in {
 
-        view.getElementById("details.address.country-label").text() mustBe "supplementary.address.country"
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country-label").text() mustBe "supplementary.address.country"
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display 'Back' button that links to 'Representative Details' page" in {
@@ -431,7 +431,7 @@ class CarrierDetailsViewSpec extends UnitViewSpec with CommonMessages with Stubs
         view.getElementById("details_address_addressLine").attr("value") mustBe empty
         view.getElementById("details_address_townOrCity").attr("value") mustBe empty
         view.getElementById("details_address_postCode").attr("value") mustBe empty
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display data in Business address inputs" in {
@@ -446,7 +446,7 @@ class CarrierDetailsViewSpec extends UnitViewSpec with CommonMessages with Stubs
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "test4"
+        view.getElementById("details_address_country").attr("value") mustBe "test4"
       }
 
       "display data in both EORI and Business address inputs" in {
@@ -461,7 +461,7 @@ class CarrierDetailsViewSpec extends UnitViewSpec with CommonMessages with Stubs
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "test4"
+        view.getElementById("details_address_country").attr("value") mustBe "test4"
       }
     }
   }

--- a/test/views/declaration/ConsigneeDetailsViewSpec.scala
+++ b/test/views/declaration/ConsigneeDetailsViewSpec.scala
@@ -105,8 +105,8 @@ class ConsigneeDetailsViewSpec extends UnitViewSpec with CommonMessages with Stu
 
         val view = createView()
 
-        view.getElementById("details.address.country-label").text() mustBe messages("supplementary.address.country")
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country-label").text() mustBe messages("supplementary.address.country")
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display 'Back' button that links to 'Exporter Details' page" in {
@@ -436,7 +436,7 @@ class ConsigneeDetailsViewSpec extends UnitViewSpec with CommonMessages with Stu
         view.getElementById("details_address_addressLine").attr("value") mustBe empty
         view.getElementById("details_address_townOrCity").attr("value") mustBe empty
         view.getElementById("details_address_postCode").attr("value") mustBe empty
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display data in Business address inputs" in {
@@ -451,7 +451,7 @@ class ConsigneeDetailsViewSpec extends UnitViewSpec with CommonMessages with Stu
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "Ukraine"
+        view.getElementById("details_address_country").attr("value") mustBe "Ukraine"
       }
 
       "display data in both EORI and Business address inputs" in {
@@ -466,7 +466,7 @@ class ConsigneeDetailsViewSpec extends UnitViewSpec with CommonMessages with Stu
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "test4"
+        view.getElementById("details_address_country").attr("value") mustBe "test4"
       }
     }
   }

--- a/test/views/declaration/ExporterDetailsViewSpec.scala
+++ b/test/views/declaration/ExporterDetailsViewSpec.scala
@@ -98,8 +98,8 @@ class ExporterDetailsViewSpec extends UnitViewSpec with CommonMessages with Stub
 
         val view = createView()
 
-        view.getElementById("details.address.country-label").text() mustBe messages("supplementary.address.country")
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country-label").text() mustBe messages("supplementary.address.country")
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display 'Back' button that links to 'Consignment References' page" in {
@@ -430,7 +430,7 @@ class ExporterDetailsViewSpec extends UnitViewSpec with CommonMessages with Stub
         view.getElementById("details_address_addressLine").attr("value") mustBe empty
         view.getElementById("details_address_townOrCity").attr("value") mustBe empty
         view.getElementById("details_address_postCode").attr("value") mustBe empty
-        view.getElementById("details.address.country").attr("value") mustBe empty
+        view.getElementById("details_address_country").attr("value") mustBe empty
       }
 
       "display data in Business address inputs" in {
@@ -445,7 +445,7 @@ class ExporterDetailsViewSpec extends UnitViewSpec with CommonMessages with Stub
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "test4"
+        view.getElementById("details_address_country").attr("value") mustBe "test4"
       }
 
       "display data in both EORI and Business address inputs" in {
@@ -460,7 +460,7 @@ class ExporterDetailsViewSpec extends UnitViewSpec with CommonMessages with Stub
         view.getElementById("details_address_addressLine").attr("value") mustBe "test1"
         view.getElementById("details_address_townOrCity").attr("value") mustBe "test2"
         view.getElementById("details_address_postCode").attr("value") mustBe "test3"
-        view.getElementById("details.address.country").attr("value") mustBe "test4"
+        view.getElementById("details_address_country").attr("value") mustBe "test4"
       }
     }
   }

--- a/test/views/declaration/RepresentativeDetailsViewSpec.scala
+++ b/test/views/declaration/RepresentativeDetailsViewSpec.scala
@@ -93,8 +93,8 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
     }
 
     "display empty input with label for Country" in {
-      view.getElementById("details.address.country-label").text() mustBe "supplementary.address.country"
-      view.getElementById("details.address.country").attr("value") mustBe empty
+      view.getElementById("details_address_country-label").text() mustBe "supplementary.address.country"
+      view.getElementById("details_address_country").attr("value") mustBe empty
     }
 
     "display three radio buttons with description (not selected)" in {
@@ -424,7 +424,7 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
         )
 
         checkErrorsSummary(view)
-        haveFieldErrorLink("details.address.country", "#details_address_country")
+        haveFieldErrorLink("details_address_country", "#details_address_country")
 
         view.select("span.error-message").text() must be("supplementary.address.country.empty")
       }
@@ -1007,7 +1007,7 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
         view.getElementById("details_address_addressLine").attr("value") must be("test1")
         view.getElementById("details_address_townOrCity").attr("value") must be("test2")
         view.getElementById("details_address_postCode").attr("value") must be("test3")
-        view.getElementById("details.address.country").attr("value") must be("test4")
+        view.getElementById("details_address_country").attr("value") must be("test4")
       }
     }
 
@@ -1055,7 +1055,7 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
         view.getElementById("details_address_addressLine").attr("value") must be("test1")
         view.getElementById("details_address_townOrCity").attr("value") must be("test2")
         view.getElementById("details_address_postCode").attr("value") must be("test3")
-        view.getElementById("details.address.country").attr("value") must be("test4")
+        view.getElementById("details_address_country").attr("value") must be("test4")
         view.getElementById("statusCode_direct").attr("checked") must be("checked")
       }
     }
@@ -1104,7 +1104,7 @@ class RepresentativeDetailsViewSpec extends UnitViewSpec with ExportsTestData wi
         view.getElementById("details_address_addressLine").attr("value") must be("test1")
         view.getElementById("details_address_townOrCity").attr("value") must be("test2")
         view.getElementById("details_address_postCode").attr("value") must be("test3")
-        view.getElementById("details.address.country").attr("value") must be("test4")
+        view.getElementById("details_address_country").attr("value") must be("test4")
         view.getElementById("statusCode_indirect").attr("checked") must be("checked")
       }
     }


### PR DESCRIPTION
This PR revert first attempt at fix which was causing duplicate ids on other pages.   The issue of 1760 was addressed by replacing '.' with '_' in the id of autocomplete elements.  This results in correct links but without focus being set to the autocompete input field.