### PR TITLE
CEDS-2057 - Rename the Export services

### DIFF
--- a/app/views/components/siteHeader.scala.html
+++ b/app/views/components/siteHeader.scala.html
@@ -24,7 +24,7 @@
 
 @govukHeader(Header(
     homepageUrl = None,
-    serviceName = Some(messages("site.service_name")),
+    serviceName = Some(messages("service.name")),
     serviceUrl = None,
     containerClasses = Some("govuk-width-container"),
     navigation = None

--- a/app/views/govuk_wrapper.scala.html
+++ b/app/views/govuk_wrapper.scala.html
@@ -59,7 +59,7 @@
 
 @insideHeader = {
     @header_nav_di(
-      navTitle = Some(messages("site.service_name")),
+      navTitle = Some(messages("service.name")),
       navTitleLink = None,
       showBetaLink = false,
       navLinks = Some(headerNavLinks))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -2,7 +2,7 @@ date.day = Day
 date.month = Month
 date.year = Year
 
-service.name=Customs Export Declaration Service
+service.name=CDS Exports Service
 
 feedback=This is a new service - your {0} will help us to improve it.
 feedback.link=feedback
@@ -58,7 +58,6 @@ site.yes = Yes
 site.save_and_continue = Save and continue
 site.acceptAndSubmitDeclaration = Accept and submit declaration
 site.save_and_come_back_later = Save and come back later
-site.service_name = Exports Declaration Service
 site.textarea.char_limit = (Limit is {0} characters)
 site.submit = Submit
 site.backToChoice = Back to choice page
@@ -167,8 +166,8 @@ declaration.type.clearance = Customs clearance request (C21)
 declaration.type.error = Choose a valid option
 
 startPage.title.sectionHeader = Guidance
-startPage.title = Declare goods you’re exporting using the Customs Declaration Service
-startPage.description = If you’re a UK business sending goods outside the EU you can use the Customs Declaration Service to make a full declaration.
+startPage.title = Declare goods you’re exporting using the CDS Exports Service
+startPage.description = If you’re a UK business sending goods outside the EU you can use the CDS Exports Service to make a full declaration.
 startPage.contents.header = Contents
 startPage.useThisServiceTo.header = Use this service to:
 startPage.useThisServiceTo.listItem.1 = start a new full declaration


### PR DESCRIPTION
A consistent naming convention must be displayed across all three CDS Exports services to provide users for a simplified experience and understanding.

The CDS Declarations Exports service was modified to:

1) the service name changed to CDS Exports in the banners at the top of each page,
2) the service name changed to CDS Exports on the start page.