### PR TITLE
CEDS-2211 - change submission status from 'Unknown' to 'Pending'

### DIFF
--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -60,7 +60,7 @@
                 <td class="table-cell">@submission.lrn</td>
                 <td class="table-cell">@submission.mrn</td>
                 <td class="table-cell">@{submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.formatter.withZone(ZoneId.systemDefault()).format(_))}</td>
-                <td class="table-cell">@{SubmissionStatus.format(notifications.headOption.map(n => n.status).getOrElse(SubmissionStatus.UNKNOWN))}</td>
+                <td class="table-cell">@{SubmissionStatus.format(notifications.headOption.map(n => n.status).getOrElse(SubmissionStatus.PENDING))}</td>
                 <td class="table-cell">
                     @if(notifications.nonEmpty){
                         <a href="@routes.NotificationsController.listOfNotificationsForSubmission(submission.uuid)">@{notifications.length}</a>

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -132,10 +132,10 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
         anchorSubmission.attr("href") mustBe routes.NotificationsController.listOfNotificationsForSubmission("id").url
       }
 
-      "submission status is unknown due to missing notification" in {
+      "submission status is 'pending' due to missing notification" in {
         val view = createView(Seq(submission -> Seq.empty))
 
-        tableCell(view)(1, 4).text() mustBe "Unknown status"
+        tableCell(view)(1, 4).text() mustBe "Pending"
       }
 
       "submission has link when contains rejected notification" in {


### PR DESCRIPTION
When no notifications have been received for a submission, change the default
on the submissions page from SubmissionStatus.UNKNOWN to SubmissionStatus.PENDING