### PR TITLE
CEDS-2269 Remove ICS & Route from the EAD

### DIFF
--- a/app/views/pdf/pdfTemplate.scala.xml
+++ b/app/views/pdf/pdfTemplate.scala.xml
@@ -62,30 +62,14 @@
             <!-- DATES INFO END -->
 
 
-            <!-- ROE and ICS START -->
-            <fo:block-container absolute-position="absolute" top="65mm" left="0mm" width="50%" height="5mm">
-                <fo:block>
-                    <fo:inline font-weight="bold">@messages("pdf.template.roe"):</fo:inline>
-                    @mrnStatus.roe
-                </fo:block>
-            </fo:block-container>
-            <fo:block-container absolute-position="absolute" top="75mm" left="0mm" width="50%" height="5mm">
-                <fo:block>
-                    <fo:inline font-weight="bold">@messages("pdf.template.ics"):</fo:inline>
-                    @mrnStatus.ics
-                </fo:block>
-            </fo:block-container>
-            <!-- ROE and ICS END -->
-
-
             <!-- ITEMS INFO START -->
-            <fo:block-container absolute-position="absolute" top="95mm" left="0mm" width="50%" height="5mm">
+            <fo:block-container absolute-position="absolute" top="65mm" left="0mm" width="50%" height="5mm">
                 <fo:block font-size="12pt" text-align="left">
                     <fo:inline font-weight="bold">@messages("pdf.template.totalPackageQuantity"):</fo:inline>
                     @mrnStatus.totalPackageQuantity
                 </fo:block>
             </fo:block-container>
-            <fo:block-container absolute-position="absolute" top="105mm" left="0mm" width="50%" height="5mm">
+            <fo:block-container absolute-position="absolute" top="75mm" left="0mm" width="50%" height="5mm">
                 <fo:block font-size="12pt" text-align="left">
                     <fo:inline font-weight="bold">@messages("pdf.template.goodsItemQuantity"):</fo:inline>
                     @mrnStatus.goodsItemQuantity

--- a/test/services/ead/EADServiceSpec.scala
+++ b/test/services/ead/EADServiceSpec.scala
@@ -74,8 +74,6 @@ class EADServiceSpec
           pdfData must include(MrnStatusSpec.completeMrnStatus.eori)
           pdfData must include(MrnStatusSpec.completeMrnStatus.declarationType)
           pdfData must include(MrnStatusSpec.completeMrnStatus.ucr.get)
-          pdfData must include(MrnStatusSpec.completeMrnStatus.roe)
-          pdfData must include(MrnStatusSpec.completeMrnStatus.ics)
           pdfData must include(MrnStatusSpec.completeMrnStatus.totalPackageQuantity)
           pdfData must include(MrnStatusSpec.completeMrnStatus.goodsItemQuantity)
           pdfData must include(MrnStatusSpec.completeMrnStatus.releasedDateTime.get)

--- a/test/unit/controllers/pdf/EADControllerSpec.scala
+++ b/test/unit/controllers/pdf/EADControllerSpec.scala
@@ -73,8 +73,6 @@ class EADControllerSpec extends ControllerSpec with Injector {
           pdfData must include(MrnStatusSpec.completeMrnStatus.eori)
           pdfData must include(MrnStatusSpec.completeMrnStatus.declarationType)
           pdfData must include(MrnStatusSpec.completeMrnStatus.ucr.get)
-          pdfData must include(MrnStatusSpec.completeMrnStatus.roe)
-          pdfData must include(MrnStatusSpec.completeMrnStatus.ics)
           pdfData must include(MrnStatusSpec.completeMrnStatus.totalPackageQuantity)
           pdfData must include(MrnStatusSpec.completeMrnStatus.goodsItemQuantity)
           pdfData must include(MrnStatusSpec.completeMrnStatus.releasedDateTime.get)


### PR DESCRIPTION
The EAD currently shows the ICS and Route (aka 'ROE').  This is no
longer required as there is a risk it may confuse other EU countries
who do not use these values.