### PR TITLE
CEDS-2234 - Improve 'Representative Details' screen

### DIFF
--- a/app/views/declaration/representative_details.scala.html
+++ b/app/views/declaration/representative_details.scala.html
@@ -47,7 +47,7 @@
 
 @govukLayout(
     title = Title("supplementary.representative.title"),
-    backButton = Some(BackButton("site.back", Navigator.backLink(RepresentativeDetails, mode)))) {
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(RepresentativeDetails, mode)))) {
 
     @formHelper(action = RepresentativeDetailsController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)


### PR DESCRIPTION
FIXED wrong Back Button label.

The Representative Details page does not require Representative Name and Address. The Tariff Guidance does not require the corresponding reference as well.