### PR TITLE
CEDS-2383 - fix for correct display on summary screen

### DIFF
--- a/app/controllers/declaration/AdditionalInformationRequiredController.scala
+++ b/app/controllers/declaration/AdditionalInformationRequiredController.scala
@@ -21,14 +21,17 @@ import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import javax.inject.Inject
-import models.{Mode}
+import models.declaration.AdditionalInformationData
+import models.requests.JourneyRequest
+import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.FrontendController
 import views.html.declaration.additional_information_required
-import scala.concurrent.{ExecutionContext}
+
+import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationRequiredController @Inject()(
   authenticate: AuthAction,
@@ -44,24 +47,27 @@ class AdditionalInformationRequiredController @Inject()(
     Ok(additionalInfoReq(mode, itemId, YesNoAnswer.form()))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     YesNoAnswer
       .form()
       .bindFromRequest()
       .fold(
-        (formWithErrors: Form[YesNoAnswer]) => BadRequest(additionalInfoReq(mode, itemId, formWithErrors)),
-        validYesNo => navigator.continueTo(mode, nextPage(yesNoAnswer = validYesNo, itemId))
+        (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(additionalInfoReq(mode, itemId, formWithErrors))),
+        validYesNo =>
+          updateCache(itemId).map { _ =>
+            navigator.continueTo(mode, nextPage(yesNoAnswer = validYesNo, itemId))
+        }
       )
-
   }
+  private def updateCache(itemId: String)(implicit r: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
+    updateExportsDeclarationSyncDirect(model => model.updatedItem(itemId, _.copy(additionalInformation = Some(AdditionalInformationData(Seq.empty)))))
 
   private def nextPage(yesNoAnswer: YesNoAnswer, itemId: String): Mode => Call =
-    mode =>
-      yesNoAnswer.answer match {
-        case YesNoAnswers.yes =>
-          controllers.declaration.routes.AdditionalInformationController.displayPage(mode, itemId)
-        case YesNoAnswers.no =>
-          controllers.declaration.routes.DocumentsProducedController.displayPage(mode, itemId)
+    yesNoAnswer.answer match {
+      case YesNoAnswers.yes =>
+        controllers.declaration.routes.AdditionalInformationController.displayPage(_, itemId)
+      case YesNoAnswers.no =>
+        controllers.declaration.routes.DocumentsProducedController.displayPage(_, itemId)
     }
 
 }

--- a/app/views/declaration/summary/union_and_national_codes.scala.html
+++ b/app/views/declaration/summary/union_and_national_codes.scala.html
@@ -72,10 +72,13 @@
             key = Key(
                 content = Text(messages("declaration.summary.items.item.additionalInformation"))
             ),
+            value = Value(
+                content = Text(messages("site.no"))
+            ),
             actions = Some(Actions(
                 items = Seq(
                     ActionItem(
-                        href = controllers.declaration.routes.AdditionalInformationController.displayPage(mode, itemId).url,
+                        href = controllers.declaration.routes.AdditionalInformationRequiredController.displayPage(mode, itemId).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.additionalInformation.change"))
                     )


### PR DESCRIPTION
Because we weren't updating the items.additionalInformation state when submitting the Y/N answer on the first page, the default value of "None" meant that the section was never rendered.

The fix is to update the cache value to Some(AdditionalInformationData(Seq.empty)).   This is the same value as would be set if the user answered 'Y' but then did not provide any data on the next page.     So as it stands, we cannot differentiate between "N" and "Y" followed by no data - both will be rendered on the summary screen as "No".

However, as the AdditionalItems page needs re-writing to remove the old "add-to-list" pattern, I think this is OK for now.