### PR TITLE
CEDS-2366 Display cached Non-Uk Office of Exit

### DIFF
--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -18,8 +18,8 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import forms.declaration.officeOfExit.{AllowedUKOfficeOfExitAnswers, OfficeOfExit, OfficeOfExitInsideUK}
 import forms.declaration.officeOfExit.OfficeOfExitInsideUK.form
+import forms.declaration.officeOfExit.{AllowedUKOfficeOfExitAnswers, OfficeOfExit, OfficeOfExitInsideUK}
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -60,7 +60,7 @@ class OfficeOfExitController @Inject()(
           Future.successful(BadRequest(officeOfExitPage(mode, formWithAdjustedErrors)))
         },
         form =>
-          updateCache(form)
+          updateCache(form, request.cacheModel.locations.officeOfExit)
             .map(_ => navigator.continueTo(mode, nextPage(request.declarationType, form.isUkOfficeOfExit)))
       )
   }
@@ -77,6 +77,10 @@ class OfficeOfExitController @Inject()(
       }
     }
 
-  private def updateCache(formData: OfficeOfExitInsideUK)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
-    updateExportsDeclarationSyncDirect(model => model.copy(locations = model.locations.copy(officeOfExit = Some(OfficeOfExit.from(formData)))))
+  private def updateCache(formData: OfficeOfExitInsideUK, officeOfExit: Option[OfficeOfExit])(
+    implicit r: JourneyRequest[AnyContent]
+  ): Future[Option[ExportsDeclaration]] =
+    updateExportsDeclarationSyncDirect(
+      model => model.copy(locations = model.locations.copy(officeOfExit = Some(OfficeOfExit.from(formData, officeOfExit))))
+    )
 }

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -157,7 +157,8 @@ object Navigator {
     case TransportPayment            => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
     case ContainerFirst              => controllers.declaration.routes.TransportPaymentController.displayPage
     case ContainerAdd                => controllers.declaration.routes.TransportContainerController.displayContainerSummary
-    case Document                    => controllers.declaration.routes.OfficeOfExitController.displayPage
+    case Document                    => controllers.declaration.routes.OfficeOfExitOutsideUkController.displayPage
+    case OfficeOfExitOutsideUK       => controllers.declaration.routes.OfficeOfExitController.displayPage
     case DestinationCountryPage      => controllers.declaration.routes.DeclarationHolderController.displayPage
     case RoutingQuestionPage         => controllers.declaration.routes.DestinationCountryController.displayPage
     case RemoveCountryPage           => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage
@@ -185,7 +186,8 @@ object Navigator {
     case TransportPayment            => controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
     case ContainerFirst              => controllers.declaration.routes.TransportPaymentController.displayPage
     case ContainerAdd                => controllers.declaration.routes.TransportContainerController.displayContainerSummary
-    case Document                    => controllers.declaration.routes.OfficeOfExitController.displayPage
+    case Document                    => controllers.declaration.routes.OfficeOfExitOutsideUkController.displayPage
+    case OfficeOfExitOutsideUK       => controllers.declaration.routes.OfficeOfExitController.displayPage
     case DestinationCountryPage      => controllers.declaration.routes.DeclarationHolderController.displayPage
     case RoutingQuestionPage         => controllers.declaration.routes.DestinationCountryController.displayPage
     case RemoveCountryPage           => controllers.declaration.routes.RoutingCountriesSummaryController.displayPage

--- a/app/forms/declaration/officeOfExit/OfficeOfExit.scala
+++ b/app/forms/declaration/officeOfExit/OfficeOfExit.scala
@@ -25,11 +25,15 @@ object OfficeOfExit {
   def from(officeOfExitOutsideUK: OfficeOfExitOutsideUK): OfficeOfExit =
     OfficeOfExit(Some(officeOfExitOutsideUK.officeId), Some(AllowedUKOfficeOfExitAnswers.no))
 
-  def from(officeOfExitInsideUK: OfficeOfExitInsideUK): OfficeOfExit = officeOfExitInsideUK.isUkOfficeOfExit match {
-    case AllowedUKOfficeOfExitAnswers.yes => OfficeOfExit(officeOfExitInsideUK.officeId, Some(officeOfExitInsideUK.isUkOfficeOfExit))
-    case _                                => OfficeOfExit(None, Some(AllowedUKOfficeOfExitAnswers.no))
-  }
-
+  def from(officeOfExitInsideUK: OfficeOfExitInsideUK, existingValue: Option[OfficeOfExit]): OfficeOfExit =
+    officeOfExitInsideUK.isUkOfficeOfExit match {
+      case AllowedUKOfficeOfExitAnswers.yes => OfficeOfExit(officeOfExitInsideUK.officeId, Some(officeOfExitInsideUK.isUkOfficeOfExit))
+      case AllowedUKOfficeOfExitAnswers.no =>
+        existingValue.flatMap(_.isUkOfficeOfExit) match {
+          case Some(AllowedUKOfficeOfExitAnswers.no) => OfficeOfExit(existingValue.flatMap(_.officeId), Some(AllowedUKOfficeOfExitAnswers.no))
+          case _                                     => OfficeOfExit(None, Some(AllowedUKOfficeOfExitAnswers.no))
+        }
+    }
 }
 object AllowedUKOfficeOfExitAnswers {
   val yes = "Yes"

--- a/test/views/declaration/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsViewSpec.scala
@@ -18,6 +18,7 @@ package views.declaration
 import base.Injector
 import forms.DeclarationPage
 import forms.declaration.Document
+import forms.declaration.officeOfExit.OfficeOfExitOutsideUK
 import models.DeclarationType.DeclarationType
 import models.{DeclarationType, Mode}
 import org.jsoup.nodes.{Document => JsonDocument}
@@ -112,28 +113,37 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with S
     }
 
     "display 'Back' button that links to 'Transaction Type' page" when {
-      "on the Standard journey" in {
+      onJourney(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY) { request =>
+        "has a valid back button" in {
 
-        val backButton = view.getElementById("back-link")
+          val backButton = view.getElementById("back-link")
 
-        backButton.text() must be("site.back")
-        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+          backButton.text() must be("site.back")
+          backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+        }
       }
 
-      "on the Supplementary journey" in {
+      onJourney(DeclarationType.CLEARANCE, DeclarationType.OCCASIONAL, DeclarationType.SIMPLIFIED) { request =>
+        "with Office Of Exit outside UK" in {
 
-        val backButton = createView(declarationType = DeclarationType.SUPPLEMENTARY).getElementById("back-link")
+          val backButton = createView(declarationType = DeclarationType.SIMPLIFIED, navigationForm = Document).getElementById("back-link")
 
-        backButton.text() must be("site.back")
-        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.NatureOfTransactionController.displayPage(Mode.Normal))
+          backButton.text() must be("site.back")
+          backButton.getElementById("back-link") must haveHref(
+            controllers.declaration.routes.OfficeOfExitOutsideUkController.displayPage(Mode.Normal)
+          )
+        }
       }
 
-      "on the Simplified journey" in {
+      onJourney(DeclarationType.CLEARANCE, DeclarationType.OCCASIONAL, DeclarationType.SIMPLIFIED) { request =>
+        " with Office Of Exit Inside UK" in {
 
-        val backButton = createView(declarationType = DeclarationType.SIMPLIFIED).getElementById("back-link")
+          val backButton =
+            createView(declarationType = DeclarationType.SIMPLIFIED, navigationForm = OfficeOfExitOutsideUK).getElementById("back-link")
 
-        backButton.text() must be("site.back")
-        backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
+          backButton.text() must be("site.back")
+          backButton.getElementById("back-link") must haveHref(controllers.declaration.routes.OfficeOfExitController.displayPage(Mode.Normal))
+        }
       }
     }
 


### PR DESCRIPTION
The QA team found a couple of bugs:

1. When a Non-UK Office of Exit exists in cache and
we go back to the Office Of Exit page were overriding the Non-UK Office
of Exit data.
2. Fix back button for Simplified and Occasional journeys