### PR TITLE
Update timeoutDialog config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -161,6 +161,6 @@ whitelist {
 }
 
 timeoutDialog {
-  timeout="13min"
+  timeout="15min"
   countdown="2min"
 }


### PR DESCRIPTION
The 'timeout' parameter is the time before forced logout occurs - not the time the pop-up first appears.  So the user should be logged out after 15min of inactivity with a 2min warning