### PR TITLE
CEDS-2230 - fix for accessibility where there is no "change" link

### DIFF
--- a/app/views/declaration/summary/parties_section.scala.html
+++ b/app/views/declaration/summary/parties_section.scala.html
@@ -70,7 +70,10 @@
                 ),
                 value = Value(
                     content = Text(declarant.details.eori.map(_.value).getOrElse(""))
-                )
+                ),
+                actions = Some(Actions(
+                    items = Seq(ActionItem())
+                ))
             )
         ))
 


### PR DESCRIPTION
There appears to be a bug with the govukfrontend  `SummaryList` component when rendering a row without a "Change" link.

The old code rendered an "illegal" empty `<span>` as a child of a `<dl>` - e.g.
```
<div class="govuk-summary-list__row declarant-eori-row">
  <dt class="govuk-summary-list__key">
    Your EORI number
  </dt>
  <dd class="govuk-summary-list__value">
    GB717572504502811
  </dd>
  <span class="govuk-summary-list__actions"></span>
</div>
```

With the change, it renders an empty `<dd>` element - 
```
<div class="govuk-summary-list__row declarant-eori-row">
  <dt class="govuk-summary-list__key">
    Your EORI number
  </dt>
  <dd class="govuk-summary-list__value">
    GB717572504502811
  </dd>
    <dd class="govuk-summary-list__actions">
      <a class="govuk-link" href=""> </a>
    </dd>
</div>
```
Well - one with an empty link.