### PR TITLE
CEDS-2277 - warehouse summary label when user said "No"

### DIFF
--- a/app/views/declaration/summary/warehouse_section.scala.html
+++ b/app/views/declaration/summary/warehouse_section.scala.html
@@ -35,7 +35,7 @@
             SummaryListRow(
                 classes = "warehouse-id-row",
                 key = Key(
-                    content = Text(messages("declaration.summary.warehouse.id"))
+                    content = Text(messages( if(warehouseIdentification.identificationNumber.isDefined) "declaration.summary.warehouse.id" else "declaration.summary.warehouse.no.label"))
                 ),
                 value = Value(
                     content = Text(warehouseIdentification.identificationNumber.getOrElse(messages("site.no")))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1059,6 +1059,7 @@ declaration.summary.items.item.supportingDocuments.code = Additional document ty
 declaration.summary.items.item.supportingDocuments.information = Additional document identifier
 declaration.summary.warehouse = Warehouse information
 declaration.summary.warehouse.id = Warehouse ID
+declaration.summary.warehouse.no.label = Warehouse
 declaration.summary.warehouse.id.change = Change warehouse ID
 declaration.summary.warehouse.supervisingOffice = Customs supervising office
 declaration.summary.warehouse.supervisingOffice.change = Change customs supervising office

--- a/test/views/declaration/summary/WarehouseSectionViewSpec.scala
+++ b/test/views/declaration/summary/WarehouseSectionViewSpec.scala
@@ -69,6 +69,15 @@ class WarehouseSectionViewSpec extends UnitViewSpec with ExportsTestData with In
       row must haveSummaryActionsHref(controllers.declaration.routes.InlandTransportDetailsController.displayPage())
     }
 
+    "display warehouse label when user said 'no'" in {
+
+      val row = section(mode, aDeclarationAfter(data, withWarehouseIdentification(Some(WarehouseIdentification(None)))))(messages, journeyRequest())
+        .getElementsByClass("warehouse-id-row")
+
+      row must haveSummaryKey(messages("declaration.summary.warehouse.no.label"))
+      row must haveSummaryValue(messages("site.no"))
+    }
+
     "not display warehouse id when question not answered" in {
 
       val view = section(mode, aDeclarationAfter(data, withoutWarehouseIdentification()))(messages, journeyRequest())


### PR DESCRIPTION
CEDS-2277 specifies that the label on the summary screen should be "Warehouse" if the user answered "No" to the "Is in warehouse?" question