### PR TITLE
CEDS-2275 - Add Transport Payment screen into Clearance Request Journey

### DIFF
--- a/app/controllers/declaration/DepartureTransportController.scala
+++ b/app/controllers/declaration/DepartureTransportController.scala
@@ -68,7 +68,7 @@ class DepartureTransportController @Inject()(
   private def nextPage(mode: Mode)(implicit request: JourneyRequest[AnyContent]): Result =
     request.declarationType match {
       case DeclarationType.CLEARANCE =>
-        navigator.continueTo(mode, controllers.declaration.routes.TransportContainerController.displayContainerSummary)
+        navigator.continueTo(mode, controllers.declaration.routes.TransportPaymentController.displayPage)
       case DeclarationType.STANDARD | DeclarationType.SUPPLEMENTARY =>
         navigator.continueTo(mode, controllers.declaration.routes.BorderTransportController.displayPage)
     }

--- a/app/controllers/declaration/TransportPaymentController.scala
+++ b/app/controllers/declaration/TransportPaymentController.scala
@@ -41,10 +41,8 @@ class TransportPaymentController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
-  private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
-
   def displayPage(mode: Mode): Action[AnyContent] =
-    (authenticate andThen journeyType(validTypes)) { implicit request =>
+    (authenticate andThen journeyType) { implicit request =>
       request.cacheModel.transport.transportPayment match {
         case Some(data) => Ok(transportPayment(mode, form().fill(data)))
         case _          => Ok(transportPayment(mode, form()))
@@ -52,7 +50,7 @@ class TransportPaymentController @Inject()(
     }
 
   def submitForm(mode: Mode): Action[AnyContent] =
-    (authenticate andThen journeyType(validTypes)).async { implicit request =>
+    (authenticate andThen journeyType).async { implicit request =>
       form()
         .bindFromRequest()
         .fold(

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -101,7 +101,8 @@ object Navigator {
   }
 
   val clearance: PartialFunction[DeclarationPage, Mode => Call] = {
-    case ContainerFirst            => controllers.declaration.routes.DepartureTransportController.displayPage
+    case TransportPayment          => controllers.declaration.routes.DepartureTransportController.displayPage
+    case ContainerFirst            => controllers.declaration.routes.TransportPaymentController.displayPage
     case ContainerAdd              => controllers.declaration.routes.TransportContainerController.displayContainerSummary
     case Document                  => controllers.declaration.routes.OfficeOfExitController.displayPage
     case DestinationCountryPage    => controllers.declaration.routes.DeclarationHolderController.displayPage

--- a/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
@@ -57,7 +57,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
   private def nextPage(decType: DeclarationType) = decType match {
     case SUPPLEMENTARY => routes.BorderTransportController.displayPage()
     case STANDARD      => routes.BorderTransportController.displayPage()
-    case CLEARANCE     => routes.TransportContainerController.displayContainerSummary()
+    case CLEARANCE     => routes.TransportPaymentController.displayPage()
   }
 
   private def formData(transportType: String, reference: String) =
@@ -68,7 +68,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
       )
     )
 
-  "Border transport controller" when {
+  "Departure transport controller" when {
     onJourney(STANDARD, SUPPLEMENTARY, CLEARANCE) { request =>
       "return 200 (OK)" when {
 

--- a/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -18,7 +18,6 @@ package unit.controllers.declaration
 
 import controllers.declaration._
 import forms.declaration.TransportPayment
-import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -66,7 +65,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
   "Transport Payment Controller" should {
 
-    onJourney(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL) { request =>
+    onEveryDeclarationJourney() { request =>
       "return 200 (OK)" when {
 
         "display page method is invoked and cache is empty" in {
@@ -115,32 +114,6 @@ class TransportPaymentControllerSpec extends ControllerSpec {
           thePageNavigatedTo mustBe routes.TransportContainerController.displayContainerSummary()
           verify(transportPaymentPage, times(0)).apply(any(), any())(any(), any())
         }
-      }
-
-    }
-
-    onJourney(CLEARANCE) { request =>
-      "return 303 (SEE_OTHER)" when {
-
-        "display page" in {
-          withNewCaching(request.cacheModel)
-
-          val result = controller.displayPage(Mode.Normal)(getRequest())
-
-          status(result) must be(SEE_OTHER)
-          redirectLocation(result) mustBe Some(controllers.routes.StartController.displayStartPage.url)
-        }
-
-        "submit" in {
-          withNewCaching(request.cacheModel)
-          val correctForm = formData(TransportPayment.other)
-
-          val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
-
-          status(result) must be(SEE_OTHER)
-          redirectLocation(result) mustBe Some(controllers.routes.StartController.displayStartPage.url)
-        }
-
       }
 
     }


### PR DESCRIPTION
There is currently no option for Declarants to add Transport Payment (data element 4/2) when completing a Clearance Request. Declarants should provide details of the transport payment when only for an EXS customs clearance request.