### PR TITLE
CEDS-2219 - Skip '7/5 Inland Mode of Transport' for Clearance Requests

### DIFF
--- a/app/controllers/declaration/InlandTransportDetailsController.scala
+++ b/app/controllers/declaration/InlandTransportDetailsController.scala
@@ -43,7 +43,9 @@ class InlandTransportDetailsController @Inject()(
 
   import forms.declaration.InlandModeOfTransportCode._
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  val validJourneys = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
+
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     request.cacheModel.locations.inlandModeOfTransportCode match {
       case Some(data) => Ok(inlandTransportDetailsPage(mode, form().fill(data)))
       case _          => Ok(inlandTransportDetailsPage(mode, form()))
@@ -65,7 +67,7 @@ class InlandTransportDetailsController @Inject()(
 
   private def nextPage(declarationType: DeclarationType): Mode => Call =
     declarationType match {
-      case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY | DeclarationType.CLEARANCE =>
+      case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
         controllers.declaration.routes.TransportLeavingTheBorderController.displayPage
       case DeclarationType.SIMPLIFIED | DeclarationType.OCCASIONAL =>
         controllers.declaration.routes.BorderTransportController.displayPage

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -64,10 +64,12 @@ class SupervisingCustomsOfficeController @Inject()(
 
   private def nextPage(declarationType: DeclarationType): Mode => Call =
     declarationType match {
-      case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD | DeclarationType.CLEARANCE =>
+      case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD =>
         controllers.declaration.routes.InlandTransportDetailsController.displayPage
       case DeclarationType.SIMPLIFIED | DeclarationType.OCCASIONAL =>
         controllers.declaration.routes.TransportPaymentController.displayPage
+      case DeclarationType.CLEARANCE =>
+        controllers.declaration.routes.TransportLeavingTheBorderController.displayPage
     }
 
   private def updateCache(formData: SupervisingCustomsOffice)(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -85,6 +85,7 @@ object Navigator {
     case GoodsLocation               => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage
     case SupervisingCustomsOffice    => controllers.declaration.routes.WarehouseIdentificationController.displayPage
     case InlandModeOfTransportCode   => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
+    case ModeOfTransportCodes        => controllers.declaration.routes.InlandTransportDetailsController.displayPage
     case WarehouseIdentification     => controllers.declaration.routes.ItemsSummaryController.displayPage
     case DeclarationAdditionalActors => controllers.declaration.routes.CarrierDetailsController.displayPage
     case TotalPackageQuantity        => controllers.declaration.routes.TotalNumberOfItemsController.displayPage
@@ -108,7 +109,7 @@ object Navigator {
     case ChangeCountryPage           => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage
     case GoodsLocation               => controllers.declaration.routes.DestinationCountryController.displayPage
     case SupervisingCustomsOffice    => controllers.declaration.routes.WarehouseIdentificationController.displayPage
-    case InlandModeOfTransportCode   => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
+    case ModeOfTransportCodes        => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
     case WarehouseIdentification     => controllers.declaration.routes.ItemsSummaryController.displayPage
     case DeclarationAdditionalActors => controllers.declaration.routes.RepresentativeDetailsController.displayPage
     case TotalPackageQuantity        => controllers.declaration.routes.OfficeOfExitController.displayPage
@@ -133,6 +134,7 @@ object Navigator {
     case GoodsLocation               => controllers.declaration.routes.DestinationCountryController.displayPage
     case SupervisingCustomsOffice    => controllers.declaration.routes.WarehouseIdentificationController.displayPage
     case InlandModeOfTransportCode   => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
+    case ModeOfTransportCodes        => controllers.declaration.routes.InlandTransportDetailsController.displayPage
     case WarehouseIdentification     => controllers.declaration.routes.ItemsSummaryController.displayPage
     case DeclarationAdditionalActors => controllers.declaration.routes.RepresentativeDetailsController.displayPage
     case TotalPackageQuantity        => controllers.declaration.routes.TotalNumberOfItemsController.displayPage
@@ -158,6 +160,7 @@ object Navigator {
     case GoodsLocation               => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage
     case SupervisingCustomsOffice    => controllers.declaration.routes.WarehouseIdentificationController.displayPage
     case InlandModeOfTransportCode   => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
+    case ModeOfTransportCodes        => controllers.declaration.routes.InlandTransportDetailsController.displayPage
     case WarehouseIdentification     => controllers.declaration.routes.ItemsSummaryController.displayPage
     case DeclarationAdditionalActors => controllers.declaration.routes.CarrierDetailsController.displayPage
     case TotalPackageQuantity        => controllers.declaration.routes.TotalNumberOfItemsController.displayPage
@@ -184,6 +187,7 @@ object Navigator {
     case ChangeCountryPage           => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage
     case SupervisingCustomsOffice    => controllers.declaration.routes.WarehouseIdentificationController.displayPage
     case InlandModeOfTransportCode   => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
+    case ModeOfTransportCodes        => controllers.declaration.routes.InlandTransportDetailsController.displayPage
     case WarehouseIdentification     => controllers.declaration.routes.ItemsSummaryController.displayPage
     case DeclarationAdditionalActors => controllers.declaration.routes.CarrierDetailsController.displayPage
     case TotalPackageQuantity        => controllers.declaration.routes.TotalNumberOfItemsController.displayPage
@@ -216,7 +220,6 @@ object Navigator {
     case TotalNumberOfItems                               => controllers.declaration.routes.OfficeOfExitController.displayPage
     case NatureOfTransaction                              => controllers.declaration.routes.TotalPackageQuantityController.displayPage
     case ProcedureCodes                                   => controllers.declaration.routes.ItemsSummaryController.displayPage
-    case ModeOfTransportCodes                             => controllers.declaration.routes.InlandTransportDetailsController.displayPage
     case DepartureTransport                               => controllers.declaration.routes.TransportLeavingTheBorderController.displayPage
   }
 

--- a/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
+++ b/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
@@ -19,7 +19,7 @@ package views.declaration
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
 import forms.declaration.ModeOfTransportCodes
-import models.Mode
+import models.{DeclarationType, Mode}
 import org.jsoup.nodes.Document
 import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
@@ -31,13 +31,13 @@ class TransportLeavingTheBorderViewSpec extends UnitViewSpec with Stubs {
 
   "Transport Leaving The Border Page" must {
 
-    onEveryDeclarationJourney { implicit request =>
+    onJourney(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL) { implicit request =>
       val view: Document = page(ModeOfTransportCodes.form, Mode.Normal)
       "display page title" in {
         view.getElementById("title").text() mustBe "declaration.transport.leavingTheBorder.title"
       }
 
-      "display 'Back' button that links to 'Inland Transport Details' page" in {
+      "display 'Back' button that links to 'Supervising Customs Office' page" in {
         val backButton = view.getElementById("back-link")
         backButton.text() mustBe messages("site.back")
         backButton must haveHref(routes.InlandTransportDetailsController.displayPage())
@@ -98,6 +98,16 @@ class TransportLeavingTheBorderViewSpec extends UnitViewSpec with Stubs {
         }
       }
     }
+  }
+
+  onJourney(DeclarationType.CLEARANCE) { implicit request =>
+    "display 'Back' button that links to 'Supervising Customs Office' page" in {
+      val view: Document = page(ModeOfTransportCodes.form, Mode.Normal)
+      val backButton = view.getElementById("back-link")
+      backButton.text() mustBe messages("site.back")
+      backButton must haveHref(routes.SupervisingCustomsOfficeController.displayPage())
+    }
+
   }
 
 }


### PR DESCRIPTION
For Clearance Requests, the '7/5 Inland Mode of Transport' data element is not required in any circumstances.