### PR TITLE
CEDS-2064 - Declarant EORI

### DIFF
--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -18,7 +18,9 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import forms.declaration.DeclarantDetails
+import forms.common.Eori
+import forms.common.YesNoAnswer.YesNoAnswers
+import forms.declaration.{DeclarantDetails, DeclarantEoirConfirmation, EntityDetails}
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -43,28 +45,30 @@ class DeclarantDetailsController @Inject()(
 
   def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.parties.declarantDetails match {
-      case Some(data) => Ok(declarantDetailsPage(mode, form().fill(data)))
-      case _          => Ok(declarantDetailsPage(mode, form()))
+      case Some(_) => Ok(declarantDetailsPage(mode, form().fill(DeclarantEoirConfirmation(YesNoAnswers.yes))))
+      case _       => Ok(declarantDetailsPage(mode, form()))
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(
         formWithErrors => Future.successful(BadRequest(declarantDetailsPage(mode, formWithErrors))),
-        validDeclarantDetails =>
-          updateCache(validDeclarantDetails)
-            .map(_ => navigator.continueTo(mode, controllers.declaration.routes.ExporterDetailsController.displayPage))
+        validForm =>
+          if (validForm.answer == YesNoAnswers.yes)
+            updateCache(DeclarantDetails(EntityDetails(Some(Eori(request.eori)), None)))
+              .map(_ => navigator.continueTo(mode, controllers.declaration.routes.ExporterDetailsController.displayPage))
+          else
+            Future.successful(SeeOther(controllers.declaration.routes.NotEligibleController.displayNotDeclarant().url).withNewSession)
       )
   }
 
-  private def form()(implicit request: JourneyRequest[AnyContent]): Form[DeclarantDetails] =
-    DeclarantDetails.form(request.declarationType)
+  private def form()(implicit request: JourneyRequest[AnyContent]): Form[DeclarantEoirConfirmation] =
+    DeclarantEoirConfirmation.form()
 
-  private def updateCache(formData: DeclarantDetails)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
+  private def updateCache(declarant: DeclarantDetails)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => {
-      val updatedParties = model.parties.copy(declarantDetails = Some(formData))
-      model.copy(parties = updatedParties)
+      model.copy(parties = model.parties.copy(declarantDetails = Some(declarant)))
     })
 }

--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -20,7 +20,7 @@ import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.Eori
 import forms.common.YesNoAnswer.YesNoAnswers
-import forms.declaration.{DeclarantDetails, DeclarantEoirConfirmation, EntityDetails}
+import forms.declaration.{DeclarantDetails, DeclarantEoriConfirmation, EntityDetails}
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -45,7 +45,7 @@ class DeclarantDetailsController @Inject()(
 
   def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.parties.declarantDetails match {
-      case Some(_) => Ok(declarantDetailsPage(mode, form().fill(DeclarantEoirConfirmation(YesNoAnswers.yes))))
+      case Some(_) => Ok(declarantDetailsPage(mode, form().fill(DeclarantEoriConfirmation(YesNoAnswers.yes))))
       case _       => Ok(declarantDetailsPage(mode, form()))
     }
   }
@@ -60,12 +60,12 @@ class DeclarantDetailsController @Inject()(
             updateCache(DeclarantDetails(EntityDetails(Some(Eori(request.eori)), None)))
               .map(_ => navigator.continueTo(mode, controllers.declaration.routes.ExporterDetailsController.displayPage))
           else
-            Future.successful(SeeOther(controllers.declaration.routes.NotEligibleController.displayNotDeclarant().url).withNewSession)
+            Future(Redirect(controllers.declaration.routes.NotEligibleController.displayNotDeclarant()).withNewSession)
       )
   }
 
-  private def form()(implicit request: JourneyRequest[AnyContent]): Form[DeclarantEoirConfirmation] =
-    DeclarantEoirConfirmation.form()
+  private def form()(implicit request: JourneyRequest[AnyContent]): Form[DeclarantEoriConfirmation] =
+    DeclarantEoriConfirmation.form()
 
   private def updateCache(declarant: DeclarantDetails)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => {

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -67,7 +67,7 @@ class DispatchLocationController @Inject()(
         controllers.declaration.routes.AdditionalDeclarationTypeController.displayPage
       case AllowedDispatchLocations.SpecialFiscalTerritory =>
         _ =>
-          controllers.declaration.routes.NotEligibleController.displayPage()
+          controllers.declaration.routes.NotEligibleController.displayNotEligible()
     }
 
   private def updateCache(formData: DispatchLocation)(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =

--- a/app/controllers/declaration/NotEligibleController.scala
+++ b/app/controllers/declaration/NotEligibleController.scala
@@ -22,6 +22,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.not_eligible
+import views.html.declaration.not_declarant
 
 import scala.concurrent.ExecutionContext
 
@@ -29,11 +30,17 @@ class NotEligibleController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
   mcc: MessagesControllerComponents,
-  notEligiblePage: not_eligible
+  notEligiblePage: not_eligible,
+  notDeclarantPage: not_declarant
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayNotEligible(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     Ok(notEligiblePage())
   }
+
+  def displayNotDeclarant(): Action[AnyContent] = Action { implicit request =>
+    Ok(notDeclarantPage())
+  }
+
 }

--- a/app/forms/declaration/DeclarantDetails.scala
+++ b/app/forms/declaration/DeclarantDetails.scala
@@ -17,22 +17,10 @@
 package forms.declaration
 
 import forms.DeclarationPage
-import forms.common.Eori
-import models.DeclarationType.DeclarationType
-import play.api.data.{Form, Forms, Mapping}
-import play.api.libs.json.Json
+import play.api.libs.json.{Json, OFormat}
 
 case class DeclarantDetails(details: EntityDetails)
 
 object DeclarantDetails extends DeclarationPage {
-  implicit val format = Json.format[DeclarantDetails]
-
-  val id = "DeclarantDetails"
-
-  val defaultEntityMapping: Mapping[EntityDetails] = Forms
-    .mapping("eori" -> Eori.mapping("declaration.declarant"))(eori => EntityDetails(Some(eori), None))(entityDetails => entityDetails.eori)
-
-  val defaultMapping = Forms.mapping("details" -> defaultEntityMapping)(DeclarantDetails.apply)(DeclarantDetails.unapply)
-
-  def form(declarationType: DeclarationType): Form[DeclarantDetails] = Form(defaultMapping)
+  implicit val format: OFormat[DeclarantDetails] = Json.format[DeclarantDetails]
 }

--- a/app/forms/declaration/DeclarantEoirConfirmation.scala
+++ b/app/forms/declaration/DeclarantEoirConfirmation.scala
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.declaration
+
+import forms.DeclarationPage
+import forms.Mapping.requiredRadio
+import forms.common.YesNoAnswer
+import play.api.data.{Form, Forms}
+import play.api.libs.json.{Json, OFormat}
+import utils.validators.forms.FieldValidator.isContainedIn
+
+case class DeclarantEoirConfirmation(answer: String)
+
+object DeclarantEoirConfirmation extends DeclarationPage {
+
+  implicit val format: OFormat[DeclarantEoirConfirmation] = Json.format[DeclarantEoirConfirmation]
+
+  val isEoriKey = "isEori"
+
+  private val mapping =
+    Forms.mapping(isEoriKey -> requiredRadio("error.yesNo.required").verifying("error.yesNo.required", isContainedIn(YesNoAnswer.allowedValues)))(
+      DeclarantEoirConfirmation.apply
+    )(DeclarantEoirConfirmation.unapply)
+
+  def form(): Form[DeclarantEoirConfirmation] = Form(mapping)
+}

--- a/app/forms/declaration/DeclarantEoriConfirmation.scala
+++ b/app/forms/declaration/DeclarantEoriConfirmation.scala
@@ -23,18 +23,18 @@ import play.api.data.{Form, Forms}
 import play.api.libs.json.{Json, OFormat}
 import utils.validators.forms.FieldValidator.isContainedIn
 
-case class DeclarantEoirConfirmation(answer: String)
+case class DeclarantEoriConfirmation(answer: String)
 
-object DeclarantEoirConfirmation extends DeclarationPage {
+object DeclarantEoriConfirmation extends DeclarationPage {
 
-  implicit val format: OFormat[DeclarantEoirConfirmation] = Json.format[DeclarantEoirConfirmation]
+  implicit val format: OFormat[DeclarantEoriConfirmation] = Json.format[DeclarantEoriConfirmation]
 
   val isEoriKey = "isEori"
 
   private val mapping =
     Forms.mapping(isEoriKey -> requiredRadio("error.yesNo.required").verifying("error.yesNo.required", isContainedIn(YesNoAnswer.allowedValues)))(
-      DeclarantEoirConfirmation.apply
-    )(DeclarantEoirConfirmation.unapply)
+      DeclarantEoriConfirmation.apply
+    )(DeclarantEoriConfirmation.unapply)
 
-  def form(): Form[DeclarantEoirConfirmation] = Form(mapping)
+  def form(): Form[DeclarantEoriConfirmation] = Form(mapping)
 }

--- a/app/views/declaration/declarant_details.scala.html
+++ b/app/views/declaration/declarant_details.scala.html
@@ -15,40 +15,63 @@
  *@
 
 @import controllers.navigation.Navigator
-@import forms.declaration.DeclarantDetails
+@import forms.common.YesNoAnswer.YesNoAnswers
+@import forms.declaration.{DeclarantDetails, DeclarantEoirConfirmation}
+@import forms.declaration.DeclarantEoirConfirmation.isEoriKey
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.{BackButton, Title}
+@import views.components.gds.Styles._
 @import views.html.components.gds._
-@import views.BackButton
-@import views.Title
 
 @this(
-    govukLayout: gdsMainTemplate,
-    errorSummary: errorSummary,
-    sectionHeader: sectionHeader,
-    exportsInputText: exportsInputText,
-    govukDetails : GovukDetails,
-    saveButtons: saveButtons,
-    tariffDetails: tariffDetails,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+govukLayout: gdsMainTemplate,
+errorSummary: errorSummary,
+sectionHeader: sectionHeader,
+govukRadios: GovukRadios,
+exportsInputText: exportsInputText,
+govukDetails : GovukDetails,
+saveButtons: saveButtons,
+tariffDetails: tariffDetails,
+formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@(mode: Mode, form: Form[DeclarantDetails])(implicit request: JourneyRequest[_], messages: Messages)
+@(mode: Mode, form: Form[DeclarantEoirConfirmation])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
     title = Title("declaration.declarant.title"),
     backButton = Some(BackButton(messages("site.back"), Navigator.backLink(DeclarantDetails, mode)))) {
 
-    @formHelper(action = controllers.declaration.routes.DeclarantDetailsController.saveAddress(mode), 'autoComplete -> "off") {
+    @formHelper(action = controllers.declaration.routes.DeclarantDetailsController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
         @sectionHeader(messages("supplementary.summary.parties.header"))
 
-        @exportsInputText(
-            field = form("details.eori"),
-            labelKey = "declaration.declarant.title",
-            isPageHeading = true
-        )
+        @govukRadios(Radios(
+            name = isEoriKey,
+            fieldset = Some(Fieldset(
+                legend = Some(Legend(
+                    content = Text(messages("declaration.declarant.titleQuestion", request.eori)),
+                    isPageHeading = true,
+                    classes = gdsPageLegend
+                ))
+            )),
+            items = Seq(
+                RadioItem(
+                    id = Some("code_yes"),
+                    value = Some(YesNoAnswers.yes),
+                    content = Text(messages("site.yes")),
+                    checked = form(isEoriKey).value.contains(YesNoAnswers.yes)
+                ),
+                RadioItem(
+                    id = Some("code_no"),
+                    value = Some(YesNoAnswers.no),
+                    content = Text(messages("site.no")),
+                    checked = form(isEoriKey).value.contains(YesNoAnswers.no)
+                )
+            ),
+            errorMessage = form(isEoriKey).error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
+        ))
 
         @tariffDetails(messages("site.details.summary_text_this"), HtmlContent(messages("declaration.declarant-details.help.bodyText", components.details_content_link())))
 

--- a/app/views/declaration/declarant_details.scala.html
+++ b/app/views/declaration/declarant_details.scala.html
@@ -16,8 +16,8 @@
 
 @import controllers.navigation.Navigator
 @import forms.common.YesNoAnswer.YesNoAnswers
-@import forms.declaration.{DeclarantDetails, DeclarantEoirConfirmation}
-@import forms.declaration.DeclarantEoirConfirmation.isEoriKey
+@import forms.declaration.{DeclarantDetails, DeclarantEoriConfirmation}
+@import forms.declaration.DeclarantEoriConfirmation.isEoriKey
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.{BackButton, Title}
@@ -36,7 +36,7 @@ tariffDetails: tariffDetails,
 formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
-@(mode: Mode, form: Form[DeclarantEoirConfirmation])(implicit request: JourneyRequest[_], messages: Messages)
+@(mode: Mode, form: Form[DeclarantEoriConfirmation])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
     title = Title("declaration.declarant.title"),

--- a/app/views/declaration/not_declarant.scala.html
+++ b/app/views/declaration/not_declarant.scala.html
@@ -29,7 +29,8 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@descriptionLink = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu">@messages("notDeclarent.descriptionLink")</a>}
+@paragraph1Link = {<a href=@controllers.routes.StartController.displayStartPage.url>@messages("notDeclarent.paragraph1Link")</a>}
+@paragraph2Link = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu">@messages("notDeclarent.paragraph2Link")</a>}
 @supportPhone = {<b>0300 200 3700</b>}
 @enquiriesLink = {<a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries" target="_blank" rel="noopener noreferrer">@messages("general.inquiries.help.link")</a>}
 
@@ -41,7 +42,11 @@
 @pageTitle(messages("notDeclarent.title"))
 
 <p class="govuk-body">
-    @Html(messages("notDeclarent.description", descriptionLink))
+    @Html(messages("notDeclarent.paragraph1", paragraph1Link))
+</p>
+
+<p class="govuk-body">
+@Html(messages("notDeclarent.paragraph2", paragraph2Link))
 </p>
 
 <h2 class="govuk-heading-m">@messages("notDeclarent.referenceTitle")</h2>

--- a/app/views/declaration/not_declarant.scala.html
+++ b/app/views/declaration/not_declarant.scala.html
@@ -1,0 +1,56 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.Title
+@import models.requests.JourneyRequest
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.html.components.gds._
+@import views.{BackButton, Title}
+@import views.html.components.gds._
+
+@this(
+        govukLayout: gdsMainTemplate,
+        pageTitle: pageTitle,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
+
+@()(implicit request: Request[_], messages: Messages)
+
+@descriptionLink = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu">@messages("notDeclarent.descriptionLink")</a>}
+@supportPhone = {<b>0300 200 3700</b>}
+@enquiriesLink = {<a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries" target="_blank" rel="noopener noreferrer">@messages("general.inquiries.help.link")</a>}
+
+@govukLayout(
+    title = Title("notDeclarent.title"),
+    backButton = Some(BackButton(messages("site.back"), controllers.routes.StartController.displayStartPage))){
+
+
+@pageTitle(messages("notDeclarent.title"))
+
+<p class="govuk-body">
+    @Html(messages("notDeclarent.description", descriptionLink))
+</p>
+
+<h2 class="govuk-heading-m">@messages("notDeclarent.referenceTitle")</h2>
+<p class="govuk-body">
+    @Html(messages("notDeclarent.reference.support", supportPhone))
+    @Html(messages("notDeclarent.reference.openingHours"))
+</p>
+
+<p class="govuk-body">
+    @enquiriesLink
+</p>
+}

--- a/app/views/declaration/summary/parties_section.scala.html
+++ b/app/views/declaration/summary/parties_section.scala.html
@@ -62,7 +62,19 @@
 @if(sectionRequired(declarationData.parties)) {
     @summaryList("declaration-parties-summary", Some(messages("declaration.summary.parties")),
 
-        declarationData.parties.exporterDetails.map(export => eoriOrAddress(
+        (Seq.empty :+ declarationData.parties.declarantDetails.map(declarant =>
+            SummaryListRow(
+                classes = "declarant-eori-row",
+                key = Key(
+                    content = Text(messages("declaration.summary.parties.declarant.eori"))
+                ),
+                value = Value(
+                    content = Text(declarant.details.eori.map(_.value).getOrElse(""))
+                )
+            )
+        ))
+
+        ++ declarationData.parties.exporterDetails.map(export => eoriOrAddress(
             "exporter",
             export.details.eori,
             export.details.address,
@@ -75,13 +87,6 @@
             consignee.details.address,
             controllers.declaration.routes.ConsigneeDetailsController.displayPage(mode),
             isEoriDefault = false
-        )).getOrElse(Seq.empty)
-
-        ++ declarationData.parties.declarantDetails.map(declarant => eoriOrAddress(
-            "declarant",
-            declarant.details.eori,
-            declarant.details.address,
-            controllers.declaration.routes.DeclarantDetailsController.displayPage(mode)
         )).getOrElse(Seq.empty)
 
         ++ declarationData.parties.representativeDetails.map(representative => eoriOrAddress(

--- a/conf/declaration.routes
+++ b/conf/declaration.routes
@@ -17,7 +17,9 @@ POST        /type                                controllers.declaration.Additio
 
 # Not Eligible
 
-GET         /not-eligible                        controllers.declaration.NotEligibleController.displayPage()
+GET         /not-eligible                       controllers.declaration.NotEligibleController.displayNotEligible()
+
+GET         /not-declarant                      controllers.declaration.NotEligibleController.displayNotDeclarant()
 
 # Consignment references
 
@@ -35,7 +37,7 @@ POST        /exporter-details                    controllers.declaration.Exporte
 
 GET         /declarant-details                   controllers.declaration.DeclarantDetailsController.displayPage(mode: models.Mode ?= models.Mode.Normal)
 
-POST        /declarant-details                   controllers.declaration.DeclarantDetailsController.saveAddress(mode: models.Mode ?= models.Mode.Normal)
+POST        /declarant-details                   controllers.declaration.DeclarantDetailsController.submitForm(mode: models.Mode ?= models.Mode.Normal)
 
 # Representative details
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -292,8 +292,10 @@ notEligible.reference.support = If you are having problems making a declaration,
 notEligible.reference.openingHours = Open 8am to 6pm, Monday to Friday (closed bank holidays).
 
 notDeclarent.title = Use a different EORI number
-notDeclarent.description = If you need to use a different EORI number, log in using the account with the EORI number you need for this declaration. If you need to change your login details {0}.
-notDeclarent.descriptionLink = contact the EORI contact team
+notDeclarent.paragraph1 = If you need to use a different EORI number you can {0}.
+notDeclarent.paragraph1Link = sign in using another Government Gateway ID
+notDeclarent.paragraph2 = If you need to use a different EORI number, log in using the account with the EORI number you need for this declaration. If you need to change your login details {0}.
+notDeclarent.paragraph2Link = contact the EORI contact team
 notDeclarent.referenceTitle = Help and support
 notDeclarent.reference.support = If you are having problems making a declaration, phone: {0} 
 notDeclarent.reference.openingHours = Open 8am to 6pm, Monday to Friday (closed bank holidays).

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -291,6 +291,13 @@ notEligible.referenceTitle = Help and support
 notEligible.reference.support = If you are having problems making a declaration, phone: {0} 
 notEligible.reference.openingHours = Open 8am to 6pm, Monday to Friday (closed bank holidays).
 
+notDeclarent.title = Change your EORI number
+notDeclarent.description = Your EORI number is linked to your login details. To change them you will need to sign in using different Government Gateway details, or {0}.
+notDeclarent.descriptionLink = contact the EORI contact team
+notDeclarent.referenceTitle = Help and support
+notDeclarent.reference.support = If you are having problems making a declaration, phone: {0} 
+notDeclarent.reference.openingHours = Open 8am to 6pm, Monday to Friday (closed bank holidays).
+
 supplementary.consignmentReferences.heading = Your references
 supplementary.consignmentReferences.header =  Consignment references
 supplementary.consignmentReferences.ducr.info = Give this declaration a Unique Consignment Reference (UCR)
@@ -308,7 +315,9 @@ supplementary.consignor.address.info = Exporter’s name and business address
 supplementary.exporter-details.help-item1 = Exporter’s EORI number, go to data element 3/2 Exporter Identification Number
 supplementary.exporter-details.help-item2 = Exporter’s name and business address, go to data element 3/1 Exporter
 
-declaration.declarant.title = What is your EORI number?
+declaration.declarant.title = Is this your EORI number?
+declaration.declarant.titleQuestion = Is your EORI number {0}?
+declaration.declarant.change.eori = No, I need to change my EORI
 declaration.declarant-details.help.bodyText = Go to data element 3/18 Declarant Identification Number in the {0}.
 declaration.declarant.eori.empty = Enter your EORI number
 declaration.declarant.eori.error.format = Enter a valid EORI number, for example GB123456789000
@@ -950,7 +959,7 @@ declaration.summary.parties.consignee.eori = Consignee''s EORI number
 declaration.summary.parties.consignee.eori.change = Change Consignee''s EORI number
 declaration.summary.parties.consignee.address = Consignee''s address
 declaration.summary.parties.consignee.address.change = Change Consignee''s address
-declaration.summary.parties.declarant.eori = Declarant''s EORI number
+declaration.summary.parties.declarant.eori = Your EORI number
 declaration.summary.parties.declarant.eori.change = Change Declarant''s EORI number
 declaration.summary.parties.declarant.address = Declarant''s address
 declaration.summary.parties.declarant.address.change = Change Declarant''s address

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -291,8 +291,8 @@ notEligible.referenceTitle = Help and support
 notEligible.reference.support = If you are having problems making a declaration, phone: {0} 
 notEligible.reference.openingHours = Open 8am to 6pm, Monday to Friday (closed bank holidays).
 
-notDeclarent.title = Change your EORI number
-notDeclarent.description = Your EORI number is linked to your login details. To change them you will need to sign in using different Government Gateway details, or {0}.
+notDeclarent.title = Use a different EORI number
+notDeclarent.description = If you need to use a different EORI number, log in using the account with the EORI number you need for this declaration. If you need to change your login details {0}.
 notDeclarent.descriptionLink = contact the EORI contact team
 notDeclarent.referenceTitle = Help and support
 notDeclarent.reference.support = If you are having problems making a declaration, phone: {0} 

--- a/docs/Customs Declare Exports AutoComplete.js
+++ b/docs/Customs Declare Exports AutoComplete.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Customs Declare Exports AutoComplete
 // @namespace    http://tampermonkey.net/
-// @version      1.34
+// @version      1.35
 // @description  decs supported: (Std-Frontier A), (Occ-Frontier B), (Smp-Frontier C), (Std-PreLodged D), (Occ-PreLodged E), (Smp-PreLodged F), (Clr-Frontier J), (Clr-PreLodged K), (Sup-SDP Y), (Sup-EIDR Z)
 // @author       You
 // @match        http*://*/customs-declare-exports*
@@ -239,21 +239,8 @@ function consigneeDetails(){
 
 function declarantDetails(){
     if (currentPageIs("/customs-declare-exports/declaration/declarant-details")) {
-        switch(getDeclaration()){
-            case 'E':
-            case 'F':
-            case 'K':
-            case 'Y':
-                document.getElementById('details_eori').value = 'GB717572504502801';
-                break;
-            case 'D':
-            case 'J':
-                document.getElementById('details_eori').value = 'GB717572504502811';
-                break;
-            default:
-                document.getElementById('details_eori').value = 'GB717572504502802';
-        }
-        document.getElementById('submit').click()
+        document.getElementById('code_yes').checked = 'checked';
+        document.getElementById('submit').click();
     }
 }
 

--- a/test/forms/declaration/DeclarantDetailsSpec.scala
+++ b/test/forms/declaration/DeclarantDetailsSpec.scala
@@ -16,64 +16,13 @@
 
 package forms.declaration
 
-import models.DeclarationType._
-import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsObject, JsValue}
-
-class DeclarantDetailsSpec extends WordSpec with MustMatchers {
-
-  import DeclarantDetailsSpec._
-
-  Seq(SUPPLEMENTARY, STANDARD, OCCASIONAL, SIMPLIFIED, CLEARANCE).map { decType =>
-    "Declarant details mapping used for binding data" should {
-
-      s"return form with errors for $decType journey" when {
-
-        "provided with empty input" in {
-
-          val form = DeclarantDetails.form(decType).bind(emptyDeclarantDetailsJSON)
-
-          form.hasErrors mustBe true
-          form.errors.length must equal(1)
-          form.errors.head.message must equal("declaration.declarant.eori.empty")
-        }
-      }
-    }
-  }
-
-  Seq(SUPPLEMENTARY, STANDARD, OCCASIONAL, SIMPLIFIED, CLEARANCE).map { decType =>
-    "Declarant details mapping used for binding data" should {
-
-      s"return form with errors for $decType journey" when {
-
-        "provided with an invalid EORI" in {
-
-          val form = DeclarantDetails.form(decType).bind(invalidDeclarantDetailsEORIOnlyJSON)
-
-          form.hasErrors mustBe true
-          form.errors.length must equal(1)
-          form.errors.head.message must equal("declaration.declarant.eori.error.format")
-        }
-      }
-
-      s"return form without errors for $decType journey" when {
-
-        "provided with valid input" in {
-
-          val form = DeclarantDetails.form(decType).bind(correctDeclarantDetailsJSON)
-
-          form.hasErrors mustBe false
-        }
-      }
-    }
-  }
-}
 
 object DeclarantDetailsSpec {
   import forms.declaration.EntityDetailsSpec._
 
-  val correctDeclarantDetails = DeclarantDetails(details = EntityDetailsSpec.correctEntityDetails)
-  val correctDeclarantDetailsEORIOnly = DeclarantDetails(details = EntityDetailsSpec.correctEntityDetailsEORIOnly)
+  val correctDeclarantDetails: DeclarantDetails = DeclarantDetails(details = EntityDetailsSpec.correctEntityDetails)
+  val correctDeclarantDetailsEORIOnly: DeclarantDetails = DeclarantDetails(details = EntityDetailsSpec.correctEntityDetailsEORIOnly)
 
   val correctDeclarantDetailsJSON: JsValue = JsObject(Map("details" -> correctEntityDetailsJSON))
   val correctDeclarantDetailsEORIOnlyJSON: JsValue = JsObject(Map("details" -> correctEntityDetailsEORIOnlyJSON))

--- a/test/forms/declaration/DeclarantEoriConfirmationSpec.scala
+++ b/test/forms/declaration/DeclarantEoriConfirmationSpec.scala
@@ -17,7 +17,7 @@
 package forms.declaration
 
 import forms.common.YesNoAnswer.YesNoAnswers
-import forms.declaration.DeclarantEoirConfirmation.isEoriKey
+import forms.declaration.DeclarantEoriConfirmation.isEoriKey
 import org.scalatest.{MustMatchers, WordSpec}
 import play.api.libs.json.{JsObject, JsString, JsValue}
 
@@ -31,7 +31,7 @@ class DeclarantEoriConfirmationSpec extends WordSpec with MustMatchers {
 
       "provided with empty input" in {
 
-        val form = DeclarantEoirConfirmation.form().bind(emptyJSON)
+        val form = DeclarantEoriConfirmation.form().bind(emptyJSON)
 
         form.hasErrors mustBe true
         form.errors.length must equal(1)
@@ -40,7 +40,7 @@ class DeclarantEoriConfirmationSpec extends WordSpec with MustMatchers {
 
       "provided with invalid input" in {
 
-        val form = DeclarantEoirConfirmation.form().bind(invalidJSON)
+        val form = DeclarantEoriConfirmation.form().bind(invalidJSON)
 
         form.hasErrors mustBe true
         form.errors.length must equal(1)
@@ -49,7 +49,7 @@ class DeclarantEoriConfirmationSpec extends WordSpec with MustMatchers {
 
       "provided with valid input" in {
 
-        val form = DeclarantEoirConfirmation.form().bind(validJSON)
+        val form = DeclarantEoriConfirmation.form().bind(validJSON)
 
         form.hasErrors mustBe false
       }

--- a/test/forms/declaration/DeclarantEoriConfirmationSpec.scala
+++ b/test/forms/declaration/DeclarantEoriConfirmationSpec.scala
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package forms.declaration
+
+import forms.common.YesNoAnswer.YesNoAnswers
+import forms.declaration.DeclarantEoirConfirmation.isEoriKey
+import org.scalatest.{MustMatchers, WordSpec}
+import play.api.libs.json.{JsObject, JsString, JsValue}
+
+class DeclarantEoriConfirmationSpec extends WordSpec with MustMatchers {
+
+  import DeclarantEoriConfirmationSpec._
+
+  "Declarant EORI confirmation mapping used for binding data" should {
+
+    "return form with errors" when {
+
+      "provided with empty input" in {
+
+        val form = DeclarantEoirConfirmation.form().bind(emptyJSON)
+
+        form.hasErrors mustBe true
+        form.errors.length must equal(1)
+        form.errors.head.message must equal("error.yesNo.required")
+      }
+
+      "provided with invalid input" in {
+
+        val form = DeclarantEoirConfirmation.form().bind(invalidJSON)
+
+        form.hasErrors mustBe true
+        form.errors.length must equal(1)
+        form.errors.head.message must equal("error.yesNo.required")
+      }
+
+      "provided with valid input" in {
+
+        val form = DeclarantEoirConfirmation.form().bind(validJSON)
+
+        form.hasErrors mustBe false
+      }
+    }
+  }
+
+}
+
+object DeclarantEoriConfirmationSpec {
+
+  val emptyJSON: JsValue = JsObject(Map(isEoriKey -> JsString("")))
+  val invalidJSON: JsValue = JsObject(Map(isEoriKey -> JsString("invalid")))
+  val validJSON: JsValue = JsObject(Map(isEoriKey -> JsString(YesNoAnswers.yes)))
+}

--- a/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -18,8 +18,8 @@ package unit.controllers.declaration
 
 import controllers.declaration.DeclarantDetailsController
 import forms.common.YesNoAnswer.YesNoAnswers
-import forms.declaration.DeclarantEoirConfirmation
-import forms.declaration.DeclarantEoirConfirmation.isEoriKey
+import forms.declaration.DeclarantEoriConfirmation
+import forms.declaration.DeclarantEoriConfirmation.isEoriKey
 import models.{DeclarationType, Mode}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -46,7 +46,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec {
 
     authorizedUser()
     withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
-    when(declarantDetailsPage.apply(any[Mode], any[Form[DeclarantEoirConfirmation]])(any(), any())).thenReturn(HtmlFormat.empty)
+    when(declarantDetailsPage.apply(any[Mode], any[Form[DeclarantEoriConfirmation]])(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   "Declarant Details Controller" should {

--- a/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
+++ b/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
@@ -31,7 +31,7 @@ import views.html.declaration.dispatch_location
 class DispatchLocationControllerSpec extends ControllerSpec {
 
   trait SetUp {
-    val dispatchLocationPage = mock[dispatch_location]
+    private val dispatchLocationPage = mock[dispatch_location]
 
     val controller = new DispatchLocationController(
       mockAuthAction,
@@ -53,7 +53,7 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
       "display page method is invoked and cache is empty" in new SetUp {
 
-        val result = controller.displayPage(Mode.Normal)(getRequest())
+        private val result = controller.displayPage(Mode.Normal)(getRequest())
 
         status(result) must be(OK)
       }
@@ -62,7 +62,7 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
         withNewCaching(aDeclaration(withDispatchLocation(OutsideEU)))
 
-        val result = controller.displayPage(Mode.Normal)(getRequest())
+        private val result = controller.displayPage(Mode.Normal)(getRequest())
 
         status(result) must be(OK)
       }
@@ -72,9 +72,9 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
       "form is incorrect" in new SetUp {
 
-        val incorrectForm = Json.toJson(DispatchLocation("incorrect"))
+        private val incorrectForm = Json.toJson(DispatchLocation("incorrect"))
 
-        val result = controller.submitForm(Mode.Normal)(postRequest(incorrectForm))
+        private val result = controller.submitForm(Mode.Normal)(postRequest(incorrectForm))
 
         status(result) must be(BAD_REQUEST)
       }
@@ -84,9 +84,9 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
       "form is correct" in new SetUp {
 
-        val correctForm = Json.toJson(DispatchLocation(OutsideEU))
+        private val correctForm = Json.toJson(DispatchLocation(OutsideEU))
 
-        val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
+        private val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalDeclarationTypeController.displayPage()
@@ -97,12 +97,12 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
       "form is correct" in new SetUp {
 
-        val correctForm = Json.toJson(DispatchLocation(SpecialFiscalTerritory))
+        private val correctForm = Json.toJson(DispatchLocation(SpecialFiscalTerritory))
 
-        val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
+        private val result = controller.submitForm(Mode.Normal)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
-        thePageNavigatedTo mustBe controllers.declaration.routes.NotEligibleController.displayPage()
+        thePageNavigatedTo mustBe controllers.declaration.routes.NotEligibleController.displayNotEligible()
       }
     }
   }

--- a/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
+++ b/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
@@ -19,34 +19,45 @@ package unit.controllers.declaration
 import controllers.declaration.NotEligibleController
 import models.DeclarationType
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.when
+import org.mockito.Mockito.{times, verify, when}
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import unit.base.ControllerSpec
-import views.html.declaration.not_eligible
+import views.html.declaration.{not_declarant, not_eligible}
 
 class NotEligibleControllerSpec extends ControllerSpec {
 
   trait SetUp {
-    val notEligiblePage = mock[not_eligible]
+    val notEligiblePage: not_eligible = mock[not_eligible]
+    val notDeclarantPage: not_declarant = mock[not_declarant]
 
     val controller =
-      new NotEligibleController(mockAuthAction, mockJourneyAction, stubMessagesControllerComponents(), notEligiblePage)(ec)
+      new NotEligibleController(mockAuthAction, mockJourneyAction, stubMessagesControllerComponents(), notEligiblePage, notDeclarantPage)(ec)
 
     authorizedUser()
     withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))
     when(notEligiblePage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
+    when(notDeclarantPage.apply()(any(), any())).thenReturn(HtmlFormat.empty)
   }
 
   "Not Eligible Controller" should {
 
     "return 200 (OK)" when {
 
-      "display method is invoked" in new SetUp {
+      "display not eligible location is invoked" in new SetUp {
 
-        val result = controller.displayPage()(getRequest())
+        private val result = controller.displayNotEligible()(getRequest())
 
         status(result) must be(OK)
+        verify(notEligiblePage, times(1)).apply()(any(), any())
+      }
+
+      "display not eligible user is invoked" in new SetUp {
+
+        private val result = controller.displayNotDeclarant()(getRequest())
+
+        status(result) must be(OK)
+        verify(notDeclarantPage, times(1)).apply()(any(), any())
       }
     }
   }

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -16,11 +16,11 @@
 
 package views.declaration
 
-import base.{Injector, TestHelper}
+import base.Injector
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
-import forms.common.Eori
-import forms.declaration.{DeclarantDetails, EntityDetails}
+import forms.common.YesNoAnswer.YesNoAnswers
+import forms.declaration.DeclarantEoirConfirmation
 import helpers.views.declaration.CommonMessages
 import models.DeclarationType.DeclarationType
 import models.Mode
@@ -36,9 +36,9 @@ import views.tags.ViewTest
 @ViewTest
 class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with CommonMessages with Stubs with Injector {
 
-  private def form(journeyType: DeclarationType): Form[DeclarantDetails] = DeclarantDetails.form(journeyType)
+  private def form(journeyType: DeclarationType): Form[DeclarantEoirConfirmation] = DeclarantEoirConfirmation.form()
   private val declarantDetailsPage = instanceOf[declarant_details]
-  private def createView(form: Form[DeclarantDetails]): Document =
+  private def createView(form: Form[DeclarantEoirConfirmation]): Document =
     declarantDetailsPage(Mode.Normal, form)(journeyRequest(), messages)
 
   "Declarant Details View on empty page" should {
@@ -57,11 +57,9 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
   "Declarant Details View on empty page" should {
 
     onEveryDeclarationJourney() { implicit request =>
-      "display input label as page title" in {
+      "display page title" in {
 
-        createView(form(request.declarationType)).getElementsByClass("govuk-label govuk-label--l").text() mustBe messages(
-          "declaration.declarant.title"
-        )
+        createView(form(request.declarationType)).getElementsByTag("h1").text() mustBe messages("declaration.declarant.titleQuestion")
       }
 
       "display section header" in {
@@ -71,12 +69,15 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
         )
       }
 
-      "display empty input with label for EORI" in {
-
+      "display radio button with Yes option" in {
         val view = createView(form(request.declarationType))
-
-        view.getElementsByAttributeValue("for", "details_eori").text() mustBe messages("declaration.declarant.title")
-        view.getElementById("details_eori").attr("value") mustBe empty
+        view.getElementById("code_yes").attr("value") mustBe YesNoAnswers.yes
+        view.getElementsByAttributeValue("for", "code_yes").text() mustBe "site.yes"
+      }
+      "display radio button with No option" in {
+        val view = createView(form(request.declarationType))
+        view.getElementById("code_no").attr("value") mustBe YesNoAnswers.no
+        view.getElementsByAttributeValue("for", "code_no").text() mustBe "site.no"
       }
 
       "display 'Back' button that links to 'Consignment References' page" in {
@@ -104,12 +105,12 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
   "Declarant Details View with invalid input" should {
 
     onEveryDeclarationJourney() { implicit request =>
-      "display error when EORI is empty" in {
+      "display error when answer is empty" in {
 
-        val view = createView(DeclarantDetails.form(request.declarationType).fillAndValidate(DeclarantDetails(EntityDetails(Some(Eori("")), None))))
+        val view = createView(form(request.declarationType).fillAndValidate(DeclarantEoirConfirmation("")))
 
         view must haveGovukGlobalErrorSummary
-        view must containErrorElementWithTagAndHref("a", "#details_eori")
+        view must containErrorElementWithTagAndHref("a", "#isEori")
 
         view.getElementsByClass("govuk-error-message").text() contains messages("declaration.declarant.eori.empty")
       }
@@ -117,13 +118,12 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
       "display error when EORI is provided, but is incorrect" in {
 
         val view = createView(
-          DeclarantDetails
-            .form(request.declarationType)
-            .fillAndValidate(DeclarantDetails(EntityDetails(Some(Eori(TestHelper.createRandomAlphanumericString(19))), None)))
+          form(request.declarationType)
+            .fillAndValidate(DeclarantEoirConfirmation("wrong"))
         )
 
         view must haveGovukGlobalErrorSummary
-        view must containErrorElementWithTagAndHref("a", "#details_eori")
+        view must containErrorElementWithTagAndHref("a", "#isEori")
 
         view.getElementsByClass("govuk-error-message").text() contains messages("declaration.declarant.eori.error.format")
       }
@@ -134,12 +134,12 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
   "Declarant Details View when filled" should {
 
     onEveryDeclarationJourney() { implicit request =>
-      "display data in EORI input" in {
+      "display answer input" in {
 
-        val form = DeclarantDetails.form(request.declarationType).fill(DeclarantDetails(EntityDetails(Some(Eori("1234")), None)))
+        val form = DeclarantEoirConfirmation.form().fill(DeclarantEoirConfirmation(YesNoAnswers.yes))
         val view = createView(form)
 
-        view.getElementById("details_eori").attr("value") mustBe "1234"
+        view.getElementById("code_yes").attr("value") mustBe YesNoAnswers.yes
       }
     }
   }

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -20,7 +20,7 @@ import base.Injector
 import controllers.declaration.routes
 import controllers.util.SaveAndReturn
 import forms.common.YesNoAnswer.YesNoAnswers
-import forms.declaration.DeclarantEoirConfirmation
+import forms.declaration.DeclarantEoriConfirmation
 import helpers.views.declaration.CommonMessages
 import models.DeclarationType.DeclarationType
 import models.Mode
@@ -36,9 +36,9 @@ import views.tags.ViewTest
 @ViewTest
 class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with CommonMessages with Stubs with Injector {
 
-  private def form(journeyType: DeclarationType): Form[DeclarantEoirConfirmation] = DeclarantEoirConfirmation.form()
+  private def form(journeyType: DeclarationType): Form[DeclarantEoriConfirmation] = DeclarantEoriConfirmation.form()
   private val declarantDetailsPage = instanceOf[declarant_details]
-  private def createView(form: Form[DeclarantEoirConfirmation]): Document =
+  private def createView(form: Form[DeclarantEoriConfirmation]): Document =
     declarantDetailsPage(Mode.Normal, form)(journeyRequest(), messages)
 
   "Declarant Details View on empty page" should {
@@ -107,7 +107,7 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
     onEveryDeclarationJourney() { implicit request =>
       "display error when answer is empty" in {
 
-        val view = createView(form(request.declarationType).fillAndValidate(DeclarantEoirConfirmation("")))
+        val view = createView(form(request.declarationType).fillAndValidate(DeclarantEoriConfirmation("")))
 
         view must haveGovukGlobalErrorSummary
         view must containErrorElementWithTagAndHref("a", "#isEori")
@@ -119,7 +119,7 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
 
         val view = createView(
           form(request.declarationType)
-            .fillAndValidate(DeclarantEoirConfirmation("wrong"))
+            .fillAndValidate(DeclarantEoriConfirmation("wrong"))
         )
 
         view must haveGovukGlobalErrorSummary
@@ -136,7 +136,7 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
     onEveryDeclarationJourney() { implicit request =>
       "display answer input" in {
 
-        val form = DeclarantEoirConfirmation.form().fill(DeclarantEoirConfirmation(YesNoAnswers.yes))
+        val form = DeclarantEoriConfirmation.form().fill(DeclarantEoriConfirmation(YesNoAnswers.yes))
         val view = createView(form)
 
         view.getElementById("code_yes").attr("value") mustBe YesNoAnswers.yes

--- a/test/views/declaration/summary/PartiesSectionViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionViewSpec.scala
@@ -26,10 +26,10 @@ import views.html.declaration.summary.parties_section
 
 class PartiesSectionViewSpec extends UnitViewSpec with ExportsTestData with Injector {
 
-  val exampleEori = "GB123456"
-  val exampleAddress = Address("fullName", "addressLine", "townOrCity", "postCode", "GB")
-  val exampleAddressContents = "fullName addressLine townOrCity postCode GB"
-  val data = aDeclaration(
+  private val exampleEori = "GB123456"
+  private val exampleAddress = Address("fullName", "addressLine", "townOrCity", "postCode", "GB")
+  private val exampleAddressContents = "fullName addressLine townOrCity postCode GB"
+  private val data = aDeclaration(
     withExporterDetails(Some(Eori(exampleEori)), Some(exampleAddress)),
     withConsigneeDetails(Some(Eori(exampleEori)), Some(exampleAddress)),
     withDeclarantDetails(Some(Eori(exampleEori)), Some(exampleAddress)),
@@ -80,21 +80,12 @@ class PartiesSectionViewSpec extends UnitViewSpec with ExportsTestData with Inje
         addressRow must haveSummaryActionsHref(controllers.declaration.routes.ConsigneeDetailsController.displayPage(Mode.Change))
       }
 
-      "contains declarant details with change button" in {
+      "contains declarant eori" in {
 
         val eoriRow = view.getElementsByClass("declarant-eori-row")
 
         eoriRow must haveSummaryKey(messages("declaration.summary.parties.declarant.eori"))
         eoriRow must haveSummaryValue(exampleEori)
-        eoriRow must haveSummaryActionsText("site.change declaration.summary.parties.declarant.eori.change")
-        eoriRow must haveSummaryActionsHref(controllers.declaration.routes.DeclarantDetailsController.displayPage(Mode.Change))
-
-        val addressRow = view.getElementsByClass("declarant-address-row")
-
-        addressRow must haveSummaryKey(messages("declaration.summary.parties.declarant.address"))
-        addressRow must haveSummaryValue(exampleAddressContents)
-        addressRow must haveSummaryActionsText("site.change declaration.summary.parties.declarant.address.change")
-        addressRow must haveSummaryActionsHref(controllers.declaration.routes.DeclarantDetailsController.displayPage(Mode.Change))
       }
 
       "contains representative details with change button" in {


### PR DESCRIPTION
This PR changes the declarant EORI page from asking the user to enter their EORI to presenting them with the EORI from their login credentials and asking them to confirm it's correct.

I've not changed the cache model.  If the user confirms that the EORI is correct I copy it into the existing DeclarantDetails structure.

I've the user select's "No" they are logged out and shown a new "ineligible" page (content subject to change).

Finally, the declarant's EORI is presented on the summary screen as the first value in the Parties Section and the ability to 'change' has been removed.