### PR TITLE
BAU-2275 - Add Transport Payment screen into Clearance Request Journey

### DIFF
--- a/app/controllers/declaration/TransportPaymentController.scala
+++ b/app/controllers/declaration/TransportPaymentController.scala
@@ -41,8 +41,10 @@ class TransportPaymentController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
+  private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL, DeclarationType.CLEARANCE)
+
   def displayPage(mode: Mode): Action[AnyContent] =
-    (authenticate andThen journeyType) { implicit request =>
+    (authenticate andThen journeyType(validTypes)) { implicit request =>
       request.cacheModel.transport.transportPayment match {
         case Some(data) => Ok(transportPayment(mode, form().fill(data)))
         case _          => Ok(transportPayment(mode, form()))
@@ -50,7 +52,7 @@ class TransportPaymentController @Inject()(
     }
 
   def submitForm(mode: Mode): Action[AnyContent] =
-    (authenticate andThen journeyType).async { implicit request =>
+    (authenticate andThen journeyType(validTypes)).async { implicit request =>
       form()
         .bindFromRequest()
         .fold(

--- a/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -18,6 +18,7 @@ package unit.controllers.declaration
 
 import controllers.declaration._
 import forms.declaration.TransportPayment
+import models.DeclarationType._
 import models.{DeclarationType, Mode}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -65,7 +66,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
   "Transport Payment Controller" should {
 
-    onEveryDeclarationJourney() { request =>
+    onJourney(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE) { request =>
       "return 200 (OK)" when {
 
         "display page method is invoked and cache is empty" in {
@@ -116,6 +117,21 @@ class TransportPaymentControllerSpec extends ControllerSpec {
         }
       }
 
+    }
+
+    onJourney(SUPPLEMENTARY) { request =>
+
+      "return 303 (SEE_OTHER)" when {
+
+        "display page method is invoked" in {
+          withNewCaching(request.cacheModel)
+
+          val result = controller.displayPage(Mode.Normal)(getRequest())
+
+          status(result) must be (SEE_OTHER)
+          redirectLocation(result) must contain(controllers.routes.StartController.displayStartPage().url)
+        }
+      }
     }
 
   }

--- a/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -120,7 +120,6 @@ class TransportPaymentControllerSpec extends ControllerSpec {
     }
 
     onJourney(SUPPLEMENTARY) { request =>
-
       "return 303 (SEE_OTHER)" when {
 
         "display page method is invoked" in {
@@ -128,7 +127,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
           val result = controller.displayPage(Mode.Normal)(getRequest())
 
-          status(result) must be (SEE_OTHER)
+          status(result) must be(SEE_OTHER)
           redirectLocation(result) must contain(controllers.routes.StartController.displayStartPage().url)
         }
       }


### PR DESCRIPTION
Ensure SUPPLEMENTARY journey is not valid for the Transport Payment page.

There is currently no option for Declarants to add Transport Payment (data element 4/2) when completing a Clearance Request. Declarants should provide details of the transport payment when only for an EXS customs clearance request.