### PR TITLE
BAU - use the default govuk class for page heading

### DIFF
--- a/app/views/declaration/representative_details.scala.html
+++ b/app/views/declaration/representative_details.scala.html
@@ -54,7 +54,7 @@
 
         @sectionHeader(messages("supplementary.summary.parties.header"))
 
-        @pageTitle(messages("supplementary.representative.title"), classes = "govuk-heading-xl")
+        @pageTitle(messages("supplementary.representative.title"))
 
         @govukRadios(Radios(
             name = "statusCode",


### PR DESCRIPTION
The pageTitle component uses a default govuk css style (defined in the 'Styles' constants).
The default style is currently slightly smaller than defined on the latest prototypes but it is consistent with the existing non-GDS pages.
By using the constants defined we can hopefully switch to the larger heading styled en-mass once all pages have been converted.