### PR TITLE
CEDS-2298 Display Time always on British time zone

### DIFF
--- a/app/models/declaration/notifications/Notification.scala
+++ b/app/models/declaration/notifications/Notification.scala
@@ -16,7 +16,7 @@
 
 package models.declaration.notifications
 
-import java.time.ZonedDateTime
+import java.time.{ZoneId, ZonedDateTime}
 
 import models.declaration.submissions.SubmissionStatus
 import models.declaration.submissions.SubmissionStatus.SubmissionStatus
@@ -38,6 +38,7 @@ case class Notification(
 
   val displayStatus = SubmissionStatus.format(status)
   val isStatusRejected: Boolean = status == SubmissionStatus.REJECTED
+  val dateTimeIssuedInUK: ZonedDateTime = dateTimeIssued.withZoneSameInstant(ZoneId.of("Europe/London"))
 }
 
 object Notification {

--- a/app/models/declaration/notifications/Notification.scala
+++ b/app/models/declaration/notifications/Notification.scala
@@ -16,7 +16,7 @@
 
 package models.declaration.notifications
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 
 import models.declaration.submissions.SubmissionStatus
 import models.declaration.submissions.SubmissionStatus.SubmissionStatus
@@ -25,7 +25,7 @@ import play.api.libs.json.Json
 case class Notification(
   actionId: String,
   mrn: String,
-  dateTimeIssued: LocalDateTime,
+  dateTimeIssued: ZonedDateTime,
   status: SubmissionStatus,
   errors: Seq[NotificationError],
   payload: String

--- a/app/models/declaration/submissions/Action.scala
+++ b/app/models/declaration/submissions/Action.scala
@@ -16,11 +16,11 @@
 
 package models.declaration.submissions
 
-import java.time.LocalDateTime
+import java.time.{ZoneId, ZoneOffset, ZonedDateTime}
 
 import play.api.libs.json.Json
 
-case class Action(id: String, requestType: RequestType, requestTimestamp: LocalDateTime = LocalDateTime.now())
+case class Action(id: String, requestType: RequestType, requestTimestamp: ZonedDateTime = ZonedDateTime.now(ZoneId.of("UTC")))
 
 object Action {
   implicit val format = Json.format[Action]

--- a/app/models/declaration/submissions/Submission.scala
+++ b/app/models/declaration/submissions/Submission.scala
@@ -16,7 +16,7 @@
 
 package models.declaration.submissions
 
-import java.time.LocalDateTime
+import java.time.ZonedDateTime
 import java.util.UUID
 
 import play.api.libs.json.Json
@@ -31,7 +31,7 @@ case class Submission(
 ) {
 
   val latestAction: Option[Action] = if (actions.nonEmpty) {
-    Some(actions.minBy(_.requestTimestamp)(Submission.localDateTimeOrdering))
+    Some(actions.minBy(_.requestTimestamp)(Submission.dateTimeOrdering))
   } else {
     None
   }
@@ -39,13 +39,12 @@ case class Submission(
 
 object Submission {
 
-  val localDateTimeOrdering: Ordering[LocalDateTime] = Ordering.fromLessThan[LocalDateTime]((a, b) => a.isBefore(b))
+  val dateTimeOrdering: Ordering[ZonedDateTime] = Ordering.fromLessThan[ZonedDateTime]((a, b) => a.isBefore(b))
 
   implicit val formats = Json.format[Submission]
 
-  implicit val ordering: Ordering[Submission] = Ordering.by[Submission, Option[LocalDateTime]](
-    submission => submission.latestAction.map(_.requestTimestamp)
-  )(Ordering.Option(localDateTimeOrdering))
+  implicit val ordering: Ordering[Submission] =
+    Ordering.by[Submission, Option[ZonedDateTime]](submission => submission.latestAction.map(_.requestTimestamp))(Ordering.Option(dateTimeOrdering))
 
   val newestEarlierOrdering: Ordering[Submission] = ordering.reverse
 }

--- a/app/views/ViewDates.scala
+++ b/app/views/ViewDates.scala
@@ -16,18 +16,17 @@
 
 package views
 
-import java.time.ZoneOffset
+import java.time.{ZoneId, ZoneOffset}
 import java.time.format.DateTimeFormatter
 import java.time.temporal.TemporalAccessor
-import java.util.Locale
 
 object ViewDates {
 
   val formatter: DateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm")
-  val submissionDateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuu 'at' HH:mm").withZone(ZoneOffset.UTC)
+  val submissionDateTimeFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMMM uuu 'at' HH:mm").withZone(ZoneId.of("Europe/London"))
   val dateAtTimeFormatter: DateTimeFormatter =
-    DateTimeFormatter.ofPattern("d MMM uuu 'at' HH:mm").withZone(ZoneOffset.UTC)
-  val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM uuu").withZone(ZoneOffset.UTC)
+    DateTimeFormatter.ofPattern("d MMM uuu 'at' HH:mm").withZone(ZoneId.of("Europe/London"))
+  val dateFormatter: DateTimeFormatter = DateTimeFormatter.ofPattern("d MMM uuu").withZone(ZoneId.of("Europe/London"))
 
   def format(temporal: TemporalAccessor): String = formatter.format(temporal)
   def formatDateTimeFullMonth(temporal: TemporalAccessor): String = submissionDateTimeFormatter.format(temporal)

--- a/app/views/declaration_information.scala.html
+++ b/app/views/declaration_information.scala.html
@@ -23,6 +23,7 @@
 @import views.BackButton
 @import views.Title
 @import views.ViewDates
+@import java.time.ZoneId
 
 @this(
     govukLayout: gdsMainTemplate,
@@ -107,7 +108,7 @@
                                 attributes = Map("id" -> s"notification_status_$index")
                             ),
                             TableRow(
-                                content = HtmlContent(ViewDates.submissionDateTimeFormatter.format(notification.dateTimeIssued)),
+                                content = HtmlContent(ViewDates.submissionDateTimeFormatter.format(notification.dateTimeIssuedInUK)),
                                 attributes = Map("id" -> s"notification_date_time_$index")
                             ),
                             TableRow(

--- a/app/views/notifications.scala.html
+++ b/app/views/notifications.scala.html
@@ -17,6 +17,7 @@
 @import java.time.format.DateTimeFormatter
 
 @import models.declaration.notifications.Notification
+@import java.time.ZoneId
 @import views.Title
 
 @this(main_template: views.html.main_template)
@@ -43,7 +44,9 @@
                     <td class="table-cell">@eori</td>
                     <td class="table-cell">@notification.actionId</td>
                     <td class="table-cell">@notification.displayStatus</td>
-                    <td class="table-cell">@DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").format(notification.dateTimeIssued)</td>
+                    <td class="table-cell">
+                        @DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm").format(notification.dateTimeIssuedInUK)
+                    </td>
                 </tr>
             }
         </table>

--- a/app/views/saved_declarations.scala.html
+++ b/app/views/saved_declarations.scala.html
@@ -20,6 +20,7 @@
 @import views.html.components.gds.{gdsMainTemplate, link, pageTitle, pagination}
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.ViewDates.formatDateTimeFullMonth
+@import java.time.ZoneId
 
 @this(
   govukLayout: gdsMainTemplate,
@@ -34,7 +35,7 @@
   declarations.currentPageElements.map { declaration =>
     Seq(
       TableRow(content = HtmlContent(link(text = declaration.ducr.getOrElse(messages("saved.declarations.noDucr")), call = routes.SavedDeclarationsController.continueDeclaration(declaration.id)))),
-      TableRow(content = HtmlContent(formatDateTimeFullMonth(declaration.updatedDateTime))),
+      TableRow(content = HtmlContent(formatDateTimeFullMonth(declaration.updatedDateTime.atZone(ZoneId.of("Europe/London"))))),
       TableRow(content = HtmlContent(link(text = messages("site.remove"), call = routes.RemoveSavedDeclarationsController.displayPage(declaration.id))))
     )
   }

--- a/app/views/submission_notifications.scala.html
+++ b/app/views/submission_notifications.scala.html
@@ -20,6 +20,7 @@
 @import models.declaration.submissions.Submission
 @import models.declaration.submissions.SubmissionStatus
 @import views.Title
+@import java.time.ZoneId
 
 @this(main_template: views.html.main_template)
 
@@ -47,7 +48,7 @@
         @for((notification, index) <- notifications.zipWithIndex){
             <tr id="submission_notifications-table-row@index" class="table-row">
                 <td id="submission_notifications-table-row@index-status" class="table-cell">@notification.displayStatus</td>
-                <td id="submission_notifications-table-row@index-date" class="table-cell">@ViewDates.format(notification.dateTimeIssued)</td>
+                <td id="submission_notifications-table-row@index-date" class="table-cell">@ViewDates.format(notification.dateTimeIssuedInUK)</td>
                 <td class="table-cell">
                 @if(notification.isStatusRejected) {
                     <a id="submission_notifications-table-row@index-amend_link" href="@routes.SubmissionsController.amend(submission.uuid)">@messages("notifications.amend")</a>

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -72,7 +72,7 @@ linkButton: linkButton
                 ),
                 TableRow(
                     content = Text(
-                        submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.submissionDateTimeFormatter.withZone(ZoneId.systemDefault()).format(_)).getOrElse("")
+                        submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.submissionDateTimeFormatter.withZone(ZoneId.of("Europe/London")).format(_)).getOrElse("")
                     ),
                     attributes = Map("id" -> s"submission-tab-$id-row$index-dateAndTime")
                 ),

--- a/app/views/submissions.scala.html
+++ b/app/views/submissions.scala.html
@@ -72,7 +72,7 @@ linkButton: linkButton
                 ),
                 TableRow(
                     content = Text(
-                        submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp).map(ViewDates.submissionDateTimeFormatter.withZone(ZoneId.of("Europe/London")).format(_)).getOrElse("")
+                        submission.actions.find(_.requestType == SubmissionRequest).map(_.requestTimestamp.withZoneSameInstant(ZoneId.of("Europe/London"))).map(ViewDates.submissionDateTimeFormatter.format(_)).getOrElse("")
                     ),
                     attributes = Map("id" -> s"submission-tab-$id-row$index-dateAndTime")
                 ),

--- a/test/base/MockConnectors.scala
+++ b/test/base/MockConnectors.scala
@@ -16,7 +16,7 @@
 
 package base
 
-import java.time.LocalDateTime
+import java.time.{ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import connectors.CustomsDeclareExportsConnector
@@ -29,7 +29,6 @@ import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito.when
 import org.mockito.invocation.InvocationOnMock
 import org.mockito.stubbing.{Answer, OngoingStubbing}
-import org.scalatest.BeforeAndAfterEach
 import org.scalatestplus.mockito.MockitoSugar
 import uk.gov.hmrc.http.HeaderCarrier
 
@@ -53,7 +52,9 @@ trait MockConnectors extends MockitoSugar {
 
   def listOfNotifications(): OngoingStubbing[Future[Seq[Notification]]] =
     when(mockCustomsDeclareExportsConnector.fetchNotifications()(any(), any()))
-      .thenReturn(Future.successful(Seq(Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload"))))
+      .thenReturn(
+        Future.successful(Seq(Notification("actionId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.UNKNOWN, Seq.empty, "payload")))
+      )
 
   def listOfSubmissions(): OngoingStubbing[Future[Seq[Submission]]] =
     when(mockCustomsDeclareExportsConnector.fetchSubmissions()(any(), any()))
@@ -66,7 +67,7 @@ trait MockConnectors extends MockitoSugar {
               lrn = "lrn",
               mrn = None,
               ducr = None,
-              actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now()))
+              actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = ZonedDateTime.now(ZoneOffset.UTC)))
             )
           )
         )

--- a/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
+++ b/test/connectors/CustomsDeclareExportsConnectorIntegrationSpec.scala
@@ -16,7 +16,7 @@
 
 package connectors
 
-import java.time.{Instant, LocalDateTime}
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import base.TestHelper._
@@ -47,7 +47,7 @@ class CustomsDeclareExportsConnectorIntegrationSpec extends ConnectorSpec with B
   private val action = Action(UUID.randomUUID().toString, SubmissionRequest)
   private val submission = Submission(id, "eori", "lrn", Some("mrn"), None, Seq(action))
   private val notification =
-    Notification("action-id", "mrn", LocalDateTime.now, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
+    Notification("action-id", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val connector = app.injector.instanceOf[CustomsDeclareExportsConnector]
 
   implicit val defaultPatience: PatienceConfig =
@@ -117,7 +117,7 @@ class CustomsDeclareExportsConnectorIntegrationSpec extends ConnectorSpec with B
            |  "actions" : [{
            |      "id" : "${UUID.randomUUID().toString}",
            |      "requestType" : "SubmissionRequest",
-           |      "requestTimestamp" : "${Instant.now().toString}"
+           |      "requestTimestamp" : "${ZonedDateTime.now(ZoneOffset.UTC).toString}"
            |   }]
           |}
         """.stripMargin

--- a/test/controllers/util/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/util/SubmissionDisplayHelperSpec.scala
@@ -16,7 +16,8 @@
 
 package controllers.util
 
-import java.time.LocalDateTime
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
+import java.time.temporal.ChronoUnit.{DAYS, HOURS, MINUTES}
 import java.util.UUID
 
 import base.TestHelper.createRandomAlphanumericString
@@ -200,10 +201,10 @@ object SubmissionDisplayHelperSpec {
   val conversationId_3: String = "b1c09f1b-7c94-4e90-b754-7c5c71c55e23"
 
   lazy val action = Action(requestType = SubmissionRequest, id = conversationId)
-  lazy val action_2 = Action(requestType = SubmissionRequest, id = conversationId_2, requestTimestamp = action.requestTimestamp.plusDays(2))
-  lazy val action_3 = Action(requestType = SubmissionRequest, id = conversationId_2, requestTimestamp = action.requestTimestamp.minusDays(2))
+  lazy val action_2 = Action(requestType = SubmissionRequest, id = conversationId_2, requestTimestamp = action.requestTimestamp.plus(2, DAYS))
+  lazy val action_3 = Action(requestType = SubmissionRequest, id = conversationId_2, requestTimestamp = action.requestTimestamp.minus(2, DAYS))
   lazy val actionCancellation =
-    Action(requestType = CancellationRequest, id = conversationId, requestTimestamp = action.requestTimestamp.plusHours(3))
+    Action(requestType = CancellationRequest, id = conversationId, requestTimestamp = action.requestTimestamp.plus(3, HOURS))
 
   lazy val submission: Submission =
     Submission(uuid = uuid, eori = eori, lrn = lrn, mrn = Some(mrn), ducr = Some(ducr), actions = Seq(action))
@@ -217,11 +218,12 @@ object SubmissionDisplayHelperSpec {
   private lazy val functionCodes: Seq[String] =
     Seq("01", "02", "03", "05", "06", "07", "08", "09", "10", "11", "16", "17", "18")
   private lazy val functionCodesRandomised: Iterator[String] = Random.shuffle(functionCodes).toIterator
+
   private def randomResponseFunctionCode: String = functionCodesRandomised.next()
 
-  val dateTimeIssued: LocalDateTime = LocalDateTime.now()
-  val dateTimeIssued_2: LocalDateTime = dateTimeIssued.plusMinutes(3)
-  val dateTimeIssued_3: LocalDateTime = dateTimeIssued_2.plusMinutes(3)
+  val dateTimeIssued: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)
+  val dateTimeIssued_2: ZonedDateTime = dateTimeIssued.plus(3, MINUTES);
+  val dateTimeIssued_3: ZonedDateTime = dateTimeIssued_2.plus(3, MINUTES);
   val functionCode: String = randomResponseFunctionCode
   val functionCode_2: String = randomResponseFunctionCode
   val functionCode_3: String = randomResponseFunctionCode

--- a/test/controllers/util/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/util/SubmissionDisplayHelperSpec.scala
@@ -222,8 +222,8 @@ object SubmissionDisplayHelperSpec {
   private def randomResponseFunctionCode: String = functionCodesRandomised.next()
 
   val dateTimeIssued: ZonedDateTime = ZonedDateTime.now(ZoneOffset.UTC)
-  val dateTimeIssued_2: ZonedDateTime = dateTimeIssued.plus(3, MINUTES);
-  val dateTimeIssued_3: ZonedDateTime = dateTimeIssued_2.plus(3, MINUTES);
+  val dateTimeIssued_2: ZonedDateTime = dateTimeIssued.plus(3, MINUTES)
+  val dateTimeIssued_3: ZonedDateTime = dateTimeIssued_2.plus(3, MINUTES)
   val functionCode: String = randomResponseFunctionCode
   val functionCode_2: String = randomResponseFunctionCode
   val functionCode_3: String = randomResponseFunctionCode

--- a/test/models/declaration/notifications/NotificationSpec.scala
+++ b/test/models/declaration/notifications/NotificationSpec.scala
@@ -16,15 +16,18 @@
 
 package models.declaration.notifications
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
 import models.declaration.submissions.SubmissionStatus
 import org.scalatest.{MustMatchers, WordSpec}
 
 class NotificationSpec extends WordSpec with MustMatchers {
-  val earlierDate = LocalDateTime.of(2019, 6, 10, 10, 10)
-  val laterDate = LocalDateTime.of(2019, 6, 15, 10, 10)
-  val latestDate = LocalDateTime.of(2019, 6, 20, 10, 10)
+
+  private val zone: ZoneId = ZoneId.of("Europe/London")
+  private val earlierDate = ZonedDateTime.of(LocalDateTime.of(2019, 6, 10, 10, 10), zone)
+  private val laterDate = ZonedDateTime.of(LocalDateTime.of(2019, 6, 15, 10, 10), zone)
+  private val latestDate = ZonedDateTime.of(LocalDateTime.of(2019, 6, 20, 10, 10), zone)
+
   val firstNotification = Notification("convId", "mrn", earlierDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   val secondNotification = Notification("convId", "mrn", laterDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   val thirdNotification = Notification("convId", "mrn", latestDate, SubmissionStatus.UNKNOWN, Seq.empty, "payload")

--- a/test/unit/controllers/NotificationControllerSpec.scala
+++ b/test/unit/controllers/NotificationControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.controllers
 
-import java.time.LocalDateTime
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import controllers.NotificationsController
@@ -36,14 +36,14 @@ import scala.concurrent.Future.successful
 class NotificationControllerSpec extends ControllerSpec {
 
   private val notification =
-    Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
+    Notification("actionId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val submission = Submission(
     uuid = UUID.randomUUID().toString,
     eori = "eori",
     lrn = "lrn",
     mrn = None,
     ducr = None,
-    actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now()))
+    actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = ZonedDateTime.now(ZoneOffset.UTC)))
   )
 
   trait SetUp {

--- a/test/unit/controllers/SubmissionsControllerSpec.scala
+++ b/test/unit/controllers/SubmissionsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package unit.controllers
 
-import java.time.{Instant, LocalDate, LocalDateTime}
+import java.time.{Instant, LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
 
 import akka.util.Timeout
@@ -43,14 +43,14 @@ import scala.concurrent.duration._
 class SubmissionsControllerSpec extends ControllerSpec with BeforeAndAfterEach {
 
   private val notification =
-    Notification("conversationID", "mrn", LocalDateTime.now(), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
+    Notification("conversationID", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.UNKNOWN, Seq.empty, "payload")
   private val submission = Submission(
     uuid = UUID.randomUUID().toString,
     eori = "eori",
     lrn = "lrn",
     mrn = None,
     ducr = None,
-    actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = LocalDateTime.now()))
+    actions = Seq(Action(requestType = SubmissionRequest, id = "conversationID", requestTimestamp = ZonedDateTime.now(ZoneOffset.UTC)))
   )
   val submissionsPage = mock[submissions]
   val declarationInformationPage = mock[declaration_information]

--- a/test/unit/services/model/RejectionReasonSpec.scala
+++ b/test/unit/services/model/RejectionReasonSpec.scala
@@ -16,13 +16,13 @@
 
 package unit.services.model
 
-import java.time.LocalDateTime
+import java.time.{Instant, ZoneOffset, ZonedDateTime}
 
 import forms.declaration.Seal
 import models.declaration.Container
-import models.{Pointer, PointerSection, PointerSectionType}
 import models.declaration.notifications.{Notification, NotificationError}
 import models.declaration.submissions.SubmissionStatus
+import models.{Pointer, PointerSection, PointerSectionType}
 import org.mockito.ArgumentMatchers._
 import org.mockito.BDDMockito.given
 import play.api.i18n.Messages
@@ -98,7 +98,7 @@ class RejectionReasonSpec extends UnitSpec with ExportsTestData {
 
     "map to Rejected Reason" when {
       val acceptedNotification =
-        Notification("convId", "mrn", LocalDateTime.now(), SubmissionStatus.ACCEPTED, Seq.empty, "")
+        Notification("convId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.ACCEPTED, Seq.empty, "")
 
       "list is empty" in {
         fromNotifications(Seq.empty)(messages) mustBe Seq.empty
@@ -114,7 +114,7 @@ class RejectionReasonSpec extends UnitSpec with ExportsTestData {
           given(messages.isDefinedAt("field.x.$.z")).willReturn(true)
           val error = NotificationError("CDS12016", Some(Pointer("x.#0.z")), None)
           val notification =
-            Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, Seq(error), "")
+            Notification("actionId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.REJECTED, Seq(error), "")
 
           fromNotifications(Seq(notification))(messages) mustBe Seq(
             RejectionReason(
@@ -131,7 +131,7 @@ class RejectionReasonSpec extends UnitSpec with ExportsTestData {
           given(messages.isDefinedAt(anyString())).willReturn(false)
           val error = NotificationError("CDS12016", Some(Pointer("x.#0.z")), None)
           val notification =
-            Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, Seq(error), "")
+            Notification("actionId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.REJECTED, Seq(error), "")
 
           fromNotifications(Seq(notification))(messages) mustBe Seq(
             RejectionReason(
@@ -147,7 +147,7 @@ class RejectionReasonSpec extends UnitSpec with ExportsTestData {
         "pointer is empty" in {
           val error = NotificationError("CDS12016", None, None)
           val notification =
-            Notification("actionId", "mrn", LocalDateTime.now(), SubmissionStatus.REJECTED, Seq(error), "")
+            Notification("actionId", "mrn", ZonedDateTime.now(ZoneOffset.UTC), SubmissionStatus.REJECTED, Seq(error), "")
 
           fromNotifications(Seq(notification))(messages) mustBe Seq(
             RejectionReason(

--- a/test/views/DeclarationInformationViewSpec.scala
+++ b/test/views/DeclarationInformationViewSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 
 import base.Injector
 import com.typesafe.config.{Config, ConfigFactory}
@@ -25,7 +25,6 @@ import models.declaration.notifications.Notification
 import models.declaration.submissions.{Submission, SubmissionStatus}
 import play.api.Configuration
 import uk.gov.hmrc.govukfrontend.views.html.components.{GovukSummaryList, GovukTable}
-import uk.gov.hmrc.play.bootstrap.config.ServicesConfig
 import views.declaration.spec.UnitViewSpec
 import views.html.components.gds.gdsMainTemplate
 import views.html.declaration_information
@@ -63,10 +62,11 @@ class DeclarationInformationViewSpec extends UnitViewSpec with Injector {
 
   private val submission: Submission = submission()
 
+  private val zone: ZoneId = ZoneId.of("Europe/London")
   private val notification = Notification(
     actionId = "action-id",
     mrn = "mrn",
-    dateTimeIssued = LocalDateTime.of(2020, 1, 1, 0, 0, 0),
+    dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 0, 0, 0), zone),
     status = SubmissionStatus.ACCEPTED,
     errors = Seq.empty,
     payload = "payload"
@@ -75,7 +75,7 @@ class DeclarationInformationViewSpec extends UnitViewSpec with Injector {
   private val rejectedNotification = Notification(
     actionId = "actionId",
     mrn = "mrn",
-    dateTimeIssued = LocalDateTime.of(2020, 2, 2, 10, 0, 0),
+    dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2020, 2, 2, 10, 0, 0), zone),
     status = SubmissionStatus.REJECTED,
     errors = Seq.empty,
     payload = ""
@@ -84,7 +84,7 @@ class DeclarationInformationViewSpec extends UnitViewSpec with Injector {
   private val additionalDocumentsNotification = Notification(
     actionId = "actionId",
     mrn = "mrn",
-    dateTimeIssued = LocalDateTime.of(2019, 3, 3, 10, 0, 0),
+    dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2019, 3, 3, 10, 0, 0), zone),
     status = SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED,
     errors = Seq.empty,
     payload = ""

--- a/test/views/NotificationsViewSpec.scala
+++ b/test/views/NotificationsViewSpec.scala
@@ -16,14 +16,14 @@
 
 package views
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZonedDateTime}
 import java.util.UUID
 
 import controllers.routes
 import models.declaration.notifications.Notification
 import models.declaration.submissions.RequestType.SubmissionRequest
 import models.declaration.submissions.SubmissionStatus.SubmissionStatus
-import models.declaration.submissions.{Action, RequestType, Submission, SubmissionStatus}
+import models.declaration.submissions.{Action, Submission, SubmissionStatus}
 import org.jsoup.nodes.Document
 import unit.tools.Stubs
 import views.declaration.spec.UnitViewSpec
@@ -36,8 +36,9 @@ class NotificationsViewSpec extends UnitViewSpec with Stubs {
   private val page = new submission_notifications(mainTemplate)
   private val actions = Action(UUID.randomUUID().toString, SubmissionRequest)
   private val submission = Submission("id", "eori", "lrn", None, None, Seq(actions))
+
   private def notification(status: SubmissionStatus = SubmissionStatus.ACCEPTED) =
-    Notification("conv-id", "mrn", LocalDateTime.of(2019, 1, 1, 0, 0), status, Seq.empty, "payload")
+    Notification("conv-id", "mrn", ZonedDateTime.of(LocalDateTime.of(2019, 1, 1, 0, 0), ZoneId.of("Europe/London")), status, Seq.empty, "payload")
 
   private def createView(submission: Submission, notifications: Seq[Notification]): Document =
     page(submission, notifications)

--- a/test/views/SavedDeclarationsViewSpec.scala
+++ b/test/views/SavedDeclarationsViewSpec.scala
@@ -23,13 +23,11 @@ import controllers.routes
 import forms.Choice.AllowedChoiceValues.ContinueDec
 import forms.declaration.ConsignmentReferences
 import forms.{Choice, Ducr, Lrn}
-import helpers.views.declaration.CommonMessages
 import models.{DeclarationStatus, ExportsDeclaration, Page, Paginated}
 import org.jsoup.nodes.Element
 import play.api.i18n.Messages
 import play.api.test.Helpers.stubMessages
 import play.twirl.api.Html
-import unit.tools.Stubs
 import views.declaration.spec.{UnitViewSpec, ViewMatchers}
 import views.html.saved_declarations
 import views.tags.ViewTest
@@ -80,13 +78,30 @@ class SavedDeclarationsViewSpec extends UnitViewSpec with Injector with ViewMatc
       view.getElementsByClass("ceds-pagination") mustNot be(empty)
     }
 
-    "display declarations" in {
+    "display created declarations before BST" in {
       val view = createView(declarations = Seq(decWithoutDucr), total = 1)
 
       numberOfTableRows(view) mustBe 1
 
       tableCell(view)(1, 0).text() mustBe messages("saved.declarations.noDucr")
       tableCell(view)(1, 1).text() mustBe "1 January 2019 at 09:45"
+      tableCell(view)(1, 2).text() mustBe messages("site.remove")
+
+      view.getElementsByClass("ceds-pagination") mustNot be(empty)
+    }
+
+    "display created declarations after BST" in {
+      val decWithoutDucrAfterBST = ExportsTestData.aDeclaration(
+        withStatus(DeclarationStatus.DRAFT),
+        withUpdateTime(LocalDateTime.of(2019, 5, 1, 9, 45, 0).toInstant(ZoneOffset.UTC))
+      )
+
+      val view = createView(declarations = Seq(decWithoutDucrAfterBST), total = 1)
+
+      numberOfTableRows(view) mustBe 1
+
+      tableCell(view)(1, 0).text() mustBe messages("saved.declarations.noDucr")
+      tableCell(view)(1, 1).text() mustBe "1 May 2019 at 10:45"
       tableCell(view)(1, 2).text() mustBe messages("site.remove")
 
       view.getElementsByClass("ceds-pagination") mustNot be(empty)

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -16,7 +16,7 @@
 
 package views
 
-import java.time.LocalDateTime
+import java.time.{LocalDateTime, ZoneId, ZoneOffset, ZonedDateTime}
 
 import base.Injector
 import controllers.routes
@@ -38,6 +38,7 @@ import views.tags.ViewTest
 @ViewTest
 class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
 
+  private val zone: ZoneId = ZoneId.of("Europe/London")
   private val page = instanceOf[submissions]
   private def createView(data: Seq[(Submission, Seq[Notification])] = Seq.empty, messages: Messages = stubMessages()): Html =
     page(data)(request, messages)
@@ -71,9 +72,11 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
     }
 
     "display page submissions" when {
-      val actionSubmission = Action(requestType = SubmissionRequest, id = "conv-id", requestTimestamp = LocalDateTime.of(2019, 1, 1, 0, 0, 0))
+      val actionSubmission =
+        Action(requestType = SubmissionRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2019, 1, 1, 0, 0, 0), zone))
 
-      val actionCancellation = Action(requestType = CancellationRequest, id = "conv-id", requestTimestamp = LocalDateTime.of(2021, 1, 1, 0, 0, 0))
+      val actionCancellation =
+        Action(requestType = CancellationRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), zone))
 
       def submissionWithDucr(ducr: String = "ducr") =
         Submission(uuid = "id", eori = "eori", lrn = "lrn", mrn = Some("mrn"), ducr = Some(ducr), actions = Seq(actionSubmission, actionCancellation))
@@ -83,7 +86,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val acceptedNotification = Notification(
         actionId = "action-id",
         mrn = "mrn",
-        dateTimeIssued = LocalDateTime.of(2020, 1, 1, 0, 0, 0),
+        dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 0, 0, 0), zone),
         status = SubmissionStatus.ACCEPTED,
         errors = Seq.empty,
         payload = "payload"
@@ -92,7 +95,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val rejectedNotification = Notification(
         actionId = "actionId",
         mrn = "mrn",
-        dateTimeIssued = LocalDateTime.now(),
+        dateTimeIssued = ZonedDateTime.now(ZoneOffset.UTC),
         status = SubmissionStatus.REJECTED,
         errors = Seq.empty,
         payload = ""
@@ -101,7 +104,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val actionNotification = Notification(
         actionId = "actionId",
         mrn = "mrn",
-        dateTimeIssued = LocalDateTime.now(),
+        dateTimeIssued = ZonedDateTime.now(ZoneOffset.UTC),
         status = SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED,
         errors = Seq.empty,
         payload = ""

--- a/test/views/SubmissionsViewSpec.scala
+++ b/test/views/SubmissionsViewSpec.scala
@@ -38,7 +38,7 @@ import views.tags.ViewTest
 @ViewTest
 class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs with Injector {
 
-  private val zone: ZoneId = ZoneId.of("Europe/London")
+  private val zone: ZoneId = ZoneId.of("UTC")
   private val page = instanceOf[submissions]
   private def createView(data: Seq[(Submission, Seq[Notification])] = Seq.empty, messages: Messages = stubMessages()): Html =
     page(data)(request, messages)
@@ -73,10 +73,10 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
 
     "display page submissions" when {
       val actionSubmission =
-        Action(requestType = SubmissionRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2019, 1, 1, 0, 0, 0), zone))
+        Action(requestType = SubmissionRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2019, 1, 1, 12, 0, 0), zone))
 
       val actionCancellation =
-        Action(requestType = CancellationRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2021, 1, 1, 0, 0, 0), zone))
+        Action(requestType = CancellationRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2021, 6, 1, 12, 0, 0), zone))
 
       def submissionWithDucr(ducr: String = "ducr") =
         Submission(uuid = "id", eori = "eori", lrn = "lrn", mrn = Some("mrn"), ducr = Some(ducr), actions = Seq(actionSubmission, actionCancellation))
@@ -86,7 +86,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val acceptedNotification = Notification(
         actionId = "action-id",
         mrn = "mrn",
-        dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 0, 0, 0), zone),
+        dateTimeIssued = ZonedDateTime.of(LocalDateTime.of(2020, 1, 1, 12, 30, 0), zone),
         status = SubmissionStatus.ACCEPTED,
         errors = Seq.empty,
         payload = "payload"
@@ -95,7 +95,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val rejectedNotification = Notification(
         actionId = "actionId",
         mrn = "mrn",
-        dateTimeIssued = ZonedDateTime.now(ZoneOffset.UTC),
+        dateTimeIssued = ZonedDateTime.now(ZoneId.of("UTC")),
         status = SubmissionStatus.REJECTED,
         errors = Seq.empty,
         payload = ""
@@ -104,19 +104,41 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
       val actionNotification = Notification(
         actionId = "actionId",
         mrn = "mrn",
-        dateTimeIssued = ZonedDateTime.now(ZoneOffset.UTC),
+        dateTimeIssued = ZonedDateTime.now(ZoneId.of("UTC")),
         status = SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED,
         errors = Seq.empty,
         payload = ""
       )
 
-      "all fields are populated" in {
+      "all fields are populated with timestamp before BST" in {
         val view = tab("other", createView(Seq(submission -> Seq(acceptedNotification))))
 
         tableCell(view)(1, 0).text() mustBe "ducr submissions.hidden.text"
         tableCell(view)(1, 1).text() mustBe "lrn"
         tableCell(view)(1, 2).text() mustBe "mrn"
-        tableCell(view)(1, 3).text() mustBe "1 January 2019 at 00:00"
+        tableCell(view)(1, 3).text() mustBe "1 January 2019 at 12:00"
+        tableCell(view)(1, 4).text() mustBe "Accepted"
+        val decInformationLink = tableCell(view)(1, 0).getElementsByTag("a").first()
+        decInformationLink.attr("href") mustBe routes.SubmissionsController.displayDeclarationWithNotifications("id").url
+      }
+
+      "all fields are populated with timestamp during BST" in {
+        val bstActionSubmission =
+          Action(requestType = SubmissionRequest, id = "conv-id", requestTimestamp = ZonedDateTime.of(LocalDateTime.of(2019, 5, 1, 12, 45, 0), zone))
+        val bstSubmission = Submission(
+          uuid = "id",
+          eori = "eori",
+          lrn = "lrn",
+          mrn = Some("mrn"),
+          ducr = Some("ducr"),
+          actions = Seq(bstActionSubmission, actionCancellation)
+        )
+        val view = tab("other", createView(Seq(bstSubmission -> Seq(acceptedNotification))))
+
+        tableCell(view)(1, 0).text() mustBe "ducr submissions.hidden.text"
+        tableCell(view)(1, 1).text() mustBe "lrn"
+        tableCell(view)(1, 2).text() mustBe "mrn"
+        tableCell(view)(1, 3).text() mustBe "1 May 2019 at 13:45"
         tableCell(view)(1, 4).text() mustBe "Accepted"
         val decInformationLink = tableCell(view)(1, 0).getElementsByTag("a").first()
         decInformationLink.attr("href") mustBe routes.SubmissionsController.displayDeclarationWithNotifications("id").url
@@ -129,7 +151,7 @@ class SubmissionsViewSpec extends UnitViewSpec with ExportsTestData with Stubs w
         tableCell(view)(1, 0).text() mustBe "submissions.hidden.text"
         tableCell(view)(1, 1).text() mustBe "lrn"
         tableCell(view)(1, 2).text() mustBe empty
-        tableCell(view)(1, 3).text() mustBe "1 January 2019 at 00:00"
+        tableCell(view)(1, 3).text() mustBe "1 January 2019 at 12:00"
         tableCell(view)(1, 4).text() mustBe "Accepted"
         val decInformationLink = tableCell(view)(1, 0).getElementsByTag("a").first()
         decInformationLink.attr("href") mustBe routes.SubmissionsController.displayDeclarationWithNotifications("id").url


### PR DESCRIPTION
DMS sends the times in UTC time, but our BE microservice converts them
to `LocalDateTime` which strips them of the Zone information.

Converting the type to `Instant` as we did in the the Movements service
allows us to store the date from DMS as `UTC` or `Zulu time` and then on
the FE we just need to inform the view that we want to render that time
on British Time Zone `Europe/London`.

This ensures that we will see the time as `GMT/UTC` and `BST` depending
on the time of the year.

This holds true as long as DMS returns their dates in UTC.