### PR TITLE
CEDS-2387 - fix for submissions with pseudo status 'Pending'

### DIFF
--- a/app/controllers/util/SubmissionDisplayHelper.scala
+++ b/app/controllers/util/SubmissionDisplayHelper.scala
@@ -35,6 +35,10 @@ object SubmissionDisplayHelper {
       (submission, currentSubmissionNotifications)
     }.sortBy(_._1)(Submission.newestEarlierOrdering)
 
-  def filterSubmissions(submissions: Seq[(Submission, Seq[Notification])], condition: Notification => Boolean): Seq[(Submission, Seq[Notification])] =
-    submissions.filter { case (_, notifications) => notifications.isEmpty || notifications.headOption.exists(condition) }
+  def filterSubmissions(
+    submissions: Seq[(Submission, Seq[Notification])],
+    condition: Seq[Notification] => Boolean
+  ): Seq[(Submission, Seq[Notification])] =
+    submissions.filter { case (_, notifications) => condition(notifications) }
+
 }

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -114,7 +114,7 @@ linkButton: linkButton
                                 tabTable(
                                     "rejected",
                                     "submissions.tab.rejected.title",
-                                    SubmissionDisplayHelper.filterSubmissions(submissions, notification => SubmissionStatus.rejectedStatuses.contains(notification.status))
+                                    SubmissionDisplayHelper.filterSubmissions(submissions, _.headOption.map(_.status).exists(SubmissionStatus.rejectedStatuses.contains))
                                 )
                             )
                         )
@@ -127,7 +127,7 @@ linkButton: linkButton
                                 tabTable(
                                     "action",
                                     "submissions.tab.action.title",
-                                    SubmissionDisplayHelper.filterSubmissions(submissions, notification => SubmissionStatus.actionRequiredStatuses.contains(notification.status))
+                                    SubmissionDisplayHelper.filterSubmissions(submissions, _.headOption.map(_.status).exists(SubmissionStatus.actionRequiredStatuses.contains))
                                 )
                             )
                         )
@@ -140,7 +140,7 @@ linkButton: linkButton
                                 tabTable(
                                     "other",
                                     "submissions.tab.other.title",
-                                    SubmissionDisplayHelper.filterSubmissions(submissions, notification => SubmissionStatus.otherStatuses.contains(notification.status))
+                                    SubmissionDisplayHelper.filterSubmissions(submissions, notifications => notifications.isEmpty || notifications.headOption.map(_.status).exists(SubmissionStatus.otherStatuses.contains))
                                 )
                             )
                         )

--- a/test/controllers/util/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/util/SubmissionDisplayHelperSpec.scala
@@ -177,14 +177,14 @@ class SubmissionDisplayHelperSpec extends WordSpec with MustMatchers {
       }
 
       "return submissions that have missing notifications" in {
-        val submissions = Seq(submission -> Seq(notification), submission_3 -> Seq(notification_2), submission_3 -> Seq.empty)
+        val submissions = Seq(submission -> Seq(notification), submission_2 -> Seq(notification_2), submission_3 -> Seq.empty)
 
         val results = SubmissionDisplayHelper.filterSubmissions(
           submissions,
           notifications => notifications.isEmpty || notifications.headOption.map(_.status).exists(SubmissionStatus.otherStatuses.contains)
         )
 
-        results must equal(Seq(submission -> Seq(notification), Seq(submission_3 -> Seq.empty)))
+        results must equal(Seq(submission -> Seq(notification), submission_3 -> Seq.empty))
       }
     }
   }

--- a/test/controllers/util/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/util/SubmissionDisplayHelperSpec.scala
@@ -166,18 +166,25 @@ class SubmissionDisplayHelperSpec extends WordSpec with MustMatchers {
       "return submissions that match the notification test" in {
         val submissions = Seq(submission -> Seq(notification), submission_2 -> Seq(notification_2), submission_3 -> Seq(notification_3))
 
-        val result1 = SubmissionDisplayHelper.filterSubmissions(submissions, _ == notification)
+        val result1 = SubmissionDisplayHelper.filterSubmissions(submissions, notifications => notifications.contains(notification))
         result1 must equal(Seq(submission -> Seq(notification)))
 
-        val result2 = SubmissionDisplayHelper.filterSubmissions(submissions, _.status == SubmissionStatus.REJECTED)
+        val result2 = SubmissionDisplayHelper.filterSubmissions(
+          submissions,
+          notifications => notifications.headOption.map(_.status).exists(SubmissionStatus.rejectedStatuses.contains)
+        )
         result2 must equal(Seq(submission_2 -> Seq(notification_2)))
       }
 
-      "return submissions that have missing notification" in {
-        val submissions = Seq(submission -> Seq.empty)
+      "return submissions that have missing notifications" in {
+        val submissions = Seq(submission -> Seq(notification), submission_3 -> Seq(notification_2), submission_3 -> Seq.empty)
 
-        SubmissionDisplayHelper.filterSubmissions(submissions, _ => true) must equal(submissions)
-        SubmissionDisplayHelper.filterSubmissions(submissions, _ => false) must equal(submissions)
+        val results = SubmissionDisplayHelper.filterSubmissions(
+          submissions,
+          notifications => notifications.isEmpty || notifications.headOption.map(_.status).exists(SubmissionStatus.otherStatuses.contains)
+        )
+
+        results must equal(Seq(submission -> Seq(notification), Seq(submission_3 -> Seq.empty)))
       }
     }
   }


### PR DESCRIPTION
These are currently being displayed in all three tabs - Rejected, Actions Required and Other
They should only be in Other until their real status is determined.