### PR TITLE
CEDS-2401 - fix for back link from consignee page when dec. is exporter

### DIFF
--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -65,7 +65,9 @@ class ConsigneeDetailsController @Inject()(
   }
 
   private def navigationForm(implicit request: JourneyRequest[AnyContent]): DeclarationPage =
-    if (request.cacheModel.parties.declarantIsExporter.exists(_.isExporter)) ExporterDetails else ConsigneeDetails
+    if (request.declarationType == DeclarationType.SUPPLEMENTARY && request.cacheModel.parties.declarantIsExporter.exists(_.isExporter))
+      ExporterDetails
+    else ConsigneeDetails
 
   private def nextPage()(implicit request: JourneyRequest[AnyContent]): Mode => Call =
     request.declarationType match {


### PR DESCRIPTION
Consignee page should only "short-cut" back to exporter details if declarant is the exporter and we are on supplementary journey.  Otherwise normal back navigation is required.

This perfectly illustrates what we discussed at the techtro today.