### PR TITLE
CEDS-2180 Fix font configuration problem in QA/Dev

### DIFF
--- a/app/services/ead/EADService.scala
+++ b/app/services/ead/EADService.scala
@@ -22,15 +22,21 @@ import java.util.Base64
 
 import javax.imageio.ImageIO
 import javax.inject.Inject
+import org.krysalis.barcode4j.HumanReadablePlacement
 import org.krysalis.barcode4j.impl.code128.Code128Bean
 import org.krysalis.barcode4j.output.bitmap.BitmapCanvasProvider
+import org.krysalis.barcode4j.tools.UnitConv
 
 class EADService @Inject()(code128Bean: Code128Bean) {
+  private val dpi = 200
 
   def base64Image(mrn: String) = {
+    code128Bean.setModuleWidth(UnitConv.in2mm(1.0f / dpi))
+    code128Bean.setFontSize(2.0f)
+    code128Bean.setMsgPosition(HumanReadablePlacement.HRP_NONE)
     code128Bean.doQuietZone(false)
 
-    val canvas = new BitmapCanvasProvider(160, BufferedImage.TYPE_BYTE_BINARY, false, 0)
+    val canvas = new BitmapCanvasProvider(dpi, BufferedImage.TYPE_BYTE_BINARY, false, 0)
     code128Bean.generateBarcode(canvas, mrn)
 
     val outputStream = new ByteArrayOutputStream


### PR DESCRIPTION
In the remote environments (development, QA and Staging) we are not able
to render the barcode due to a NullPointerException caused by the lack
of font configuration in our JRE-headless

```
java.lang.NullPointerException: null
	at sun.awt.FontConfiguration.getVersion(FontConfiguration.java:1264)
	at sun.awt.FontConfiguration.readFontConfigFile(FontConfiguration.java:219)
	at sun.awt.FontConfiguration.init(FontConfiguration.java:107)
	at sun.awt.X11FontManager.createFontConfiguration(X11FontManager.java:774)
```

We believe this is being caused by the fact that we were printing the
MRN as part of the barcode image. We hope that by removing the MRN from
the barcode image we will avoid this issue.

The line that fixes the issue is:
`code128Bean.setMsgPosition(HumanReadablePlacement.HRP_NONE)`

with @bambuchaAdm