### PR TITLE
CEDS-2189 Make CommodityDetails.descriptionOfGoods optional

### DIFF
--- a/app/views/declaration/summary/item_section.scala.html
+++ b/app/views/declaration/summary/item_section.scala.html
@@ -14,7 +14,10 @@
  * limitations under the License.
  *@
 
-@import models.DeclarationType._
+@import views.html.declaration.summary.onward_supply_relief
+@import views.html.declaration.summary.package_information
+@import views.html.declaration.summary.union_and_national_codes
+@import views.html.declaration.summary.supporting_documents
 @import models.declaration.ExportItem
 @import models.requests.JourneyRequest
 @import models.viewmodels.HtmlTableRow
@@ -46,7 +49,7 @@ components.table_row(s"item-${item.sequenceId}-procedureCode", HtmlTableRow(
 @item.commodityDetails.map(commodityDetails =>
     components.table_row(s"item-${item.sequenceId}-goodsDescription", HtmlTableRow(
         label = messages("declaration.summary.items.item.goodsDescription"),
-        value = commodityDetails.descriptionOfGoods,
+        value = commodityDetails.descriptionOfGoods.getOrElse(""),
         call = Some(controllers.declaration.routes.CommodityDetailsController.displayPage(mode, item.id)),
         changeLabel = Some(messages("declaration.summary.items.item.goodsDescription.change", item.sequenceId))
     ))

--- a/test/forms/declaration/CommodityDetailsSpec.scala
+++ b/test/forms/declaration/CommodityDetailsSpec.scala
@@ -77,9 +77,9 @@ class CommodityDetailsSpec extends WordSpec with MustMatchers {
     }
   }
 
-  "CommodityDetails mapping used for declarations where code is optional" should {
+  "CommodityDetails mapping used for declarations where code and declaration is optional" should {
 
-    for (decType <- Set(DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)) {
+    for (decType <- Set(DeclarationType.CLEARANCE)) {
 
       s"return form with errors for $decType" when {
         "provided with invalid commodity code" in {
@@ -103,7 +103,7 @@ class CommodityDetailsSpec extends WordSpec with MustMatchers {
         "provided with missing description" in {
           val form = CommodityDetails.form(decType).bind(formData("12345678", ""))
 
-          form.errors mustBe Seq(FormError(descriptionOfGoodsKey, "declaration.commodityDetails.description.error.empty"))
+          form.hasErrors must be(false)
         }
       }
 
@@ -116,6 +116,12 @@ class CommodityDetailsSpec extends WordSpec with MustMatchers {
 
         "provided with missing commodity code" in {
           val form = CommodityDetails.form(decType).bind(formData("", "description"))
+
+          form.hasErrors must be(false)
+        }
+
+        "provided with both missing commodity code and commodity description" in {
+          val form = CommodityDetails.form(decType).bind(formData("", ""))
 
           form.hasErrors must be(false)
         }

--- a/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
@@ -83,7 +83,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
       "display page method is invoked and cache contains data" in {
 
-        val details = CommodityDetails(Some("12345678"), "Description")
+        val details = CommodityDetails(Some("12345678"), Some("Description"))
         val item = anItem(withCommodityDetails(details))
         withNewCaching(aDeclaration(withItems(item)))
 
@@ -102,7 +102,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
         withNewCaching(aDeclaration())
 
-        val incorrectForm = Json.toJson(CommodityDetails(None, "Description"))
+        val incorrectForm = Json.toJson(CommodityDetails(None, Some("Description")))
 
         val result = controller.submitForm(Mode.Normal, itemId)(postRequest(incorrectForm))
 
@@ -115,7 +115,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
       "return 303 (SEE_OTHER) and redirect to UN Dangerous Goods Code page" in {
 
         withNewCaching(declaration)
-        val correctForm = Json.toJson(CommodityDetails(Some("12345678"), "Description"))
+        val correctForm = Json.toJson(CommodityDetails(Some("12345678"), Some("Description")))
 
         val result = controller.submitForm(Mode.Normal, itemId)(postRequest(correctForm))
 
@@ -128,7 +128,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
       "return 303 (SEE_OTHER) and redirect to UN Dangerous Goods Code page" in {
 
         withNewCaching(declaration)
-        val correctForm = Json.toJson(CommodityDetails(None, "Description"))
+        val correctForm = Json.toJson(CommodityDetails(None, Some("Description")))
 
         val result = controller.submitForm(Mode.Normal, itemId)(postRequest(correctForm))
 
@@ -141,7 +141,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
       "return 303 (SEE_OTHER) and redirect to UN Dangerous Goods Code page" in {
 
         withNewCaching(declaration)
-        val correctForm = Json.toJson(CommodityDetails(Some("12345678"), "Description"))
+        val correctForm = Json.toJson(CommodityDetails(Some("12345678"), Some("Description")))
 
         val result = controller.submitForm(Mode.Normal, itemId)(postRequest(correctForm))
 

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -44,7 +44,7 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
     form: Form[CommodityDetails],
     commodityDetails: Option[CommodityDetails] = None
   ): Unit = {
-    val view = createView(declarationType, commodityDetails.fold(form)(form.fill(_)))
+    val view = createView(declarationType, commodityDetails.fold(form)(form.fill))
 
     "display page title" in {
       view.getElementById("title").text() mustBe realMessages("declaration.commodityDetails.title")
@@ -56,7 +56,7 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
     }
 
     "display description textarea field" in {
-      val expectedDescription = commodityDetails.map(_.descriptionOfGoods).getOrElse("")
+      val expectedDescription = commodityDetails.flatMap(_.descriptionOfGoods).getOrElse("")
       view.getElementById(CommodityDetails.descriptionOfGoodsKey).text() mustBe expectedDescription
     }
 
@@ -84,7 +84,7 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
 
   "Commodity Details View on populated page" when {
 
-    val details = Some(CommodityDetails(Some("12345678"), "Description"))
+    val details = Some(CommodityDetails(Some("12345678"), Some("Description")))
 
     for (decType <- DeclarationType.values) {
       s"we are on $decType journey" should {

--- a/test/views/declaration/ItemSummaryViewSpec.scala
+++ b/test/views/declaration/ItemSummaryViewSpec.scala
@@ -86,7 +86,7 @@ class ItemSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
               sequenceId = 1,
               procedureCodes = Some(ProcedureCodesData(Some("procedure-code1"), Seq.empty)),
               statisticalValue = Some(StatisticalValue("")),
-              commodityDetails = Some(CommodityDetails(Some("item-type1"), "")),
+              commodityDetails = Some(CommodityDetails(Some("item-type1"), Some(""))),
               packageInformation = Some(List(PackageInformation("", 1, "")))
             ),
             ExportItem(
@@ -94,7 +94,7 @@ class ItemSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
               sequenceId = 2,
               procedureCodes = Some(ProcedureCodesData(Some("procedure-code2"), Seq.empty)),
               statisticalValue = Some(StatisticalValue("")),
-              commodityDetails = Some(CommodityDetails(Some("item-type2"), "")),
+              commodityDetails = Some(CommodityDetails(Some("item-type2"), Some(""))),
               packageInformation = Some(List(PackageInformation("", 2, "")))
             )
           )

--- a/test/views/declaration/summary/ItemSectionViewSpec.scala
+++ b/test/views/declaration/summary/ItemSectionViewSpec.scala
@@ -32,7 +32,7 @@ class ItemSectionViewSpec extends UnitViewSpec with ExportsTestData {
     withFiscalInformation(FiscalInformation("Yes")),
     withAdditionalFiscalReferenceData(AdditionalFiscalReferencesData(Seq(AdditionalFiscalReference("GB", "1234")))),
     withStatisticalValue("123"),
-    withCommodityDetails(CommodityDetails(Some("231"), "description")),
+    withCommodityDetails(CommodityDetails(Some("231"), Some("description"))),
     withUNDangerousGoodsCode(UNDangerousGoodsCode(Some("345"))),
     withCUSCode(CusCode(Some("321"))),
     withTaricCodes(TaricCode("999"), TaricCode("888")),


### PR DESCRIPTION
For Clearance Requests, data elements '6/14 Commodity code' and
'6/8 Description of Goods' are not required in the majority of cases.

This data element is not required on clearance requests using procedure
codes 00 18 or 00 19 in D.E. 1/10.

**Depends on: https://github.com/hmrc/customs-declare-exports/pull/169**