### PR TITLE
CEDS-2180 Generate PDF with 128-Barcode based on MRN

### DIFF
--- a/app/controllers/pdf/EADController.scala
+++ b/app/controllers/pdf/EADController.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.pdf
+
+import java.time.LocalDate
+
+import com.dmanchester.playfop.sapi.PlayFop
+import javax.inject.Inject
+import org.apache.fop.apps.FOUserAgent
+import org.apache.xmlgraphics.util.MimeConstants
+import play.api.i18n.I18nSupport
+import play.api.mvc.MessagesControllerComponents
+import play.twirl.api.XmlFormat
+import services.ead.EADService
+import uk.gov.hmrc.play.bootstrap.controller.FrontendController
+import views.xml.pdf.pdfTemplate
+
+class EADController @Inject()(pdfTemplate: pdfTemplate, eadService: EADService)(mcc: MessagesControllerComponents, val playFop: PlayFop)
+    extends FrontendController(mcc) with I18nSupport {
+
+  private val mimeType: String = MimeConstants.MIME_PDF
+
+  def generatePdf(mrn: String) = Action { implicit request =>
+    {
+      val fileName = s"EAD-${mrn}-${LocalDate.now}.pdf"
+
+      val myFOUserAgentBlock = { foUserAgent: FOUserAgent =>
+        foUserAgent.setAuthor("HMRC")
+      }
+
+      val xml: XmlFormat.Appendable = pdfTemplate.render("Export accompanying document (EAD)", mrn, eadService.base64Image(mrn))
+
+      val pdf: Array[Byte] = playFop.processTwirlXml(xml, mimeType, autoDetectFontsForPDF = true, foUserAgentBlock = myFOUserAgentBlock)
+
+      Ok(pdf).as(mimeType).withHeaders(CONTENT_DISPOSITION -> s"attachment; filename=$fileName")
+    }
+  }
+}

--- a/app/services/ead/EADService.scala
+++ b/app/services/ead/EADService.scala
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package services.ead
+
+import java.awt.image.BufferedImage
+import java.io.ByteArrayOutputStream
+import java.util.Base64
+
+import javax.imageio.ImageIO
+import javax.inject.Inject
+import org.krysalis.barcode4j.impl.code128.Code128Bean
+import org.krysalis.barcode4j.output.bitmap.BitmapCanvasProvider
+
+class EADService @Inject()(code128Bean: Code128Bean) {
+
+  def base64Image(mrn: String) = {
+    code128Bean.doQuietZone(false)
+
+    val canvas = new BitmapCanvasProvider(160, BufferedImage.TYPE_BYTE_BINARY, false, 0)
+    code128Bean.generateBarcode(canvas, mrn)
+
+    val outputStream = new ByteArrayOutputStream
+    ImageIO.write(canvas.getBufferedImage, "png", outputStream)
+    outputStream.flush()
+    canvas.finish()
+    outputStream.close()
+
+    Base64.getEncoder.encodeToString(outputStream.toByteArray)
+  }
+}

--- a/app/views/pdf/pdfTemplate.scala.xml
+++ b/app/views/pdf/pdfTemplate.scala.xml
@@ -1,0 +1,20 @@
+@this()
+
+@(text: String, mrn: String, base64Image: String)
+
+<fo:root xmlns:fo="http://www.w3.org/1999/XSL/Format">
+    <fo:layout-master-set>
+        <fo:simple-page-master master-name="EAD" margin-top="1cm" margin-bottom="1cm" margin-left="1cm" margin-right="1cm">
+            <fo:region-body region-name="xsl-region-body"/>
+        </fo:simple-page-master>
+    </fo:layout-master-set>
+    <fo:page-sequence master-reference="EAD">
+        <fo:flow flow-name="xsl-region-body">
+            <fo:block text-align="center" font-size="30pt">@text</fo:block>
+            <fo:block text-align="right">
+                <fo:external-graphic src="data:image/png;base64,@base64Image"> </fo:external-graphic>
+            </fo:block>
+            <fo:block text-align="right" font-size="15pt">MRN: @mrn</fo:block>
+        </fo:flow>
+    </fo:page-sequence>
+</fo:root>

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -39,6 +39,7 @@ play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.FrontendFilters"
 # Additional play modules can be added here
 play.application.loader = "uk.gov.hmrc.play.bootstrap.ApplicationLoader"
 play.modules.enabled += "com.kenshoo.play.metrics.PlayModule"
+play.modules.enabled += "com.dmanchester.playfop.sapi.PlayFopModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.FrontendModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.HttpClientModule"
 play.modules.enabled += "uk.gov.hmrc.play.bootstrap.AuditModule"

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -310,3 +310,5 @@ POST        /summary                             controllers.declaration.Summary
 GET         /confirmation                        controllers.declaration.ConfirmationController.displaySubmissionConfirmation()
 
 GET         /draft-saved                         controllers.declaration.ConfirmationController.displayDraftConfirmation()
+
+GET         /ead/:mrn                            controllers.pdf.EADController.generatePdf(mrn)

--- a/conf/logback.xml
+++ b/conf/logback.xml
@@ -71,6 +71,10 @@
     <logger name="io.netty" level="INFO"/>
     <logger name="sun.net.www.protocol.http" level="INFO"/>
 
+    <logger name="com.dmanchester.playfop" level="INFO" />
+    <logger name="org.apache.fop" level="ERROR" />
+    <logger name="org.apache.xmlgraphics" level="ERROR" />
+
     <logger name="connector" level="TRACE">
         <appender-ref ref="STDOUT"/>
     </logger>

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -18,7 +18,9 @@ object AppDependencies {
     "ai.x"                 %% "play-json-extensions"          % "0.40.2",
     "uk.gov.hmrc"          %% "play-whitelist-filter"         % "3.1.0-play-26",
     "com.typesafe.play"    %% "play-json-joda"                % "2.6.10",
-    "com.github.tototoshi" %% "scala-csv"                     % "1.3.6"
+    "com.github.tototoshi" %% "scala-csv"                     % "1.3.6",
+    "com.dmanchester"      %% "playfop"                       % "1.0",
+    "net.sf.barcode4j"     %  "barcode4j"                     % "2.1"
   )
 
   val test: Seq[ModuleID] = Seq(
@@ -28,6 +30,7 @@ object AppDependencies {
     "org.pegdown"            %  "pegdown"            % "1.6.0"             % "test, it",
     "org.jsoup"              %  "jsoup"              % "1.12.1"            % "test",
     "com.typesafe.play"      %% "play-test"          % PlayVersion.current % "test",
-    "org.mockito"            %  "mockito-core"       % "3.0.0"             % "test"
+    "org.mockito"            %  "mockito-core"       % "3.0.0"             % "test",
+    "org.apache.pdfbox"      %  "pdfbox"             % "2.0.19"            % "test"
   )
 }

--- a/test/unit/base/ControllerSpec.scala
+++ b/test/unit/base/ControllerSpec.scala
@@ -24,7 +24,7 @@ import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.libs.json.JsValue
 import play.api.mvc._
-import play.api.test.FakeRequest
+import play.api.test.{DefaultAwaitTimeout, FakeRequest}
 import play.api.test.Helpers.{contentAsString, _}
 import play.twirl.api.Html
 import services.cache.{ExportsDeclarationBuilder, ExportsItemBuilder}
@@ -36,7 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 trait ControllerSpec
     extends UnitSpec with Stubs with MockAuthAction with MockConnectors with MockExportCacheService with MockNavigator with ExportsDeclarationBuilder
-    with ExportsItemBuilder with JourneyActionMocks {
+    with ExportsItemBuilder with JourneyActionMocks with DefaultAwaitTimeout {
 
   implicit val ec: ExecutionContext = ExecutionContext.global
 

--- a/test/unit/controllers/pdf/EADControllerSpec.scala
+++ b/test/unit/controllers/pdf/EADControllerSpec.scala
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers.pdf
+
+import java.io.ByteArrayInputStream
+
+import base.Injector
+import com.dmanchester.playfop.sapi.PlayFop
+import controllers.pdf.EADController
+import org.apache.pdfbox.pdmodel.PDDocument
+import org.apache.pdfbox.text.PDFTextStripper
+import org.krysalis.barcode4j.impl.code128.Code128Bean
+import play.api.test.Helpers._
+import services.ead.EADService
+import unit.base.ControllerSpec
+import views.xml.pdf.pdfTemplate
+
+class EADControllerSpec extends ControllerSpec with Injector {
+
+  val mcc = stubMessagesControllerComponents()
+  val pdfTemplate = new pdfTemplate()
+  val playFop = instanceOf[PlayFop]
+  val eADService = instanceOf[EADService]
+
+  val controller = new EADController(pdfTemplate, eADService)(mcc, playFop)
+
+  "EAD Controller" should {
+
+    "return 200" when {
+
+      "display page method is invoked" in {
+
+        val mrn = "20GB0NNR0WK39FGV09"
+        val result = controller.generatePdf(mrn).apply(getRequest())
+
+        status(result) must be(OK)
+
+        val pdfDocument = PDDocument.load(new ByteArrayInputStream(contentAsBytes(result).toArray))
+
+        try {
+          val pdfData = new PDFTextStripper().getText(pdfDocument)
+          pdfData must include(mrn)
+        } finally {
+          pdfDocument.close()
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
* An Export Accompanying Document ('EAD') is a short summary in a
   format agreed access the EU.
 * A lorry driver needs to have a physical copy of an EAD with them
   as they cross a border from the from an EU state to a non-EU state.
 * Declarants need to be able to generate an EAD as a PDF, which they
   can send electronically (or physically) to a driver.

**NOTE:**
This is a version using a XSL template.
@bambuchaAdm enjoyed https://pdfbox.apache.org/ API and is going to create an investigative spike to compare it. The test of fire will be once we have the final template with the DIS data