### PR TITLE
CEDS-2120: EORI is not accepted by DMS if it starts with lowercase letters

### DIFF
--- a/app/forms/common/Eori.scala
+++ b/app/forms/common/Eori.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.common
+
+import play.api.data.Forms.text
+import play.api.data.Mapping
+import play.api.libs.json.{Format, JsResult, JsString, JsValue, Reads}
+import utils.validators.forms.FieldValidator._
+
+case class Eori(value: String) {
+  override def toString() = value
+}
+
+object Eori {
+  def build(value: String): Eori = new Eori(value.toUpperCase)
+
+  implicit val format: Format[Eori] = new Format[Eori] {
+    override def writes(o: Eori): JsValue = JsString(o.value)
+
+    private val mappedReads = Reads.StringReads.map(value => Eori.build(value))
+
+    override def reads(json: JsValue): JsResult[Eori] = mappedReads.reads(json)
+  }
+
+  def mapping(errorPrefix: String): Mapping[Eori] =
+    text()
+      .verifying(s"${errorPrefix}.eori.empty", nonEmpty)
+      .verifying(s"${errorPrefix}.eori.error.format", isValidEORIPattern and noLongerThan(17) and noShorterThan(3))
+      .transform(build, unapply(_).getOrElse(""))
+}

--- a/app/forms/declaration/DeclarantDetails.scala
+++ b/app/forms/declaration/DeclarantDetails.scala
@@ -15,11 +15,11 @@
  */
 
 package forms.declaration
+
 import forms.DeclarationPage
-import play.api.data.Forms.text
+import forms.common.Eori
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
-import utils.validators.forms.FieldValidator._
 
 case class DeclarantDetails(details: EntityDetails)
 

--- a/app/forms/declaration/DeclarationAdditionalActors.scala
+++ b/app/forms/declaration/DeclarationAdditionalActors.scala
@@ -17,6 +17,7 @@
 package forms.declaration
 
 import forms.DeclarationPage
+import forms.common.Eori
 import forms.declaration.DeclarationAdditionalActors.PartyType
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms}
@@ -24,7 +25,7 @@ import play.api.libs.json.{JsValue, Json}
 import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfNot
 import utils.validators.forms.FieldValidator._
 
-case class DeclarationAdditionalActors(eori: Option[String], partyType: Option[String]) {
+case class DeclarationAdditionalActors(eori: Option[Eori], partyType: Option[String]) {
 
   def isDefined: Boolean = eori.isDefined && partyType.isDefined
 
@@ -43,7 +44,7 @@ object DeclarationAdditionalActors extends DeclarationPage {
   val formId = "DeclarationAdditionalActors"
 
   val mapping = Forms.mapping(
-    "eori" -> optional(text().verifying("supplementary.eori.error.format", isValidEORIPattern and noLongerThan(17) and noShorterThan(3))),
+    "eori" -> optional(Eori.mapping("supplementary")),
     "partyType" -> mandatoryIfNot(
       "eori",
       "",

--- a/app/forms/declaration/DeclarationHolder.scala
+++ b/app/forms/declaration/DeclarationHolder.scala
@@ -17,13 +17,14 @@
 package forms.declaration
 
 import forms.DeclarationPage
+import forms.common.Eori
 import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
 import services.HolderOfAuthorisationCode
 import utils.validators.forms.FieldValidator._
 
-case class DeclarationHolder(authorisationTypeCode: Option[String], eori: Option[String]) {
+case class DeclarationHolder(authorisationTypeCode: Option[String], eori: Option[Eori]) {
   override def toString: String = s"${authorisationTypeCode.getOrElse("")}-${eori.getOrElse("")}"
 }
 
@@ -35,17 +36,17 @@ object DeclarationHolder extends DeclarationPage {
       text()
         .verifying("supplementary.declarationHolder.authorisationCode.invalid", isContainedIn(HolderOfAuthorisationCode.all.map(_.value)))
     ),
-    "eori" -> optional(text().verifying("supplementary.eori.error.format", isValidEORIPattern and noLongerThan(17) and noShorterThan(3)))
+    "eori" -> optional(Eori.mapping("supplementary"))
   )(DeclarationHolder.apply)(DeclarationHolder.unapply)
 
   def form(): Form[DeclarationHolder] = Form(mapping)
 
   // Method for parse format typeCode-eori
   def buildFromString(value: String): DeclarationHolder = {
-    val dividedString = value.split('-')
+    val dividedString: Array[String] = value.split('-')
 
     if (dividedString.length == 0) DeclarationHolder(None, None)
     else if (dividedString.length == 1) DeclarationHolder(Some(value.split('-')(0)), None)
-    else DeclarationHolder(Some(value.split('-')(0)), Some(value.split('-')(1)))
+    else DeclarationHolder(Some(value.split('-')(0)), Some(Eori(value.split('-')(1))))
   }
 }

--- a/app/forms/declaration/EntityDetails.scala
+++ b/app/forms/declaration/EntityDetails.scala
@@ -16,30 +16,10 @@
 
 package forms.declaration
 
-import forms.common.Address
-import play.api.data.Forms.{optional, text}
-import play.api.data.{Form, Forms, Mapping}
-import play.api.libs.json.{Format, JsResult, JsString, JsValue, Json, Reads}
-import utils.validators.forms.FieldValidator._
-
-case class Eori(value: String)
-object Eori {
-  def build(value: String): Eori = new Eori(value.toUpperCase)
-
-  implicit val format: Format[Eori] = new Format[Eori] {
-    override def writes(o: Eori): JsValue = JsString(o.value)
-
-    private val mappedReads = Reads.StringReads.map(value => Eori.build(value))
-
-    override def reads(json: JsValue): JsResult[Eori] = mappedReads.reads(json)
-  }
-
-  def mapping(errorPrefix: String): Mapping[Eori] =
-    text()
-      .verifying(s"${errorPrefix}.eori.empty", nonEmpty)
-      .verifying(s"${errorPrefix}.eori.error.format", isValidEORIPattern and noLongerThan(17) and noShorterThan(3))
-      .transform(build, unapply(_).getOrElse(""))
-}
+import forms.common.{Address, Eori}
+import play.api.data.Forms.optional
+import play.api.data.{Form, Forms}
+import play.api.libs.json.Json
 
 case class EntityDetails(
   eori: Option[Eori], // alphanumeric, max length 17 characters

--- a/app/views/declaration/summary/eori_or_address_section.scala.html
+++ b/app/views/declaration/summary/eori_or_address_section.scala.html
@@ -15,10 +15,10 @@
  *@
 
 @import forms.common.Address
+@import forms.common.Eori
 @import models.requests.JourneyRequest
 @import models.viewmodels.HtmlTableRow
 @import play.api.mvc.Call
-@import forms.declaration.Eori
 
 @(
         id: String,

--- a/test/forms/declaration/DeclarationAdditionalActorsSpec.scala
+++ b/test/forms/declaration/DeclarationAdditionalActorsSpec.scala
@@ -16,6 +16,7 @@
 
 package forms.declaration
 
+import forms.common.Eori
 import forms.declaration.DeclarationAdditionalActors.PartyType.{Consolidator, FreightForwarder}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsObject, JsString, JsValue}
@@ -57,13 +58,13 @@ class DeclarationAdditionalActorsSpec extends WordSpec with MustMatchers {
 }
 
 object DeclarationAdditionalActorsSpec {
-  val correctAdditionalActors1 = DeclarationAdditionalActors(eori = Some("eori1"), partyType = Some(Consolidator))
-  val correctAdditionalActors2 = DeclarationAdditionalActors(eori = Some("eori99"), partyType = Some(FreightForwarder))
+  val correctAdditionalActors1 = DeclarationAdditionalActors(eori = Some(Eori("eori1")), partyType = Some(Consolidator))
+  val correctAdditionalActors2 = DeclarationAdditionalActors(eori = Some(Eori("eori99")), partyType = Some(FreightForwarder))
 
   val emptyAdditionalActors = DeclarationAdditionalActors(eori = None, partyType = None)
-  val correctEORIPartyNotSelected = DeclarationAdditionalActors(eori = Some("1234567890123456"), partyType = None)
+  val correctEORIPartyNotSelected = DeclarationAdditionalActors(eori = Some(Eori("1234567890123456")), partyType = None)
   val incorrectAdditionalActors =
-    DeclarationAdditionalActors(eori = Some("123456789123456789"), partyType = Some("Incorrect"))
+    DeclarationAdditionalActors(eori = Some(Eori("123456789123456789")), partyType = Some("Incorrect"))
 
   val correctAdditionalActorsJSON: JsValue = JsObject(Map("eori" -> JsString("GB12345678912345"), "partyType" -> JsString(Consolidator)))
   val emptyAdditionalActorsJSON: JsValue = JsObject(Map("eori" -> JsString(""), "partyType" -> JsString("")))

--- a/test/forms/declaration/EntityDetailsSpec.scala
+++ b/test/forms/declaration/EntityDetailsSpec.scala
@@ -16,7 +16,7 @@
 
 package forms.declaration
 
-import forms.common.{Address, AddressSpec}
+import forms.common.{Address, AddressSpec, Eori}
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 

--- a/test/models/declaration/DeclarationHoldersDataSpec.scala
+++ b/test/models/declaration/DeclarationHoldersDataSpec.scala
@@ -16,12 +16,13 @@
 
 package models.declaration
 
+import forms.common.Eori
 import forms.declaration.DeclarationHolder
 import play.api.libs.json.{JsArray, JsObject, JsString, JsValue}
 
 object DeclarationHoldersDataSpec {
   val correctDeclarationHolder =
-    DeclarationHolder(authorisationTypeCode = Some("1234"), eori = Some("PL213472539481923"))
+    DeclarationHolder(authorisationTypeCode = Some("1234"), eori = Some(Eori("PL213472539481923")))
   val correctDeclarationHoldersData = DeclarationHoldersData(Seq(correctDeclarationHolder))
   val correctDeclarationHolderJSON: JsValue = JsObject(Map("authorisationTypeCode" -> JsString("1234"), "eori" -> JsString("PL213472539481923")))
   val anotherCorrectDeclarationHolderJSON: JsValue = JsObject(

--- a/test/models/declaration/ExportDeclarationTestData.scala
+++ b/test/models/declaration/ExportDeclarationTestData.scala
@@ -19,7 +19,7 @@ package models.declaration
 import java.time.Instant
 import java.util.UUID
 
-import forms.common.Date
+import forms.common.{Date, Eori}
 import forms.declaration.ConsignmentReferencesSpec._
 import forms.declaration.DeclarantDetailsSpec._
 import forms.declaration.DeclarationAdditionalActorsSpec.correctAdditionalActors1
@@ -130,8 +130,8 @@ object ExportDeclarationTestData {
       declarationHoldersData = Some(
         DeclarationHoldersData(
           Seq(
-            DeclarationHolder(authorisationTypeCode = Some("1234"), eori = Some("PL213472539481923")),
-            DeclarationHolder(authorisationTypeCode = Some("4321"), eori = Some("PT213472539481923"))
+            DeclarationHolder(authorisationTypeCode = Some("1234"), eori = Some(Eori("PL213472539481923"))),
+            DeclarationHolder(authorisationTypeCode = Some("4321"), eori = Some(Eori("PT213472539481923")))
           )
         )
       ),

--- a/test/services/cache/ExportsDeclarationBuilder.scala
+++ b/test/services/cache/ExportsDeclarationBuilder.scala
@@ -19,7 +19,7 @@ package services.cache
 import java.time.{Instant, LocalDate, LocalDateTime, ZoneOffset}
 import java.util.UUID
 
-import forms.common.Address
+import forms.common.{Address, Eori}
 import forms.declaration.DispatchLocation.AllowedDispatchLocations.OutsideEU
 import forms.declaration._
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
@@ -158,7 +158,7 @@ trait ExportsDeclarationBuilder {
   def withoutDeclarationHolders(): ExportsDeclarationModifier =
     cache => cache.copy(parties = cache.parties.copy(declarationHoldersData = None))
 
-  def withDeclarationHolders(authorisationTypeCode: Option[String] = None, eori: Option[String] = None): ExportsDeclarationModifier = { cache =>
+  def withDeclarationHolders(authorisationTypeCode: Option[String] = None, eori: Option[Eori] = None): ExportsDeclarationModifier = { cache =>
     val existing: Seq[DeclarationHolder] = cache.parties.declarationHoldersData.map(_.holders).getOrElse(Seq.empty)
     val holdersData = DeclarationHoldersData(existing :+ DeclarationHolder(authorisationTypeCode, eori))
     cache.copy(parties = cache.parties.copy(declarationHoldersData = Some(holdersData)))

--- a/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -17,7 +17,8 @@
 package unit.controllers.declaration
 
 import controllers.declaration.CarrierDetailsController
-import forms.declaration.{CarrierDetails, EntityDetails, Eori}
+import forms.common.Eori
+import forms.declaration.{CarrierDetails, EntityDetails}
 import models.DeclarationType._
 import models.Mode
 import org.mockito.ArgumentCaptor

--- a/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -17,7 +17,8 @@
 package unit.controllers.declaration
 
 import controllers.declaration.ConsigneeDetailsController
-import forms.declaration.{ConsigneeDetails, EntityDetails, Eori}
+import forms.common.Eori
+import forms.declaration.{ConsigneeDetails, EntityDetails}
 import models.Mode
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, when}

--- a/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -17,7 +17,8 @@
 package unit.controllers.declaration
 
 import controllers.declaration.DeclarantDetailsController
-import forms.declaration.{DeclarantDetails, EntityDetails, Eori}
+import forms.common.Eori
+import forms.declaration.{DeclarantDetails, EntityDetails}
 import models.{DeclarationType, Mode}
 import play.api.libs.json.Json
 import play.api.test.Helpers._

--- a/test/unit/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationAdditionalActorsControllerSpec.scala
@@ -19,6 +19,7 @@ package unit.controllers.declaration
 import base.TestHelper
 import controllers.declaration.DeclarationAdditionalActorsController
 import controllers.util.Remove
+import forms.common.Eori
 import forms.declaration.DeclarationAdditionalActors
 import models.{DeclarationType, Mode}
 import models.declaration.DeclarationAdditionalActorsData
@@ -49,7 +50,7 @@ class DeclarationAdditionalActorsControllerSpec extends ControllerSpec with Erro
   }
 
   val eori = "GB12345678912345"
-  val additionalActor = DeclarationAdditionalActors(Some(eori), Some("CS"))
+  val additionalActor = DeclarationAdditionalActors(Some(Eori(eori)), Some("CS"))
   val declarationWithActor =
     aDeclaration(withDeclarationAdditionalActors(additionalActor))
 

--- a/test/unit/controllers/declaration/DeclarationHolderControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderControllerSpec.scala
@@ -18,6 +18,7 @@ package unit.controllers.declaration
 
 import controllers.declaration.DeclarationHolderController
 import controllers.util.Remove
+import forms.common.Eori
 import forms.declaration.DeclarationHolder
 import models.{DeclarationType, Mode}
 import models.declaration.DeclarationHoldersData
@@ -46,9 +47,9 @@ class DeclarationHolderControllerSpec extends ControllerSpec with ErrorHandlerMo
     withNewCaching(aDeclaration())
   }
 
-  val declarationWithHolder = aDeclaration(withDeclarationHolders(Some("ACP"), Some("GB123456")))
+  val declarationWithHolder = aDeclaration(withDeclarationHolders(Some("ACP"), Some(Eori("GB123456"))))
   val maxAmountOfItems = aDeclaration(
-    withDeclarationHolders(Seq.fill(DeclarationHoldersData.limitOfHolders)(DeclarationHolder(Some("ACP"), Some("GB123456"))): _*)
+    withDeclarationHolders(Seq.fill(DeclarationHoldersData.limitOfHolders)(DeclarationHolder(Some("ACP"), Some(Eori("GB123456")))): _*)
   )
 
   "Declaration Additional Actors controller" should {

--- a/test/unit/controllers/declaration/ExporterDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ExporterDetailsControllerSpec.scala
@@ -17,8 +17,8 @@
 package unit.controllers.declaration
 
 import controllers.declaration.ExporterDetailsController
-import forms.common.Address
-import forms.declaration.{Eori, ExporterDetails}
+import forms.common.{Address, Eori}
+import forms.declaration.ExporterDetails
 import models.Mode
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any

--- a/test/unit/controllers/declaration/RepresentativeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/RepresentativeDetailsControllerSpec.scala
@@ -19,7 +19,8 @@ package unit.controllers.declaration
 import controllers.declaration.RepresentativeDetailsController
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
-import forms.declaration.{EntityDetails, Eori, RepresentativeDetails}
+import forms.common.Eori
+import forms.declaration.{EntityDetails, RepresentativeDetails}
 import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any

--- a/test/views/declaration/CarrierDetailsViewSpec.scala
+++ b/test/views/declaration/CarrierDetailsViewSpec.scala
@@ -19,8 +19,8 @@ package views.declaration
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.common.Address
-import forms.declaration.{CarrierDetails, EntityDetails, Eori}
+import forms.common.{Address, Eori}
+import forms.declaration.{CarrierDetails, EntityDetails}
 import helpers.views.declaration.CommonMessages
 import models.Mode
 import models.requests.JourneyRequest

--- a/test/views/declaration/ConsigneeDetailsViewSpec.scala
+++ b/test/views/declaration/ConsigneeDetailsViewSpec.scala
@@ -19,8 +19,8 @@ package views.declaration
 import base.TestHelper
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.common.Address
-import forms.declaration.{ConsigneeDetails, EntityDetails, Eori}
+import forms.common.{Address, Eori}
+import forms.declaration.{ConsigneeDetails, EntityDetails}
 import helpers.views.declaration.CommonMessages
 import models.Mode
 import models.requests.JourneyRequest

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -19,7 +19,8 @@ package views.declaration
 import base.TestHelper
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.declaration.{DeclarantDetails, EntityDetails, Eori}
+import forms.common.Eori
+import forms.declaration.{DeclarantDetails, EntityDetails}
 import helpers.views.declaration.CommonMessages
 import models.Mode
 import org.jsoup.nodes.Document

--- a/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/DeclarationAdditionalActorsViewSpec.scala
@@ -19,6 +19,7 @@ package views.declaration
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
+import forms.common.Eori
 import forms.declaration.DeclarationAdditionalActors
 import helpers.views.declaration.CommonMessages
 import models.requests.JourneyRequest
@@ -87,7 +88,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
 
       "display four radio buttons with description (not selected)" in {
 
-        val view = createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(""), Some(""))), request)
+        val view = createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(Eori("")), Some(""))), request)
 
         val optionOne = view.getElementById("supplementary.partyType.CS")
         optionOne.attr("checked") mustBe empty
@@ -159,7 +160,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
         val view = createView(
           DeclarationAdditionalActors
             .form()
-            .fillAndValidate(DeclarationAdditionalActors(Some(TestHelper.createRandomAlphanumericString(18)), Some(""))),
+            .fillAndValidate(DeclarationAdditionalActors(Some(Eori(TestHelper.createRandomAlphanumericString(18))), Some(""))),
           request
         )
 
@@ -176,7 +177,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
         val view = createView(
           DeclarationAdditionalActors
             .form()
-            .fillAndValidate(DeclarationAdditionalActors(Some(TestHelper.createRandomAlphanumericString(17)), Some(""))),
+            .fillAndValidate(DeclarationAdditionalActors(Some(Eori(TestHelper.createRandomAlphanumericString(17))), Some(""))),
           request
         )
 
@@ -194,9 +195,9 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
       "display EORI with CS selected" in {
 
         val view =
-          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some("1234"), Some("CS"))), request)
+          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(Eori("GB1234")), Some("CS"))), request)
 
-        view.getElementById("eori").attr("value") mustBe "1234"
+        view.getElementById("eori").attr("value") mustBe "GB1234"
         view.getElementById("supplementary.partyType.CS").attr("checked") mustBe "checked"
         view.getElementById("supplementary.partyType.MF").attr("checked") mustBe empty
         view.getElementById("supplementary.partyType.FW").attr("checked") mustBe empty
@@ -206,9 +207,9 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
       "display EORI with MF selected" in {
 
         val view =
-          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some("1234"), Some("MF"))), request)
+          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(Eori("GB1234")), Some("MF"))), request)
 
-        view.getElementById("eori").attr("value") mustBe "1234"
+        view.getElementById("eori").attr("value") mustBe "GB1234"
         view.getElementById("supplementary.partyType.CS").attr("checked") mustBe empty
         view.getElementById("supplementary.partyType.MF").attr("checked") mustBe "checked"
         view.getElementById("supplementary.partyType.FW").attr("checked") mustBe empty
@@ -218,7 +219,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
       "display EORI with FW selected" in {
 
         val view =
-          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some("1234"), Some("FW"))), request)
+          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(Eori("1234")), Some("FW"))), request)
 
         view.getElementById("eori").attr("value") mustBe "1234"
         view.getElementById("supplementary.partyType.CS").attr("checked") mustBe empty
@@ -230,7 +231,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
       "display EORI with WH selected" in {
 
         val view =
-          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some("1234"), Some("WH"))), request)
+          createView(DeclarationAdditionalActors.form().fill(DeclarationAdditionalActors(Some(Eori("1234")), Some("WH"))), request)
 
         view.getElementById("eori").attr("value") mustBe "1234"
         view.getElementById("supplementary.partyType.CS").attr("checked") mustBe empty
@@ -242,7 +243,7 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
       "display one row with data in table" in {
 
         val view =
-          declarationAdditionalActorsPage(Mode.Normal, form, Seq(DeclarationAdditionalActors(Some("12345"), Some("CS"))))(
+          declarationAdditionalActorsPage(Mode.Normal, form, Seq(DeclarationAdditionalActors(Some(Eori("GB12345")), Some("CS"))))(
             request,
             realMessagesApi.preferred(request)
           )
@@ -250,13 +251,13 @@ class DeclarationAdditionalActorsViewSpec extends UnitViewSpec with CommonMessag
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe "Party’s EORI number"
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe "Party type"
 
-        view.select("table>tbody>tr>th:nth-child(1)").text() mustBe "12345"
+        view.select("table>tbody>tr>th:nth-child(1)").text() mustBe "GB12345"
         view.select("table>tbody>tr>td:nth-child(2)").text() mustBe "Consolidator"
 
         val removeButton = view.select("table>tbody>tr>td:nth-child(3)>button")
 
-        removeButton.text() must include("Remove Consolidator 12345")
-        removeButton.attr("value") mustBe """{"eori":"12345","partyType":"CS"}"""
+        removeButton.text() must include("Remove Consolidator GB12345")
+        removeButton.attr("value") mustBe """{"eori":"GB12345","partyType":"CS"}"""
       }
 
     }

--- a/test/views/declaration/DeclarationHolderViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderViewSpec.scala
@@ -19,6 +19,7 @@ package views.declaration
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
+import forms.common.Eori
 import forms.declaration.DeclarationHolder
 import helpers.views.declaration.CommonMessages
 import models.Mode
@@ -117,7 +118,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
         val view = createView(
           DeclarationHolder
             .form()
-            .fillAndValidate(DeclarationHolder(Some("12345"), Some(TestHelper.createRandomAlphanumericString(17))))
+            .fillAndValidate(DeclarationHolder(Some("12345"), Some(Eori(TestHelper.createRandomAlphanumericString(17)))))
         )
 
         view must haveGlobalErrorSummary
@@ -131,7 +132,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
         val view = createView(
           DeclarationHolder
             .form()
-            .fillAndValidate(DeclarationHolder(Some("ACE"), Some(TestHelper.createRandomAlphanumericString(18))))
+            .fillAndValidate(DeclarationHolder(Some("ACE"), Some(Eori(TestHelper.createRandomAlphanumericString(18)))))
         )
 
         view must haveGlobalErrorSummary
@@ -146,7 +147,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
           DeclarationHolder
             .form()
             .fillAndValidate(
-              DeclarationHolder(Some(TestHelper.createRandomAlphanumericString(6)), Some(TestHelper.createRandomAlphanumericString(18)))
+              DeclarationHolder(Some(TestHelper.createRandomAlphanumericString(6)), Some(Eori(TestHelper.createRandomAlphanumericString(18))))
             )
         )
 
@@ -172,7 +173,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
 
       "display data in EORI input" in {
 
-        val view = createView(DeclarationHolder.form().fill(DeclarationHolder(None, Some("test"))))
+        val view = createView(DeclarationHolder.form().fill(DeclarationHolder(None, Some(Eori("test")))))
 
         view.getElementById("authorisationTypeCode").attr("value") mustBe empty
         view.getElementById("eori").attr("value") mustBe "test"
@@ -180,7 +181,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
 
       "display data in both inputs" in {
 
-        val view = createView(DeclarationHolder.form().fill(DeclarationHolder(Some("test"), Some("test1"))))
+        val view = createView(DeclarationHolder.form().fill(DeclarationHolder(Some("test"), Some(Eori("test1")))))
 
         view.getElementById("authorisationTypeCode").attr("value") mustBe "test"
         view.getElementById("eori").attr("value") mustBe "test1"
@@ -189,7 +190,7 @@ class DeclarationHolderViewSpec extends UnitViewSpec with CommonMessages with St
       "display one row with data in table" in {
 
         val view =
-          declarationHolderPage(Mode.Normal, form, Seq(DeclarationHolder(Some("1234"), Some("1234"))))(request, messages)
+          declarationHolderPage(Mode.Normal, form, Seq(DeclarationHolder(Some("1234"), Some(Eori("1234")))))(request, messages)
 
         view.getElementById("removable_elements-row0-label").text() mustBe "1234-1234"
 

--- a/test/views/declaration/ExporterDetailsViewSpec.scala
+++ b/test/views/declaration/ExporterDetailsViewSpec.scala
@@ -19,8 +19,8 @@ package views.declaration
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.common.Address
-import forms.declaration.{EntityDetails, Eori, ExporterDetails}
+import forms.common.{Address, Eori}
+import forms.declaration.{EntityDetails, ExporterDetails}
 import helpers.views.declaration.CommonMessages
 import models.Mode
 import models.requests.JourneyRequest

--- a/test/views/declaration/summary/AdditionalAndAuthorisedPartiesSectionViewSpec.scala
+++ b/test/views/declaration/summary/AdditionalAndAuthorisedPartiesSectionViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.summary
 
+import forms.common.Eori
 import forms.declaration.{DeclarationAdditionalActors, DeclarationHolder}
 import models.Mode
 import services.cache.ExportsTestData
@@ -31,9 +32,11 @@ class AdditionalAndAuthorisedPartiesSectionViewSpec extends UnitViewSpec with Ex
   val authorisationTypeCode1 = "partyType1"
   val authorisationTypeCode2 = "partyType2"
 
-  val additionalActors = Seq(DeclarationAdditionalActors(Some(eori1), Some(partyType1)), DeclarationAdditionalActors(Some(eori2), Some(partyType2)))
+  val additionalActors =
+    Seq(DeclarationAdditionalActors(Some(Eori(eori1)), Some(partyType1)), DeclarationAdditionalActors(Some(Eori(eori2)), Some(partyType2)))
 
-  val holders = Seq(DeclarationHolder(Some(authorisationTypeCode1), Some(eori1)), DeclarationHolder(Some(authorisationTypeCode2), Some(eori2)))
+  val holders =
+    Seq(DeclarationHolder(Some(authorisationTypeCode1), Some(Eori(eori1))), DeclarationHolder(Some(authorisationTypeCode2), Some(Eori(eori2))))
 
   "Additional and authorised parties section" should {
 

--- a/test/views/declaration/summary/EoriOrAddressSectionViewSpec.scala
+++ b/test/views/declaration/summary/EoriOrAddressSectionViewSpec.scala
@@ -16,8 +16,7 @@
 
 package views.declaration.summary
 
-import forms.common.Address
-import forms.declaration.Eori
+import forms.common.{Address, Eori}
 import services.cache.ExportsTestData
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.summary.eori_or_address_section

--- a/test/views/declaration/summary/PartiesSectionViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionViewSpec.scala
@@ -16,10 +16,8 @@
 
 package views.declaration.summary
 
-import forms.common.Address
-import forms.declaration.Eori
-import models.{DeclarationType, Mode}
-import models.DeclarationType._
+import forms.common.{Address, Eori}
+import models.Mode
 import models.declaration.DeclarationAdditionalActorsData
 import services.cache.ExportsTestData
 import views.declaration.spec.UnitViewSpec


### PR DESCRIPTION
 CEDS-2120 EORI is not accepted by DMS if it starts with lowercase letters
    
     >lowercase to uppercase implemeantion for /additional-actors page
    
     >lowercase to uppercase implemeantion for /holder-of-authorisation page
    
     >Unit test case fixes
