### PR TITLE
CEDS-2227 GDSfy Locations section including using accessible-autocomplete

### DIFF
--- a/app/assets/stylesheets/customsdecexfrontend-app.scss
+++ b/app/assets/stylesheets/customsdecexfrontend-app.scss
@@ -21,3 +21,6 @@ $govuk-images-path: "/customs-declare-exports/assets/lib/govuk-frontend/govuk/as
 $govuk-fonts-path: "/customs-declare-exports/assets/lib/govuk-frontend/govuk/assets/fonts/";
 @import 'lib/govuk-frontend/govuk/all';
 
+//Below are all the CSS Overwrites that are required in order for the UI to align with the prototype
+@import 'partials/_gdsSummaryLists.scss';
+

--- a/app/assets/stylesheets/customsdecexfrontend-app.scss
+++ b/app/assets/stylesheets/customsdecexfrontend-app.scss
@@ -19,8 +19,11 @@
 $govuk-assets-path: '/customs-declare-exports/assets/';
 $govuk-images-path: "/customs-declare-exports/assets/lib/govuk-frontend/govuk/assets/images/";
 $govuk-fonts-path: "/customs-declare-exports/assets/lib/govuk-frontend/govuk/assets/fonts/";
+
+@import 'lib/accessible-autocomplete/dist/accessible-autocomplete.min';
+
 @import 'lib/govuk-frontend/govuk/all';
 
 //Below are all the CSS Overwrites that are required in order for the UI to align with the prototype
 @import 'partials/_gdsSummaryLists.scss';
-
+@import 'partials/_gdsBase.scss';

--- a/app/assets/stylesheets/partials/_gdsBase.scss
+++ b/app/assets/stylesheets/partials/_gdsBase.scss
@@ -1,0 +1,12 @@
+/*
+====================================
+CSS Classes to support GovUK Accessible autocomplete Dropdown
+Context: The
+====================================
+*/
+.govuk-template__body {
+  margin: 0;
+  background-color: #fff;
+  position: relative;
+  z-index: -2;
+}

--- a/app/assets/stylesheets/partials/_gdsSummaryLists.scss
+++ b/app/assets/stylesheets/partials/_gdsSummaryLists.scss
@@ -1,0 +1,16 @@
+/*
+====================================
+CSS Classes to support GDS Design System SummaryLists as implemented by the Exports Prototype
+====================================
+*/
+.govuk-summary-list__actions {
+  width: 40%;
+}
+
+.govuk-summary-list__actions-list-item:last-child {
+  margin-left: 10px;
+}
+
+.govuk-summary-list__actions-list-item:not(:last-child) {
+  border-right: 0px;
+}

--- a/app/views/components/fields/field_accessible_autocomplete.scala.html
+++ b/app/views/components/fields/field_accessible_autocomplete.scala.html
@@ -40,14 +40,14 @@ To avoid problems, we need to remove [] from field.
 }
 
 <div id="@fieldNameWithoutBrackets-autocomplete-outer" class="govuk-form-group @if(allErrors.nonEmpty) {govuk-form-group--error}">
-    <label id="@(fieldNameWithoutBrackets)-label" for="@fieldNameWithoutBrackets" class="@if(labelClass.nonEmpty){@labelClass}" >
+    <label id="@(fieldNameWithoutBrackets)-label" for="@fieldNameWithoutBrackets" class="govuk-label@if(labelClass.nonEmpty){ @labelClass}" >
         @messages(label)
     </label>
 
     @allErrors.map { error => <span id="error-message-@{field.name}-input" class="govuk-error-message">@messages(error)</span> }
 
     @hintText.map { ht =>
-        <span class="form-hint" id="@(fieldNameWithoutBrackets)-hint">@ht</span>
+        <span class="govuk-hint" id="@(fieldNameWithoutBrackets)-hint">@ht</span>
     }
 
     @input_accessible_autocomplete(

--- a/app/views/components/fields/field_accessible_autocomplete.scala.html
+++ b/app/views/components/fields/field_accessible_autocomplete.scala.html
@@ -1,0 +1,58 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import services.view.AutoCompleteItem
+@import views.html.helper._
+@import views.html.components.inputs.input_accessible_autocomplete
+
+@(field: Field, label: String, labelClass: Option[String], hintText: Option[String], emptySelectValue: String, items: List[AutoCompleteItem], args: (Symbol, Any)*)(implicit messages: Messages)
+@*
+Some fields contains Sequence as type of the field, e.g. countries of routing on destination countries page.
+JQuery treats [] as element's attribute and tried evaluated this.
+To avoid problems, we need to remove [] from field.
+*@
+@fieldNameWithoutBrackets = @{
+    field.name.replace("[]", "").replace(".", "_")
+}
+
+@elements = @{
+    FieldElements(field.id, field, null, args.toMap, messages)
+}
+
+@allErrors = @{
+    elements.errors ++ args.flatMap {
+        case ('otherErrors, otherErrors: Seq[_]) => otherErrors.map(_.toString)
+        case _ => Seq.empty
+    }
+}
+
+<div id="@fieldNameWithoutBrackets-autocomplete-outer" class="govuk-form-group @if(allErrors.nonEmpty) {govuk-form-group--error}">
+    <label id="@(fieldNameWithoutBrackets)-label" for="@fieldNameWithoutBrackets" class="@if(labelClass.nonEmpty){@labelClass}" >
+        @messages(label)
+    </label>
+
+    @allErrors.map { error => <span id="error-message-@{field.name}-input" class="govuk-error-message">@messages(error)</span> }
+
+    @hintText.map { ht =>
+        <span class="form-hint" id="@(fieldNameWithoutBrackets)-hint">@ht</span>
+    }
+
+    @input_accessible_autocomplete(
+        field = field,
+        emptySelectValue = emptySelectValue,
+        items = items
+    )
+</div>

--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -33,6 +33,7 @@
 
 @head = {
     <link rel="shortcut icon" href='@routes.Assets.versioned("/lib/govuk-frontend/govuk/assets/images/favicon.ico")' type="image/x-icon" />
+    <link rel="shortcut icon" href='@routes.Assets.versioned("lib/accessible-autocomplete/dist/accessible-autocomplete.min.css")' rel="stylesheet" type="text/css" />
     <meta name="format-detection" content="telephone=no" />
     <!--[if lte IE 8]><link href='@controllers.routes.Assets.versioned("stylesheets/application-ie-8.css")' rel="stylesheet" type="text/css" /><![endif]-->
     <!--[if gt IE 8]><!--><link href='@routes.Assets.versioned("stylesheets/customsdecexfrontend-app.css")' media="screen" rel="stylesheet" type="text/css" /><!--<![endif]-->

--- a/app/views/components/inputs/input_accessible_autocomplete.scala.html
+++ b/app/views/components/inputs/input_accessible_autocomplete.scala.html
@@ -1,0 +1,55 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import services.view.AutoCompleteItem
+@import views.html.helper._
+
+@(field: Field, emptySelectValue: String, items: List[AutoCompleteItem])(implicit messages: Messages)
+@*
+Some fields contains Sequence as type of the field, e.g. countries of routing on destination countries page.
+JQuery treats [] as element's attribute and tried evaluated this.
+To avoid problems, we need to remove [] from field.
+*@
+@fieldNameWithoutBrackets = @{
+    field.name.replace("[]", "").replace(".", "_")
+}
+
+@selectedValue = @{
+    field.value getOrElse ""
+}
+
+<div id="@(fieldNameWithoutBrackets)-container" class="autocomplete__wrapper govuk-input--width-20">
+    <select class="govuk-form-group" id="@(fieldNameWithoutBrackets)" name="@field.name" value="@field.value">
+        <option value="">@emptySelectValue</option>
+        @items.map { i =>
+            <option value="@i.value" @if(selectedValue == i.value) {selected="selected"}>@i.label</option>
+        }
+    </select>
+</div>
+
+<script src="/customs-declare-exports/assets/lib/accessible-autocomplete/dist/accessible-autocomplete.min.js" type="text/javascript"></script>
+<script type="text/javascript">
+    var selectedElement = document.querySelector("#@(fieldNameWithoutBrackets)")
+    accessibleAutocomplete.enhanceSelectElement({
+        confirmOnBlur: true,
+        defaultValue: '',
+        selectElement: selectedElement,
+        showAllValues: true,
+        displayMenu: 'overlay',
+        autoselect: false,
+        preserveNullOptions: true
+    })
+</script>

--- a/app/views/declaration/destinationCountries/change_routing_country.scala.html
+++ b/app/views/declaration/destinationCountries/change_routing_country.scala.html
@@ -14,50 +14,73 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
-@import forms.declaration.countries.Countries.CountryPage
+@import forms.declaration.countries.Countries._
 @import forms.declaration.countries.Country
 @import forms.declaration.RoutingQuestionYesNo.ChangeCountryPage
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
 @import services.Countries
 @import services.view.AutoCompleteItem
 @import views.Title
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+@this(
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    govukDetails : GovukDetails,
+    govukFieldset: GovukFieldset,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
 
 @(mode: Mode, form: Form[Country], page: CountryPage, countryToChange: String)(implicit request: JourneyRequest[_], messages: Messages)
 
-@main_template(
-    title = Title("declaration.routingCountry.title", "declaration.routingCountry.heading")
-) {
+@tariff = {
+@components.details(messages("site.details.summary_text_this")) {
+    @Html(messages("declaration.routingQuestion.help.bodyText", components.details_content_link()))
+}
+}
 
-    @components.back_link(Navigator.backLink(ChangeCountryPage, mode), mode)
+@autocomplete = {
+@components.fields.field_accessible_autocomplete(
+    form("countryCode"),
+    "",
+    None,
+    None,
+    messages("declaration.routingCountry.empty"),
+    AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
+)
+}
 
-    @components.error_summary(form.errors)
+@govukLayout(
+    title = Title(s"declaration.routingCountry.title", "declaration.routingCountry.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(ChangeCountryPage, mode)))){
 
-    @components.heading(
-        title = messages(s"declaration.${page.id}.question"),
-        sectionHeader = messages("declaration.routingCountry.heading")
-    )
+    @formHelper(action = controllers.declaration.routes.RoutingCountriesSummaryController.submitChangeCountry(mode, countryToChange), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-    @helper.form(routes.RoutingCountriesSummaryController.submitChangeCountry(mode, countryToChange), 'autoComplete -> "off") {
-        @helper.CSRF.formField
+        @sectionHeader(messages("declaration.routingCountry.heading"))
 
-        @components.fields.field_autocomplete(
-            form("countryCode"),
-            "",
-            None,
-            None,
-            messages(s"declaration.${page.id}.empty"),
-            AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
-        )
-
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages(s"declaration.${page.id}.question")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/change_routing_country.scala.html
+++ b/app/views/declaration/destinationCountries/change_routing_country.scala.html
@@ -25,6 +25,7 @@
 @import services.view.AutoCompleteItem
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -40,7 +41,6 @@
     tariffDetails: tariffDetails,
     formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
-
 
 @(mode: Mode, form: Form[Country], page: CountryPage, countryToChange: String)(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -73,7 +73,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages(s"declaration.${page.id}.question")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/country_of_routing.scala.html
+++ b/app/views/declaration/destinationCountries/country_of_routing.scala.html
@@ -25,6 +25,7 @@
 @import services.view.AutoCompleteItem
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -40,7 +41,6 @@
         tariffDetails: tariffDetails,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
-
 
 @(mode: Mode, form: Form[Country], page: CountryPage)(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -73,7 +73,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages(s"declaration.${page.id}.question")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/country_of_routing.scala.html
+++ b/app/views/declaration/destinationCountries/country_of_routing.scala.html
@@ -14,50 +14,73 @@
  * limitations under the License.
  *@
 
+@import controllers.navigation.Navigator
 @import controllers.declaration.routes
-@import forms.declaration.countries.Countries.CountryPage
+@import forms.declaration.countries.Countries._
 @import forms.declaration.countries.Country
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
 @import services.Countries
 @import services.view.AutoCompleteItem
 @import views.Title
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukFieldset: GovukFieldset,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
 
 @(mode: Mode, form: Form[Country], page: CountryPage)(implicit request: JourneyRequest[_], messages: Messages)
 
-@main_template(
-    title = Title("declaration.routingCountry.title", "declaration.routingCountry.heading")
-) {
+@tariff = {
+@components.details(messages("site.details.summary_text_this")) {
+    @Html(messages("declaration.routingQuestion.help.bodyText", components.details_content_link()))
+}
+}
 
-    @components.back_link(routes.RoutingCountriesController.displayRoutingQuestion())
+@autocomplete = {
+@components.fields.field_accessible_autocomplete(
+    form("countryCode"),
+    "",
+    None,
+    None,
+    messages("declaration.routingCountry.empty"),
+    AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
+)
+}
 
-    @components.error_summary(form.errors)
+@govukLayout(
+    title = Title(s"declaration.${page.id}.question", "declaration.routingCountry.heading"),
+    backButton = Some(BackButton(messages("site.back"), routes.RoutingCountriesController.displayRoutingQuestion()))){
 
-    @components.heading(
-        title = messages(s"declaration.${page.id}.question"),
-        sectionHeader = messages("declaration.routingCountry.heading")
-    )
+    @formHelper(action = controllers.declaration.routes.RoutingCountriesController.submitRoutingCountry(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-    @helper.form(routes.RoutingCountriesController.submitRoutingCountry(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
+        @sectionHeader(messages("declaration.routingCountry.heading"))
 
-        @components.fields.field_autocomplete(
-            form("countryCode"),
-            "",
-            None,
-            None,
-            messages(s"declaration.${page.id}.empty"),
-            AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
-        )
-        @components.details(messages("site.details.summary_text_this")){
-            @Html(messages("declaration.routingQuestion.help.bodyText", components.details_content_link()))
-        }
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages(s"declaration.${page.id}.question")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/destination_country.scala.html
+++ b/app/views/declaration/destinationCountries/destination_country.scala.html
@@ -24,6 +24,7 @@
 @import services.view.AutoCompleteItem
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -71,7 +72,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.destinationCountry.question")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/destination_country.scala.html
+++ b/app/views/declaration/destinationCountries/destination_country.scala.html
@@ -14,54 +14,71 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
 @import forms.declaration.countries.Countries.DestinationCountryPage
 @import forms.declaration.countries.Country
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
 @import services.Countries
 @import services.view.AutoCompleteItem
 @import views.Title
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukFieldset: GovukFieldset,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[Country])(implicit request: JourneyRequest[_], messages: Messages)
 
-@tariffBody = { @Html(messages("declaration.type.destinationCountrySummaryText",  components.details_content_link())) }
+@tariff = {
+@components.details(messages("site.details.summary_text_this")) {
+    @Html(messages("declaration.type.destinationCountrySummaryText", components.details_content_link()))
+}
+}
 
-@main_template(
-    title = Title("declaration.destinationCountry.title", "declaration.destinationCountry.heading")
-) {
+@autocomplete = {
+@components.fields.field_accessible_autocomplete(
+    form("countryCode"),
+    "",
+    None,
+    None,
+    messages("declaration.destinationCountry.empty"),
+    AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
+)
+}
 
-    @components.back_link(Navigator.backLink(DestinationCountryPage, mode))
+@govukLayout(
+    title = Title("declaration.destinationCountry.title", "declaration.destinationCountry.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(DestinationCountryPage, mode)))){
 
-    @components.error_summary(form.errors)
+    @formHelper(action = controllers.declaration.routes.DestinationCountryController.submit(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-    @components.heading(
-        title = messages("declaration.destinationCountry.question"),
-        sectionHeader = messages("declaration.destinationCountry.heading")
-    )
+        @sectionHeader(messages("declaration.destinationCountry.heading"))
 
-    @helper.form(routes.DestinationCountryController.submit(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.fields.field_autocomplete(
-            form("countryCode"),
-            "",
-            None,
-            None,
-            messages("declaration.destinationCountry.empty"),
-            AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
-        )
-
-        @components.details(messages("site.details.summary_text_this")){
-          @tariffBody
-        }
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.destinationCountry.question")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/origination_country.scala.html
+++ b/app/views/declaration/destinationCountries/origination_country.scala.html
@@ -24,6 +24,7 @@
 @import services.view.AutoCompleteItem
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -39,7 +40,6 @@
         tariffDetails: tariffDetails,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
-
 
 @(mode: Mode, form: Form[Country])(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -72,7 +72,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.originationCountry.question")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/origination_country.scala.html
+++ b/app/views/declaration/destinationCountries/origination_country.scala.html
@@ -14,54 +14,72 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
 @import forms.declaration.countries.Countries.OriginationCountryPage
 @import forms.declaration.countries.Country
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
 @import services.Countries
 @import services.view.AutoCompleteItem
 @import views.Title
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukFieldset: GovukFieldset,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
 
 @(mode: Mode, form: Form[Country])(implicit request: JourneyRequest[_], messages: Messages)
 
-@tariffBody = {@Html(messages("declaration.type.originationCountrySummaryText", components.details_content_link()))}
+@tariff = {
+    @components.details(messages("declaration.type.tariff_summary_text")) {
+        @Html(messages("declaration.type.originationCountrySummaryText", components.details_content_link()))
+    }
+}
 
-@main_template(
-    title = Title("declaration.originationCountry.title", "declaration.originationCountry.heading")
-) {
-
-    @components.back_link(Navigator.backLink(OriginationCountryPage, mode))
-
-    @components.error_summary(form.errors)
-
-    @components.heading(
-        title = messages("declaration.originationCountry.question"),
-        sectionHeader = messages("declaration.originationCountry.heading")
+@autocomplete = {
+    @components.fields.field_accessible_autocomplete(
+        form("countryCode"),
+        "",
+        None,
+        None,
+        messages("declaration.originationCountry.empty"),
+        AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
     )
+}
 
-    @helper.form(routes.OriginationCountryController.submit(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
+@govukLayout(
+    title = Title("declaration.originationCountry.title", "declaration.originationCountry.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(OriginationCountryPage, mode)))){
 
-        @components.fields.field_autocomplete(
-            form("countryCode"),
-            "",
-            None,
-            None,
-            messages("declaration.originationCountry.empty"),
-            AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode)
-        )
+    @formHelper(action = controllers.declaration.routes.OriginationCountryController.submit(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-        @components.details(messages("declaration.type.tariff_summary_text")){
-           @tariffBody
-        }
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @sectionHeader(messages("declaration.originationCountry.heading"))
+
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.originationCountry.question")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/remove_routing_country.scala.html
+++ b/app/views/declaration/destinationCountries/remove_routing_country.scala.html
@@ -14,57 +14,95 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
+@import play.twirl.api.HtmlFormat
+@import scala.collection.immutable
 @import forms.declaration.RoutingQuestionYesNo.{no, RemoveCountryPage, yes}
 @import models.requests.JourneyRequest
 @import services.model.Country
 @import views.components.inputs.RadioOption
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.Radios
+@import views.html.components.gds._
+@import views.BackButton
 @import views.Title
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukFieldset: GovukFieldset,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukTable : GovukTable,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
 
 @(mode: Mode, form: Form[Boolean], countryToRemove: Country)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
-@main_template(
-    title = Title("declaration.routingCountries.remove.title", "declaration.routingCountries.remove.heading")
-) {
+@routingTable = {
+    @govukTable(Table(
+        rows = Seq(Seq(TableRow(
+            content = Text(countryToRemove.asString()),
+            attributes = Map("id" -> "country-to-remove")
+        ))),
+        head = Some(List(HeadCell(
+            content = Text(messages("declaration.routingCountries.remove.countryHeader")),
+            attributes = Map("id" -> "country-header")
+        ))),
+        firstCellIsHeader = false
+  ))
+}
 
-    @components.back_link(Navigator.backLink(RemoveCountryPage, mode), mode)
-
-    @components.error_summary(form.errors)
-
-    @components.heading(
-        title = messages("declaration.routingCountries.remove.question"),
-        sectionHeader = messages("declaration.routingCountries.remove.heading")
-    )
-
-    <table id="remove-country-table" class="form-group">
-        <thead>
-            <th class="table-head" id="country-header">@messages("declaration.routingCountries.remove.countryHeader")</th>
-        </thead>
-        <tbody>
-            <td class="table-cell" id="country-to-remove">@countryToRemove.asString()</td>
-        </tbody>
-    </table>
-
-    @helper.form(routes.RoutingCountriesSummaryController.submitRemoveCountry(mode, countryToRemove.countryCode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.fields.field_radio(
-            field = form("answer"),
-            legend = "",
-            inputs = Seq(
-                RadioOption("Yes", yes, messages("site.yes")),
-                RadioOption("No", no, messages("site.no"))
+@radios = {
+    @govukRadios(Radios(
+        name = "answer",
+        items = Seq(
+            RadioItem(
+                id = Some("Yes"),
+                value = Some(yes),
+                content = Text(messages("site.yes")),
+                checked = form("answer").value.contains("Yes")
+            ),
+            RadioItem(
+                id = Some("No"),
+                value = Some(no),
+                content = Text(messages("site.no")),
+                checked = form("answer").value.contains("No")
             )
-        )
+            ),
+            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+    ))
+}
 
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+@govukLayout(
+    title = Title("declaration.routingCountries.remove.title", "declaration.routingCountries.remove.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(RemoveCountryPage, mode)))){
+
+    @formHelper(action = controllers.declaration.routes.RoutingCountriesSummaryController.submitRemoveCountry(mode, countryToRemove.countryCode), 'autoComplete -> "off") {
+
+        @errorSummary(form.errors)
+
+        @sectionHeader(messages("declaration.routingCountries.remove.heading"))
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.routingCountries.remove.question")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                routingTable,
+                radios,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/remove_routing_country.scala.html
+++ b/app/views/declaration/destinationCountries/remove_routing_country.scala.html
@@ -20,16 +20,15 @@
 @import forms.declaration.RoutingQuestionYesNo.{no, RemoveCountryPage, yes}
 @import models.requests.JourneyRequest
 @import services.model.Country
-@import views.components.inputs.RadioOption
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
-@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.Radios
 @import views.html.components.gds._
 @import views.BackButton
+@import views.components.gds.Styles
 @import views.Title
 
 @this(
@@ -95,7 +94,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.routingCountries.remove.question")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/remove_routing_country.scala.html
+++ b/app/views/declaration/destinationCountries/remove_routing_country.scala.html
@@ -79,7 +79,7 @@
                 checked = form("answer").value.contains("No")
             )
             ),
-            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+            errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
     ))
 }
 

--- a/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
+++ b/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
@@ -30,6 +30,7 @@
 @import views.html.components.gds.errorSummary
 @import views.html.components.gds.sectionHeader
 @import views.html.components.gds.saveButtons
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 @import views.BackButton
@@ -146,7 +147,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.routingCountries.summary.header", countriesOfRouting.size)),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
+++ b/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
@@ -19,12 +19,7 @@
 @import forms.declaration.RoutingQuestionYesNo.{no, RoutingQuestionPage, yes}
 @import models.requests.JourneyRequest
 @import services.model.Country
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
 @import uk.gov.hmrc.govukfrontend.views.html.components._
-@import uk.gov.hmrc.govukfrontend.views.html.components.GovukFieldset
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
 @import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text

--- a/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
+++ b/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
@@ -129,7 +129,7 @@
                 checked = form("answer").value.contains("No")
             )
             ),
-            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+            errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
     ))
 }
 

--- a/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
+++ b/app/views/declaration/destinationCountries/routing_countries_summary.scala.html
@@ -19,26 +19,43 @@
 @import forms.declaration.RoutingQuestionYesNo.{no, RoutingQuestionPage, yes}
 @import models.requests.JourneyRequest
 @import services.model.Country
-@import views.components.inputs.RadioOption
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukSummaryList
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukFieldset
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.Radios
+@import views.html.components.gds.gdsMainTemplate
+@import views.html.components.gds.errorSummary
+@import views.html.components.gds.sectionHeader
+@import views.html.components.gds.saveButtons
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
+@import views.BackButton
 @import views.Title
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukFieldset: GovukFieldset,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukSummaryList : GovukSummaryList,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[Boolean], countriesOfRouting: Seq[Country])(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
-@main_template(
-    title = Title("declaration.routingCountries.summary.title", "declaration.routingCountries.summary.heading")
-) {
-
-    @components.back_link(Navigator.backLink(RoutingQuestionPage, mode), mode)
-
-    @components.error_summary(form.errors)
-
-    @components.heading(
-        title = messages("declaration.routingCountries.summary.header", countriesOfRouting.size),
-        sectionHeader = messages("declaration.routingCountries.summary.heading")
-    )
-
+@routingCountriesTableOld = {
     <table id="routing-countries-table" class="form-group">
         <tbody>
             @countriesOfRouting.zipWithIndex.map { case (country, index) =>
@@ -61,24 +78,87 @@
             }
         </tbody>
     </table>
+}
 
-    @helper.form(routes.RoutingCountriesSummaryController.submit(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.fields.field_radio(
-            field = form("answer"),
-            legend = messages("declaration.routingCountries.summary.question"),
-            inputs = Seq(
-                RadioOption("Yes", yes, messages("site.yes")),
-                RadioOption("No", no, messages("site.no"))
+@rountingCountriesList = {
+    @govukSummaryList(SummaryList(
+        rows = countriesOfRouting.zipWithIndex.map { case (country, index) =>
+            SummaryListRow(
+                key = Key(
+                    content = Text(messages("declaration.routingCountries.summary.table.code"))
+                ),
+                value = Value(
+                    content = Text(country.asString())
+                ),
+                actions = Some(Actions(
+                    items = Seq(
+                        ActionItem(
+                            href = routes.RoutingCountriesSummaryController.displayChangeCountryPage(mode, country.countryCode).url,
+                            content = Text(messages("site.change")),
+                            visuallyHiddenText = Some(messages("declaration.routingCountries.summary.change.hint", country.countryName))
+                        ),
+                        ActionItem(
+                            href = routes.RoutingCountriesSummaryController.displayRemoveCountryPage(mode, country.countryCode).url,
+                            content = Text(messages("site.remove")),
+                            visuallyHiddenText = Some(messages("declaration.routingCountries.summary.remove.hint", country.countryName))
+                        )
+                    ),
+                    classes = ""
+                ))
             )
-        )
+        }
+    ))
+}
 
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+@radios = {
+    @govukRadios(Radios(
+        name = "answer",
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.routingCountries.summary.question")),
+                classes= "govuk-fieldset__legend--m",
+                isPageHeading = false
+            ))
+        )),
+        items = Seq(
+            RadioItem(
+                id = Some("Yes"),
+                value = Some(yes),
+                content = Text(messages("site.yes")),
+                checked = form("answer").value.contains("Yes")
+            ),
+            RadioItem(
+                id = Some("No"),
+                value = Some(no),
+                content = Text(messages("site.no")),
+                checked = form("answer").value.contains("No")
+            )
+            ),
+            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+    ))
+}
+
+
+@govukLayout(
+    title = Title("declaration.routingCountries.summary.title", "declaration.routingCountries.summary.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(RoutingQuestionPage, mode)))){
+
+    @formHelper(action = controllers.declaration.routes.RoutingCountriesSummaryController.submit(mode), 'autoComplete -> "off") {
+
+        @errorSummary(form.errors)
+
+        @sectionHeader(messages("declaration.routingCountries.summary.heading"))
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.routingCountries.summary.header", countriesOfRouting.size)),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                rountingCountriesList,
+                radios,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/destinationCountries/routing_country_question.scala.html
+++ b/app/views/declaration/destinationCountries/routing_country_question.scala.html
@@ -14,52 +14,80 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
 @import forms.declaration.RoutingQuestionYesNo.{no, RoutingQuestionPage, yes}
 @import models.requests.JourneyRequest
-@import views.components.inputs.RadioOption
 @import views.Title
+@import views.html.components.gds.gdsMainTemplate
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukButton
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukRadios
+@import uk.gov.hmrc.govukfrontend.views.html.components.GovukDetails
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.Radios
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.errormessage.ErrorMessage
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Legend
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.radios.RadioItem
+@import uk.gov.hmrc.govukfrontend.views.viewmodels.fieldset.Fieldset
+@import views.components.gds.Styles.gdsPageLegend
+@import views.html.components.gds.errorSummary
+@import views.html.components.gds.sectionHeader
+@import views.html.components.gds.saveButtons
+@import views.html.components.gds.tariffDetails
+@import views.BackButton
 
-@this(main_template: views.html.main_template)
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[Boolean], countryOfDestination: String)(implicit request: JourneyRequest[AnyContent], messages: Messages)
 
+
 @tariffBody = { @Html(messages("declaration.routingQuestion.help.bodyText", components.details_content_link())) }
 
-@main_template(
-    title = Title("declaration.routingQuestion.title", "declaration.routingQuestion.heading")
-) {
+    @govukLayout(
+    title = Title("declaration.routingQuestion.title", "declaration.routingQuestion.heading"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(RoutingQuestionPage, mode)))){
 
-    @components.back_link(Navigator.backLink(RoutingQuestionPage, mode), mode)
+    @formHelper(action = controllers.declaration.routes.RoutingCountriesController.submitRoutingAnswer(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-    @components.error_summary(form.errors)
+        @sectionHeader(messages("declaration.routingQuestion.heading"))
 
-    @components.heading(
-        title = messages("declaration.routingQuestion.question", countryOfDestination),
-        sectionHeader = messages("declaration.routingQuestion.heading")
-    )
+        @govukRadios(Radios(
+            name = "answer",
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(messages("declaration.routingQuestion.question", countryOfDestination)),
+                    isPageHeading = true,
+                    classes = gdsPageLegend
+                ))
+            )),
+            items = Seq(
+                RadioItem(
+                    id = Some("Yes"),
+                    value = Some(yes),
+                    content = Text(messages("site.yes")),
+                    checked = form("answer").value.contains("Yes")
+                ),
+                RadioItem(
+                    id = Some("No"),
+                    value = Some(no),
+                    content = Text(messages("site.no")),
+                    checked = form("answer").value.contains("No")
+                )
+            ),
+            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+        ))
+        @components.details(messages("site.details.summary_text_this")) { @tariffBody }
 
-    @helper.form(routes.RoutingCountriesController.submitRoutingAnswer(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.fields.field_radio(
-            field = form("answer"),
-            legend = "",
-            inputs = Seq(
-                RadioOption("Yes", yes, messages("site.yes")),
-                RadioOption("No", no, messages("site.no"))
-            )
-        )
-
-        @components.details(messages("site.details.summary_text_this")){
-          @tariffBody
-        }
-        <div class="section mb-0">
-            @components.buttons.save_and_continue_button()
-        </div>
-        <div class="section">
-            @components.buttons.save_and_return_later_button()
-        </div>
+        @saveButtons()
     }
 }

--- a/app/views/declaration/destinationCountries/routing_country_question.scala.html
+++ b/app/views/declaration/destinationCountries/routing_country_question.scala.html
@@ -84,7 +84,7 @@
                     checked = form("answer").value.contains("No")
                 )
             ),
-            errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+            errorMessage = form("answer").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
         ))
         @components.details(messages("site.details.summary_text_this")) { @tariffBody }
 

--- a/app/views/declaration/officeOfExit/office_of_exit_clearance.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_clearance.scala.html
@@ -14,60 +14,109 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
-@import forms.declaration.officeOfExit.{AllowedCircumstancesCodeAnswers, OfficeOfExitClearance}
+@import forms.declaration.officeOfExit.OfficeOfExitClearance
+@import forms.declaration.officeOfExit.AllowedCircumstancesCodeAnswers
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
-@import services.OfficeOfExits
 @import services.view.AutoCompleteItem
+@import services.OfficeOfExits
 @import views.Title
-@import views.components.inputs.RadioOption
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukRadios: GovukRadios,
+        govukDetails : GovukDetails,
+        govukFieldset: GovukFieldset,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[OfficeOfExitClearance])(implicit request: JourneyRequest[_], messages: Messages)
 
 @tariffBodyDesc = { @Html(messages("declaration.type.consignmentTariffText", components.details_content_link())) }
+@tariffBody = {
+    @components.tariff_body_partial(
+        messages("supplementary.representative-details.help-item1"),
+        messages("supplementary.representative-details.help-item2")
+    )(tariffBodyDesc)
+}
+@tariff = { @components.details(messages("site.details.summary_text_these")){ @tariffBody } }
 
-@tariffBody = { @components.tariff_body_partial(messages("supplementary.representative-details.help-item1"), messages("supplementary.representative-details.help-item2"))(tariffBodyDesc)}
+@autocomplete = {
+    @components.fields.field_accessible_autocomplete(
+        field = form("officeId"),
+        label = messages("declaration.officeOfExit"),
+        labelClass = Some("form-label-bold"),
+        hintText = Some(messages("declaration.officeOfExit.hint")),
+        messages("declaration.officeOfExit.empty"),
+        AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
+    )
+}
 
-@main_template(
-    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header")
-) {
-    @helper.form(routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.back_link(Navigator.backLink(OfficeOfExitClearance, mode), mode)
-
-        @components.error_summary(form.errors)
-
-        @components.heading(
-            sectionHeader = messages("declaration.summary.locations.header"),
-            title = messages("declaration.officeOfExit.title"))
-
-        @components.fields.field_autocomplete(
-            field = form("officeId"),
-            label = messages("declaration.officeOfExit"),
-            labelClass = Some("form-label-bold"),
-            hintText = Some(messages("declaration.officeOfExit.hint")),
-            messages("declaration.officeOfExit.empty"),
-            AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
-        )
-
-        @components.fields.field_radio(
-            field = form("circumstancesCode"),
-            legend = messages("standard.officeOfExit.circumstancesCode"),
-            hint = Some(messages("standard.officeOfExit.circumstancesCode.hint")),
-            inputs = Seq(
-                RadioOption("Yes", AllowedCircumstancesCodeAnswers.yes, messages("site.yes")),
-                RadioOption("No", AllowedCircumstancesCodeAnswers.no, messages("site.no"))
+@radios = {
+    @govukRadios(Radios(
+        name = "circumstancesCode",
+        hint = Some(Hint(
+            content = Text(messages("standard.officeOfExit.circumstancesCode.hint")),
+            attributes = Map("id" -> "circumstancesCode-hint")
+        )),
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("standard.officeOfExit.circumstancesCode")),
+                classes= "govuk-fieldset__legend--m",
+                isPageHeading = false
+            ))
+        )),
+        items = Seq(
+            RadioItem(
+                id = Some("Yes"),
+                value = Some(AllowedCircumstancesCodeAnswers.yes),
+                content = Text(messages("site.yes")),
+                checked = form("circumstancesCode").value.contains("Yes")
+            ),
+            RadioItem(
+                id = Some("No"),
+                value = Some(AllowedCircumstancesCodeAnswers.no),
+                content = Text(messages("site.no")),
+                checked = form("circumstancesCode").value.contains("No")
             )
-        )
+        ),
+        errorMessage = form("circumstancesCode").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+    ))
+}
 
-        @components.details(messages("site.details.summary_text_these")){
-           @tariffBody
-        }
-        @components.submit_button()
-        @components.buttons.save_and_return_later_button()
+
+@govukLayout(
+    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(OfficeOfExitClearance, mode)))){
+
+    @formHelper(action = controllers.declaration.routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
+
+        @sectionHeader(messages("declaration.summary.locations.header"))
+
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.officeOfExit.title")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                radios,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/officeOfExit/office_of_exit_clearance.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_clearance.scala.html
@@ -24,6 +24,7 @@
 @import services.OfficeOfExits
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -108,7 +109,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.officeOfExit.title")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/officeOfExit/office_of_exit_standard.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_standard.scala.html
@@ -14,60 +14,108 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
-@import forms.declaration.officeOfExit.{AllowedCircumstancesCodeAnswers, OfficeOfExitStandard}
+@import forms.declaration.officeOfExit.OfficeOfExitStandard
+@import forms.declaration.officeOfExit.AllowedCircumstancesCodeAnswers
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
-@import services.OfficeOfExits
 @import services.view.AutoCompleteItem
+@import services.OfficeOfExits
 @import views.Title
-@import views.components.inputs.RadioOption
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+
+@this(
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    govukDetails : GovukDetails,
+    govukFieldset: GovukFieldset,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[OfficeOfExitStandard])(implicit request: JourneyRequest[_], messages: Messages)
 
 @tariffBodyDesc = { @Html(messages("declaration.type.consignmentTariffText", components.details_content_link())) }
+@tariffBody = {
+    @components.tariff_body_partial(
+        messages("supplementary.representative-details.help-item1"),
+        messages("supplementary.representative-details.help-item2")
+    )(tariffBodyDesc)
+}
+@tariff = { @components.details(messages("site.details.summary_text_these")){ @tariffBody } }
 
-@tariffBody = { @components.tariff_body_partial(messages("supplementary.representative-details.help-item1"), messages("supplementary.representative-details.help-item2"))(tariffBodyDesc)}
+@autocomplete = {
+    @components.fields.field_accessible_autocomplete(
+        field = form("officeId"),
+        label = messages("declaration.officeOfExit"),
+        labelClass = Some("govuk-label--m"),
+        hintText = Some(messages("declaration.officeOfExit.hint")),
+        messages("declaration.officeOfExit.empty"),
+        AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
+    )
+}
 
-@main_template(
-    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header")
-) {
-    @helper.form(routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
-
-        @components.back_link(Navigator.backLink(OfficeOfExitStandard, mode), mode)
-
-        @components.error_summary(form.errors)
-
-        @components.heading(
-            sectionHeader = messages("declaration.summary.locations.header"),
-            title = messages("declaration.officeOfExit.title"))
-
-        @components.fields.field_autocomplete(
-            field = form("officeId"),
-            label = messages("declaration.officeOfExit"),
-            labelClass = Some("form-label-bold"),
-            hintText = Some(messages("declaration.officeOfExit.hint")),
-            messages("declaration.officeOfExit.empty"),
-            AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
-        )
-
-        @components.fields.field_radio(
-            field = form("circumstancesCode"),
-            legend = messages("standard.officeOfExit.circumstancesCode"),
-            hint = Some(messages("standard.officeOfExit.circumstancesCode.hint")),
-            inputs = Seq(
-                RadioOption("Yes", AllowedCircumstancesCodeAnswers.yes, messages("site.yes")),
-                RadioOption("No", AllowedCircumstancesCodeAnswers.no, messages("site.no"))
+@radios = {
+    @govukRadios(Radios(
+        name = "circumstancesCode",
+        hint = Some(Hint(
+            content = Text(messages("standard.officeOfExit.circumstancesCode.hint")),
+            attributes = Map("id" -> "circumstancesCode-hint")
+        )),
+        fieldset = Some(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("standard.officeOfExit.circumstancesCode")),
+                classes= "govuk-fieldset__legend--m",
+                isPageHeading = false
+            ))
+        )),
+        items = Seq(
+            RadioItem(
+                id = Some("Yes"),
+                value = Some(AllowedCircumstancesCodeAnswers.yes),
+                content = Text(messages("site.yes")),
+                checked = form("circumstancesCode").value.contains("Yes")
+            ),
+            RadioItem(
+                id = Some("No"),
+                value = Some(AllowedCircumstancesCodeAnswers.no),
+                content = Text(messages("site.no")),
+                checked = form("circumstancesCode").value.contains("No")
             )
-        )
+        ),
+        errorMessage = form("circumstancesCode").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+    ))
+}
 
-        @components.details(messages("site.details.summary_text_these")){
-           @tariffBody
-        }
-        @components.submit_button()
-        @components.buttons.save_and_return_later_button()
+@govukLayout(
+    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(OfficeOfExitStandard, mode)))){
+
+    @formHelper(action = controllers.declaration.routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
+
+        @sectionHeader(messages("declaration.summary.locations.header"))
+
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.officeOfExit.title")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                radios,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/officeOfExit/office_of_exit_standard.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_standard.scala.html
@@ -24,6 +24,7 @@
 @import services.OfficeOfExits
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -107,7 +108,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.officeOfExit.title")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/app/views/declaration/officeOfExit/office_of_exit_supplementary.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_supplementary.scala.html
@@ -14,48 +14,73 @@
  * limitations under the License.
  *@
 
-@import controllers.declaration.routes
 @import controllers.navigation.Navigator
 @import forms.declaration.officeOfExit.OfficeOfExitSupplementary
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
 @import models.requests.JourneyRequest
-@import services.OfficeOfExits
 @import services.view.AutoCompleteItem
+@import services.OfficeOfExits
 @import views.Title
+@import views.BackButton
+@import scala.collection.immutable
+@import play.twirl.api.HtmlFormat
 
-@this(main_template: views.html.main_template)
+
+@this(
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        govukDetails : GovukDetails,
+        govukFieldset: GovukFieldset,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[OfficeOfExitSupplementary])(implicit request: JourneyRequest[_], messages: Messages)
 
 @tariffBodyDesc = { @Html(messages("declaration.type.consignmentTariffText", components.details_content_link())) }
+@tariffBody = {
+@components.tariff_body_partial(
+    messages("supplementary.representative-details.help-item1"),
+    messages("supplementary.representative-details.help-item2")
+)(tariffBodyDesc)
+}
+@tariff = { @components.details(messages("site.details.summary_text_these")){ @tariffBody } }
 
-@tariffBody = { @components.tariff_body_partial(messages("supplementary.representative-details.help-item1"), messages("supplementary.representative-details.help-item2"))(tariffBodyDesc)}
+@autocomplete = {
+@components.fields.field_accessible_autocomplete(
+    field = form("officeId"),
+    label = messages("declaration.officeOfExit"),
+    labelClass = Some("form-label-bold"),
+    hintText = Some(messages("declaration.officeOfExit.hint")),
+    messages("declaration.officeOfExit.empty"),
+    AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
+)
+}
 
-@main_template(
-    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header")
-) {
-    @helper.form(routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
-        @helper.CSRF.formField
+@govukLayout(
+    title = Title("declaration.officeOfExit.title", "declaration.summary.locations.header"),
+    backButton = Some(BackButton(messages("site.back"), Navigator.backLink(OfficeOfExitSupplementary, mode)))){
 
-        @components.back_link(Navigator.backLink(OfficeOfExitSupplementary, mode), mode)
+    @formHelper(action = controllers.declaration.routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
+        @errorSummary(form.errors)
 
-        @components.error_summary(form.errors)
+        @sectionHeader(messages("declaration.summary.locations.header"))
 
-        @components.heading(
-            sectionHeader = messages("declaration.summary.locations.header"),
-            title = messages("declaration.officeOfExit.title"))
-
-        @components.fields.field_autocomplete(
-                  field = form("officeId"),
-                  label = messages("declaration.officeOfExit"),
-                  labelClass = Some("form-label-bold"),
-                  hintText = Some(messages("declaration.officeOfExit.hint")),
-                  messages("standard.officeOfExit.empty"),
-                  AutoCompleteItem.fromOfficeOfExit(OfficeOfExits.all)
-              )
-        @components.details(messages("site.details.summary_text_these")){
-            @tariffBody
-        }
-        @components.submit_button()
-        @components.buttons.save_and_return_later_button()
+        @govukFieldset(Fieldset(
+            legend = Some(Legend(
+                content = Text(messages("declaration.officeOfExit.title")),
+                classes = "govuk-fieldset__legend--xl",
+                isPageHeading = true
+            )),
+            html = HtmlFormat.fill(immutable.Seq(
+                autocomplete,
+                tariff,
+                saveButtons()
+            ))
+        ))
     }
 }

--- a/app/views/declaration/officeOfExit/office_of_exit_supplementary.scala.html
+++ b/app/views/declaration/officeOfExit/office_of_exit_supplementary.scala.html
@@ -23,6 +23,7 @@
 @import services.OfficeOfExits
 @import views.Title
 @import views.BackButton
+@import views.components.gds.Styles
 @import scala.collection.immutable
 @import play.twirl.api.HtmlFormat
 
@@ -73,7 +74,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.officeOfExit.title")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = Styles.gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(

--- a/docs/Customs Declare Exports AutoComplete.js
+++ b/docs/Customs Declare Exports AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Customs Declare Exports AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      1.35
+// @version      1.36
 // @description  decs supported: (Std-Frontier A), (Occ-Frontier B), (Smp-Frontier C), (Std-PreLodged D), (Occ-PreLodged E), (Smp-PreLodged F), (Clr-Frontier J), (Clr-PreLodged K), (Sup-SDP Y), (Sup-EIDR Z)
 // @author       You
 // @match        http*://*/customs-declare-exports*
@@ -358,36 +358,45 @@ function holderOfAuthorisation(){
 
 function originationCountry(){
     if (currentPageIs("/customs-declare-exports/declaration/origination-country")) {
-        selectFromAutoPredict(document.getElementById("countryCode-container"), "GB");
-        document.getElementsByClassName('button')[0].click()
+        document.querySelector("#countryCode-container input").value = 'United Kingdom - GB';
+        setTimeout(() => {
+            document.getElementById('countryCode__option--0').dispatchEvent(new Event("click"));
+            document.getElementById('submit').click();
+        } , 250);
     }
 }
 
 function destinationCountry(){
     if (currentPageIs("/customs-declare-exports/declaration/destination-country")) {
-        selectFromAutoPredict(document.getElementById("countryCode-container"), "US");
-        document.getElementsByClassName('button')[0].click()
+        document.querySelector("#countryCode-container input").value = 'United States of America - US';
+        setTimeout(() => {
+            document.getElementById('countryCode__option--0').dispatchEvent(new Event("click"));
+            document.getElementById('submit').click();
+        } , 250);
     }
 }
 
 function countryOfRouting(){
     if (currentPageIs("/customs-declare-exports/declaration/country-of-routing")) {
-        document.getElementById('Yes').click()
-        document.getElementsByClassName('button')[0].click()
+        document.getElementById('Yes').click();
+        document.getElementById('submit').click();
     }
 }
 
 function countriesOfRouting(){
     if (currentPageIs("/customs-declare-exports/declaration/countries-of-routing")) {
-        selectFromAutoPredict(document.getElementById("countryCode-container"), "GB");
-        document.getElementsByClassName('button')[0].click()
+        document.querySelector("#countryCode-container input").value = 'China - CN';
+        setTimeout(() => {
+            document.getElementById('countryCode__option--0').dispatchEvent(new Event("click"));
+            document.getElementById('submit').click();
+        } , 250);
     }
 }
 
 function countriesOfRoutingSummary(){
     if (currentPageIs("/customs-declare-exports/declaration/countries-summary")) {
-        document.getElementById('No').click()
-        document.getElementsByClassName('button')[0].click()
+        document.getElementById('No').click();
+        document.getElementById('submit').click();
     }
 }
 
@@ -424,23 +433,25 @@ function officeOfExit(){
             case 'F':
             case 'K':
             case 'Y':
-                selectFromAutoPredict(document.getElementById('officeId-container'), "GB000041");
+                document.querySelector("#officeId-container input").value = 'GB000041';
                 break;
             case 'J':
-                selectFromAutoPredict(document.getElementById('officeId-container'), "GB000054");
+                document.querySelector("#officeId-container input").value = 'GB000054';
                 break;
             case 'Z':
-                selectFromAutoPredict(document.getElementById('officeId-container'), "GB000051");
+                document.querySelector("#officeId-container input").value = 'GB000051';
                 break;
             default:
-                selectFromAutoPredict(document.getElementById('officeId-container'), "GB000434");
+                document.querySelector("#officeId-container input").value = 'GB000434';
         }
 
-        if(document.getElementById("circumstancesCode")) {
-            selectRadioOption(document.getElementById("circumstancesCode"), 1);
-        }
-
-        document.getElementsByClassName('button')[0].click()
+        setTimeout(() => {
+            document.getElementById('officeId__option--0').dispatchEvent(new Event("click"));
+            if(document.getElementById('Yes')) {
+                document.getElementById('Yes').click()
+            }
+            document.getElementById('submit').click()
+        } , 250);
     }
 }
 

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -14,13 +14,14 @@ object AppDependencies {
     "uk.gov.hmrc"          %% "bootstrap-play-26"             % "1.3.0",
     "uk.gov.hmrc"          %% "play-frontend-govuk"           % "0.32.0-play-26",
     "uk.gov.hmrc"          %% "auth-client"                   % "2.32.1-play-26",
-    "org.webjars.npm"      %  "govuk-frontend"                % "3.4.0",
     "ai.x"                 %% "play-json-extensions"          % "0.40.2",
     "uk.gov.hmrc"          %% "play-whitelist-filter"         % "3.1.0-play-26",
     "com.typesafe.play"    %% "play-json-joda"                % "2.6.10",
     "com.github.tototoshi" %% "scala-csv"                     % "1.3.6",
     "com.dmanchester"      %% "playfop"                       % "1.0",
-    "net.sf.barcode4j"     %  "barcode4j"                     % "2.1"
+    "net.sf.barcode4j"     %  "barcode4j"                     % "2.1",
+    "org.webjars.npm"      %  "govuk-frontend"                % "3.4.0",
+    "org.webjars.npm"      %  "accessible-autocomplete"       % "2.0.2"
   )
 
   val test: Seq[ModuleID] = Seq(

--- a/test/views/declaration/destinationCountries/ChangeRoutingCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/ChangeRoutingCountryViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.countries.{Countries, Country}
 import forms.declaration.countries.Countries.{FirstRoutingCountryPage, NextRoutingCountryPage}
@@ -29,10 +30,10 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.change_routing_country
 
-class ChangeRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class ChangeRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
   private val countryToChange = "GB"
-  private val changeRoutingCountryPage = new change_routing_country(mainTemplate)
+  private val changeRoutingCountryPage = instanceOf[change_routing_country]
 
   private def firstRoutingForm(request: JourneyRequest[_]): Form[Country] =
     Countries.form(FirstRoutingCountryPage)(request)
@@ -55,12 +56,12 @@ class ChangeRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
       s"have page question during changing first routing country for ${request.declarationType}" in {
 
-        firstRoutingView(request).getElementById("title").text() mustBe messages("declaration.firstRoutingCountry.question")
+        firstRoutingView(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.firstRoutingCountry.question")
       }
 
       s"have page question during changing next routing country for ${request.declarationType}" in {
 
-        nextRoutingView(request).getElementById("title").text() mustBe messages("declaration.routingCountry.question")
+        nextRoutingView(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.routingCountry.question")
       }
 
       s"display back button that links to 'Countries summary' for first routing country page for ${request.declarationType}" in {

--- a/test/views/declaration/destinationCountries/CountryOfRoutingViewSpec.scala
+++ b/test/views/declaration/destinationCountries/CountryOfRoutingViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.countries.{Countries, Country}
 import forms.declaration.countries.Countries.{FirstRoutingCountryPage, NextRoutingCountryPage}
@@ -29,9 +30,9 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.country_of_routing
 
-class CountryOfRoutingViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class CountryOfRoutingViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
-  private val countryOfRoutingPage = new country_of_routing(mainTemplate)
+  private val countryOfRoutingPage = instanceOf[country_of_routing]
 
   private def firstRoutingForm(request: JourneyRequest[_]): Form[Country] =
     Countries.form(FirstRoutingCountryPage)(request)
@@ -87,10 +88,9 @@ class CountryOfRoutingViewSpec extends UnitViewSpec with Stubs with ExportsTestD
     }
 
     "First Routing Country view" should {
-
       "have page question" in {
 
-        firstRoutingView(request).getElementById("title").text() mustBe messages("declaration.firstRoutingCountry.question")
+        firstRoutingView(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.firstRoutingCountry.question")
       }
     }
 
@@ -98,7 +98,7 @@ class CountryOfRoutingViewSpec extends UnitViewSpec with Stubs with ExportsTestD
 
       "have page question" in {
 
-        nextRoutingView(request).getElementById("title").text() mustBe messages("declaration.routingCountry.question")
+        nextRoutingView(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.routingCountry.question")
       }
     }
   }

--- a/test/views/declaration/destinationCountries/DestinationCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/DestinationCountryViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.countries.Countries.DestinationCountryPage
 import forms.declaration.countries.{Countries, Country}
@@ -29,9 +30,9 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.destination_country
 
-class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
-  private val destinationCountryPage = new destination_country(mainTemplate)
+  private val destinationCountryPage = instanceOf[destination_country]
 
   private def form(request: JourneyRequest[_]): Form[Country] = Countries.form(DestinationCountryPage)(request)
   private def view(request: JourneyRequest[_]): Html = destinationCountryPage(Mode.Normal, form(request))(request, messages)
@@ -54,7 +55,7 @@ class DestinationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
 
       s"display page question for ${request.declarationType}" in {
 
-        view(request).getElementById("title").text() mustBe messages("declaration.destinationCountry.question")
+        view(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.destinationCountry.question")
       }
 
       s"display page heading for ${request.declarationType}" in {

--- a/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.countries.{Countries, Country}
 import forms.declaration.countries.Countries.OriginationCountryPage
@@ -29,9 +30,9 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.origination_country
 
-class OriginationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class OriginationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
-  private val originationCountryPage = new origination_country(mainTemplate)
+  val originationCountryPage = instanceOf[origination_country]
 
   private def form(request: JourneyRequest[_]): Form[Country] =
     Countries.form(OriginationCountryPage)(request)
@@ -56,7 +57,7 @@ class OriginationCountryViewSpec extends UnitViewSpec with Stubs with ExportsTes
 
       s"display page question for ${request.declarationType}" in {
 
-        view(request).getElementById("title").text() mustBe messages("declaration.originationCountry.question")
+        view(request).getElementsByClass("govuk-fieldset__legend").text() mustBe messages("declaration.originationCountry.question")
       }
 
       s"display page heading for ${request.declarationType}" in {

--- a/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
@@ -24,6 +24,7 @@ import play.api.data.Form
 import services.cache.ExportsTestData
 import services.model.Country
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.remove_routing_country
 
@@ -48,7 +49,7 @@ class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display page question" in {
 
-      view.getElementsByClass("govuk-fieldset__legend--xl").text() mustBe messages("declaration.routingCountries.remove.question")
+      view.getElementsByClass(Styles.gdsPageLegend).text() mustBe messages("declaration.routingCountries.remove.question")
     }
 
     "display page header" in {

--- a/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RemoveRoutingCountryViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.RoutingQuestionYesNo
 import models.Mode
@@ -26,12 +27,12 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.remove_routing_country
 
-class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
   val country = Country("Poland", "PL")
   val form: Form[Boolean] = RoutingQuestionYesNo.form()
 
-  val removeRoutingCountryPage = new remove_routing_country(mainTemplate)
+  val removeRoutingCountryPage = instanceOf[remove_routing_country]
   val view = removeRoutingCountryPage(Mode.Normal, form, country)(journeyRequest(), messages)
 
   "Remove routing country page" should {
@@ -47,7 +48,7 @@ class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display page question" in {
 
-      view.getElementById("title").text() mustBe messages("declaration.routingCountries.remove.question")
+      view.getElementsByClass("govuk-fieldset__legend--xl").text() mustBe messages("declaration.routingCountries.remove.question")
     }
 
     "display page header" in {
@@ -67,8 +68,8 @@ class RemoveRoutingCountryViewSpec extends UnitViewSpec with Stubs with ExportsT
 
     "display Yes/No radio options" in {
 
-      view.getElementById("Yes-label").text() mustBe messages("site.yes")
-      view.getElementById("No-label").text() mustBe messages("site.no")
+      view.getElementsByAttributeValue("for", "Yes").text().text() mustBe messages("site.yes")
+      view.getElementsByAttributeValue("for", "No").text() mustBe messages("site.no")
     }
 
     "display back button that links to 'Countries summary' page" in {

--- a/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.RoutingQuestionYesNo
 import models.Mode
@@ -26,12 +27,12 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.routing_countries_summary
 
-class RoutingCountriesSummaryViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class RoutingCountriesSummaryViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
   val countries = Seq(Country("France", "FR"), Country("Poland", "PL"))
   val form: Form[Boolean] = RoutingQuestionYesNo.form()
 
-  val routingCountriesSummaryPage = new routing_countries_summary(mainTemplate)
+  val routingCountriesSummaryPage = instanceOf[routing_countries_summary]
   val view = routingCountriesSummaryPage(Mode.Normal, form, countries)(journeyRequest(), messages)
 
   "Routing Countries Summary" should {
@@ -53,18 +54,18 @@ class RoutingCountriesSummaryViewSpec extends UnitViewSpec with Stubs with Expor
 
     "display page title for the table" in {
 
-      view.getElementById("title").text() mustBe messages("declaration.routingCountries.summary.header")
+      view.getElementsByClass("govuk-fieldset__legend--xl").text() mustBe messages("declaration.routingCountries.summary.header")
     }
 
     "display page question" in {
 
-      view.getElementById("answer-label").text() mustBe messages("declaration.routingCountries.summary.question")
+      view.getElementsByClass("govuk-fieldset__legend--m").text() mustBe messages("declaration.routingCountries.summary.question")
     }
 
     "have Yes/No answers" in {
 
-      view.getElementById("Yes-label").text() mustBe messages("site.yes")
-      view.getElementById("No-label").text() mustBe messages("site.no")
+      view.getElementsByAttributeValue("for", "Yes").text().text() mustBe messages("site.yes")
+      view.getElementsByAttributeValue("for", "No").text() mustBe messages("site.no")
     }
 
     "display back button that links to 'Destination country' page" in {

--- a/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountriesSummaryViewSpec.scala
@@ -24,6 +24,7 @@ import play.api.data.Form
 import services.cache.ExportsTestData
 import services.model.Country
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.routing_countries_summary
 
@@ -54,7 +55,7 @@ class RoutingCountriesSummaryViewSpec extends UnitViewSpec with Stubs with Expor
 
     "display page title for the table" in {
 
-      view.getElementsByClass("govuk-fieldset__legend--xl").text() mustBe messages("declaration.routingCountries.summary.header")
+      view.getElementsByClass(Styles.gdsPageLegend).text() mustBe messages("declaration.routingCountries.summary.header")
     }
 
     "display page question" in {

--- a/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
@@ -16,6 +16,7 @@
 
 package views.declaration.destinationCountries
 
+import base.Injector
 import controllers.declaration.routes
 import forms.declaration.RoutingQuestionYesNo
 import models.Mode
@@ -25,12 +26,11 @@ import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.routing_country_question
 
-class RoutingCountryQuestionViewSpec extends UnitViewSpec with Stubs with ExportsTestData {
+class RoutingCountryQuestionViewSpec extends UnitViewSpec with Stubs with ExportsTestData with Injector {
 
   val countryOfDestination = "Poland"
   val form: Form[Boolean] = RoutingQuestionYesNo.form()
-
-  val routingQuestionPage = new routing_country_question(mainTemplate)
+  val routingQuestionPage = instanceOf[routing_country_question]
   val view = routingQuestionPage(Mode.Normal, form, countryOfDestination)(journeyRequest(), messages)
 
   "Routing country question page" should {
@@ -53,13 +53,13 @@ class RoutingCountryQuestionViewSpec extends UnitViewSpec with Stubs with Export
 
     "have page question" in {
 
-      view.getElementById("title").text() mustBe messages("declaration.routingQuestion.question")
+      view.getElementsByClass("govuk-fieldset__heading").text() mustBe messages("declaration.routingQuestion.question")
     }
 
     "have Yes/No answers" in {
 
-      view.getElementById("Yes-label").text() mustBe messages("site.yes")
-      view.getElementById("No-label").text() mustBe messages("site.no")
+      view.getElementsByAttributeValue("for", "Yes").text().text() mustBe messages("site.yes")
+      view.getElementsByAttributeValue("for", "No").text() mustBe messages("site.no")
     }
 
     "display Tariff section text" in {

--- a/test/views/declaration/officeOfExit/OfficeOfExitClearanceViewSpec.scala
+++ b/test/views/declaration/officeOfExit/OfficeOfExitClearanceViewSpec.scala
@@ -34,7 +34,7 @@ import views.tags.ViewTest
 @ViewTest
 class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
 
-  private val page: office_of_exit_clearance = new office_of_exit_clearance(mainTemplate)
+  private val page: office_of_exit_clearance = instanceOf[office_of_exit_clearance]
   private val form: Form[OfficeOfExitClearance] = clearanceForm()
   private def createView(mode: Mode = Mode.Normal, form: Form[OfficeOfExitClearance] = form): Document =
     page(mode, form)(journeyRequest(CLEARANCE), stubMessages())
@@ -60,7 +60,7 @@ class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData wi
     "Office of Exit View on empty page for standard" should {
 
       "display page title" in {
-        view.getElementById("title").text() mustBe "declaration.officeOfExit.title"
+        view.getElementsByClass("govuk-fieldset__heading").text() mustBe "declaration.officeOfExit.title"
       }
 
       "display section header" in {
@@ -74,7 +74,7 @@ class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData wi
       }
 
       "display circumstances code question" in {
-        view.getElementById("circumstancesCode-label").text() mustBe "standard.officeOfExit.circumstancesCode"
+        view.getElementsByClass("govuk-fieldset__legend--m").text() mustBe "standard.officeOfExit.circumstancesCode"
         view.getElementById("circumstancesCode-hint").text() mustBe "standard.officeOfExit.circumstancesCode.hint"
       }
 
@@ -104,12 +104,17 @@ class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData wi
         val form = clearanceForm().fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("circumstancesCode-error").text() mustBe "standard.officeOfExit.circumstancesCode.error"
         view
-          .getElementById("error-message-circumstancesCode-input")
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
           .text() mustBe "standard.officeOfExit.circumstancesCode.error"
+        view
+          .getElementById("circumstancesCode-error")
+          .text() must include("standard.officeOfExit.circumstancesCode.error")
       }
 
       "display errors when all inputs are incorrect" in {
@@ -117,9 +122,14 @@ class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData wi
         val form = clearanceForm().fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("officeId-error").text() mustBe "declaration.officeOfExit.length"
+        view
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
+          .text() mustBe "declaration.officeOfExit.length"
         view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.length"
       }
 
@@ -128,9 +138,14 @@ class OfficeOfExitClearanceViewSpec extends UnitViewSpec with ExportsTestData wi
         val form = clearanceForm().fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("officeId-error").text() mustBe "declaration.officeOfExit.specialCharacters"
+        view
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
+          .text() mustBe "declaration.officeOfExit.specialCharacters"
         view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.specialCharacters"
       }
     }

--- a/test/views/declaration/officeOfExit/OfficeOfExitStandardViewSpec.scala
+++ b/test/views/declaration/officeOfExit/OfficeOfExitStandardViewSpec.scala
@@ -32,7 +32,7 @@ import views.tags.ViewTest
 @ViewTest
 class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
 
-  private val page: office_of_exit_standard = new office_of_exit_standard(mainTemplate)
+  private val page: office_of_exit_standard = instanceOf[office_of_exit_standard]
   private val form: Form[OfficeOfExitStandard] = OfficeOfExitForms.standardForm()
   private def createView(mode: Mode = Mode.Normal, form: Form[OfficeOfExitStandard] = form): Document =
     page(mode, form)(journeyRequest(), stubMessages())
@@ -58,7 +58,7 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
     "Office of Exit View on empty page for standard" should {
 
       "display page title" in {
-        view.getElementById("title").text() mustBe "declaration.officeOfExit.title"
+        view.getElementsByClass("govuk-fieldset__heading").text() mustBe "declaration.officeOfExit.title"
       }
 
       "display section header" in {
@@ -72,7 +72,7 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
       }
 
       "display circumstances code question" in {
-        view.getElementById("circumstancesCode-label").text() mustBe "standard.officeOfExit.circumstancesCode"
+        view.getElementsByClass("govuk-fieldset__legend--m").text() mustBe "standard.officeOfExit.circumstancesCode"
         view.getElementById("circumstancesCode-hint").text() mustBe "standard.officeOfExit.circumstancesCode.hint"
       }
 
@@ -102,15 +102,23 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
         val form = OfficeOfExitForms.standardForm.fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("officeId-error").text() mustBe "declaration.officeOfExit.empty"
+        view
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
+          .text() mustBe "declaration.officeOfExit.empty"
         view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.empty"
 
-        view.getElementById("circumstancesCode-error").text() mustBe "standard.officeOfExit.circumstancesCode.error"
         view
-          .getElementById("error-message-circumstancesCode-input")
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(1)
           .text() mustBe "standard.officeOfExit.circumstancesCode.error"
+        view.getElementById("circumstancesCode-error").text() must include("standard.officeOfExit.circumstancesCode.error")
       }
 
       "display errors when all inputs are incorrect" in {
@@ -118,9 +126,14 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
         val form = OfficeOfExitForms.standardForm.fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("officeId-error").text() mustBe "declaration.officeOfExit.length"
+        view
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
+          .text() mustBe "declaration.officeOfExit.length"
         view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.length"
       }
 
@@ -129,9 +142,14 @@ class OfficeOfExitStandardViewSpec extends UnitViewSpec with ExportsTestData wit
         val form = OfficeOfExitForms.standardForm.fillAndValidate(data)
         val view = createView(form = form)
 
-        checkErrorsSummary(view)
+        view.getElementById("error-summary-title").text() must be("error.summary.title")
 
-        view.getElementById("officeId-error").text() mustBe "declaration.officeOfExit.specialCharacters"
+        view
+          .getElementsByClass("govuk-list govuk-error-summary__list")
+          .get(0)
+          .getElementsByTag("li")
+          .get(0)
+          .text() mustBe "declaration.officeOfExit.specialCharacters"
         view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.specialCharacters"
       }
     }

--- a/test/views/declaration/officeOfExit/OfficeOfExitSupplementaryViewSpec.scala
+++ b/test/views/declaration/officeOfExit/OfficeOfExitSupplementaryViewSpec.scala
@@ -33,7 +33,7 @@ import views.tags.ViewTest
 @ViewTest
 class OfficeOfExitSupplementaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
 
-  private val page = new office_of_exit_supplementary(mainTemplate)
+  private val page = instanceOf[office_of_exit_supplementary]
   private val form: Form[OfficeOfExitSupplementary] = OfficeOfExitForms.supplementaryForm()
   private def createView(mode: Mode = Mode.Normal, form: Form[OfficeOfExitSupplementary] = form): Document =
     page(mode, form)(journeyRequest(SUPPLEMENTARY), stubMessages())
@@ -52,7 +52,7 @@ class OfficeOfExitSupplementaryViewSpec extends UnitViewSpec with ExportsTestDat
     }
 
     "display page title" in {
-      view.getElementById("title").text() mustBe "declaration.officeOfExit.title"
+      view.getElementsByClass("govuk-fieldset__heading").text() mustBe "declaration.officeOfExit.title"
     }
 
     "display section header" in {
@@ -95,7 +95,8 @@ class OfficeOfExitSupplementaryViewSpec extends UnitViewSpec with ExportsTestDat
       val view =
         createView(form = OfficeOfExitForms.supplementaryForm.fillAndValidate(OfficeOfExitSupplementary("123456789")))
 
-      checkErrorsSummary(view)
+      view.getElementById("error-summary-title").text() must be("error.summary.title")
+
       haveFieldErrorLink("officeId", "#officeId")
 
       view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.length"
@@ -105,7 +106,7 @@ class OfficeOfExitSupplementaryViewSpec extends UnitViewSpec with ExportsTestDat
 
       val view = createView(form = OfficeOfExitForms.supplementaryForm.fillAndValidate(OfficeOfExitSupplementary("")))
 
-      checkErrorsSummary(view)
+      view.getElementById("error-summary-title").text() must be("error.summary.title")
       haveFieldErrorLink("officeId", "#officeId")
 
       view.getElementById("error-message-officeId-input").text() mustBe "declaration.officeOfExit.empty"


### PR DESCRIPTION
This is the most tested library for an accessible dropdown/autocomplete
HTML input at GovUK: https://alphagov.github.io/accessible-autocomplete

This is the suggested approach taken by the HMRC CDS Exports prototype
and also recommended by @christophercameron-hmrc


This also includes rebuilding the following pages using GDS Design System:
 * Routing Question page
 * Routing Contries Summary page
 * Remove Contry page