### PR TITLE
BAU - fix for transport summary section where questions where shown

### DIFF
--- a/app/views/declaration/summary/transport_section.scala.html
+++ b/app/views/declaration/summary/transport_section.scala.html
@@ -61,7 +61,7 @@
             ))
         )
 
-        @if(declarationData.transport.meansOfTransportCrossingTheBorderType.isDefined && declarationData.transport.meansOfTransportCrossingTheBorderIDNumber.isDefined) {
+        @if(declarationData.transport.meansOfTransportOnDepartureType.isDefined && declarationData.transport.meansOfTransportOnDepartureIDNumber.isDefined) {
             @components.table_row("transport-reference", HtmlTableRow(
                 label = messages("declaration.summary.transport.departure.meansOfTransport.header"),
                 value = messagesForDepartureMeansOfTransport(declarationData.transport),
@@ -70,7 +70,7 @@
             ))
         }
 
-        @if(declarationData.transport.meansOfTransportOnDepartureType.isDefined && declarationData.transport.meansOfTransportOnDepartureIDNumber.isDefined) {
+        @if(declarationData.transport.meansOfTransportCrossingTheBorderType.isDefined && declarationData.transport.meansOfTransportCrossingTheBorderIDNumber.isDefined) {
             @components.table_row("active-transport-type", HtmlTableRow(
                 label = messages("declaration.summary.transport.border.meansOfTransport.header"),
                 value = messagesForBorderMeansOfTransport(declarationData.transport),

--- a/test/services/cache/ExportsDeclarationBuilder.scala
+++ b/test/services/cache/ExportsDeclarationBuilder.scala
@@ -283,8 +283,8 @@ trait ExportsDeclarationBuilder {
 
   def withBorderTransport(
     meansOfTransportCrossingTheBorderNationality: Option[String] = None,
-    meansOfTransportCrossingTheBorderType: String = "",
-    meansOfTransportCrossingTheBorderIDNumber: String = ""
+    meansOfTransportCrossingTheBorderType: String = "20",
+    meansOfTransportCrossingTheBorderIDNumber: String = "123"
   ): ExportsDeclarationModifier =
     withBorderTransport(
       BorderTransport(meansOfTransportCrossingTheBorderNationality, meansOfTransportCrossingTheBorderType, meansOfTransportCrossingTheBorderIDNumber)

--- a/test/views/declaration/summary/TransportSectionViewSpec.scala
+++ b/test/views/declaration/summary/TransportSectionViewSpec.scala
@@ -129,7 +129,7 @@ class TransportSectionViewSpec extends UnitViewSpec with ExportsTestData {
     }
 
     "not display transport reference if question not answered" in {
-      val view = transport_section(Mode.Normal, aDeclarationAfter(data, withoutBorderTransport()))(messages, journeyRequest())
+      val view = transport_section(Mode.Normal, aDeclarationAfter(data, withoutMeansOfTransportOnDepartureType()))(messages, journeyRequest())
 
       view.getElementById("transport-reference-label") mustBe null
       view.getElementById("transport-reference-0") mustBe null
@@ -138,7 +138,7 @@ class TransportSectionViewSpec extends UnitViewSpec with ExportsTestData {
     }
 
     "not display active transport type if question not answered" in {
-      val view = transport_section(Mode.Normal, aDeclarationAfter(data, withoutMeansOfTransportOnDepartureType()))(messages, journeyRequest())
+      val view = transport_section(Mode.Normal, aDeclarationAfter(data, withoutBorderTransport()))(messages, journeyRequest())
 
       view.getElementById("active-transport-type-label") mustBe null
       view.getElementById("active-transport-type-0") mustBe null


### PR DESCRIPTION
that hadn't been asked.  Bug caused by transposing `meansOfTransportCrossingTheBorder` and `meansOfTransportOnDeparture`.  Bug only revealed by change that caused one of the pages to be skipped (they are normally both shown so the summary was correctly showing the answers to both pages).