### PR TITLE
CEDS-2237 - use default GDS page heading style

### DIFF
--- a/app/views/declaration/declaration_additional_actors.scala.html
+++ b/app/views/declaration/declaration_additional_actors.scala.html
@@ -23,6 +23,7 @@
 @import views.{BackButton, Title}
 @import views.html.components.gds._
 @import views.components.gds._
+@import views.components.gds.Styles._
 @import play.twirl.api.HtmlFormat
 @import scala.collection.immutable
 
@@ -175,7 +176,7 @@
         @govukFieldset(Fieldset(
             legend = Some(Legend(
                 content = Text(messages("declaration.additionalActors.title")),
-                classes = "govuk-fieldset__legend--xl",
+                classes = gdsPageLegend,
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(immutable.Seq(


### PR DESCRIPTION
The constant value `Styles.gdsPageLegend` defines a smaller page heading style that is more consistent with the existing non-GDS pages and can be changed once all pages have been converted.