### PR TITLE
CEDS-2441 Make Consignor Eori mandatory

### DIFF
--- a/app/controllers/declaration/ConsignorEoriNumberController.scala
+++ b/app/controllers/declaration/ConsignorEoriNumberController.scala
@@ -70,10 +70,10 @@ class ConsignorEoriNumberController @Inject()(
       )
   }
 
-  private def nextPage(hasEori: Option[String])(implicit request: JourneyRequest[_]): Mode => Call =
-    if (hasEori.getOrElse(YesNoAnswers.no) == YesNoAnswers.yes && request.cacheModel.isDeclarantExporter) {
+  private def nextPage(hasEori: String)(implicit request: JourneyRequest[_]): Mode => Call =
+    if (hasEori == YesNoAnswers.yes && request.cacheModel.isDeclarantExporter) {
       controllers.declaration.routes.CarrierDetailsController.displayPage
-    } else if (hasEori.getOrElse(YesNoAnswers.no) == YesNoAnswers.yes) {
+    } else if (hasEori == YesNoAnswers.yes) {
       controllers.declaration.routes.RepresentativeAgentController.displayPage
     } else {
       controllers.declaration.routes.ConsignorDetailsController.displayPage

--- a/app/forms/declaration/consignor/ConsignorEoriNumber.scala
+++ b/app/forms/declaration/consignor/ConsignorEoriNumber.scala
@@ -17,14 +17,14 @@
 package forms.declaration.consignor
 
 import forms.DeclarationPage
-import forms.Mapping.optionalRadio
-import forms.common.Eori
+import forms.Mapping.requiredRadio
+import forms.common.{Eori, YesNoAnswer}
 import forms.common.YesNoAnswer.YesNoAnswers
 import play.api.data.{Form, Forms, Mapping}
 import play.api.libs.json.{Json, OFormat}
 import uk.gov.voa.play.form.ConditionalMappings.mandatoryIfEqual
 
-case class ConsignorEoriNumber(eori: Option[Eori], hasEori: Option[String])
+case class ConsignorEoriNumber(eori: Option[Eori], hasEori: String)
 
 object ConsignorEoriNumber extends DeclarationPage {
   implicit val format: OFormat[ConsignorEoriNumber] = Json.format[ConsignorEoriNumber]
@@ -36,15 +36,14 @@ object ConsignorEoriNumber extends DeclarationPage {
 
   val mapping: Mapping[ConsignorEoriNumber] = Forms.mapping(
     eori -> mandatoryIfEqual(hasEori, YesNoAnswers.yes, Eori.mapping("declaration")),
-    hasEori -> optionalRadio("declaration.consignorEori.hasEori.empty", Seq(YesNoAnswers.yes, YesNoAnswers.no))
-      .transform[Option[String]](choice => Option(choice), choice => choice.getOrElse(""))
+    hasEori -> requiredRadio("declaration.consignorEori.hasEori.empty", YesNoAnswer.allowedValues)
   )(ConsignorEoriNumber.apply)(ConsignorEoriNumber.unapply)
 
   def form(): Form[ConsignorEoriNumber] = Form(ConsignorEoriNumber.mapping)
 
   def apply(consignorDetails: ConsignorDetails): ConsignorEoriNumber =
     consignorDetails.details.eori match {
-      case Some(eori) => ConsignorEoriNumber(Some(eori), Some(YesNoAnswers.yes))
-      case _          => ConsignorEoriNumber(None, Some(YesNoAnswers.no))
+      case Some(eori) => ConsignorEoriNumber(Some(eori), YesNoAnswers.yes)
+      case _          => ConsignorEoriNumber(None, YesNoAnswers.no)
     }
 }

--- a/test/unit/forms/declaration/consignor/ConsignorEoriNumberSpec.scala
+++ b/test/unit/forms/declaration/consignor/ConsignorEoriNumberSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.forms.declaration.consignor
+
+import forms.common.Eori
+import forms.common.YesNoAnswer.YesNoAnswers
+import forms.declaration.consignor.ConsignorEoriNumber
+import forms.declaration.consignor.ConsignorEoriNumber.form
+import play.api.data.FormError
+import unit.base.FormSpec
+
+class ConsignorEoriNumberSpec extends FormSpec {
+
+  "Consignor Eori Number form" should {
+
+    "has no errors" when {
+
+      "the answer is 'No'" in {
+
+        val correctModel = ConsignorEoriNumber(None, YesNoAnswers.no)
+
+        val result = form.fillAndValidate(correctModel)
+
+        result.errors mustBe empty
+      }
+
+      "the answer is 'Yes' and EORI is provided" in {
+
+        val correctModel = ConsignorEoriNumber(Some(Eori("GB123456789")), YesNoAnswers.yes)
+
+        val result = form.fillAndValidate(correctModel)
+
+        result.errors mustBe empty
+      }
+    }
+
+    "has errors" when {
+
+      "the answer is 'Yes' and EORI is not provided" in {
+
+        val incorrectData = Map("eori" -> "", "hasEori" -> "Yes")
+
+        val result = form.bind(incorrectData)
+
+        result.errors mustBe Seq(FormError("eori", "declaration.eori.empty"))
+      }
+
+      "there is no answer on the question" in {
+
+        val incorrectData = Map.empty[String, String]
+
+        val result = form.bind(incorrectData)
+
+        result.errors mustBe Seq(FormError("hasEori", "declaration.consignorEori.hasEori.empty"))
+      }
+    }
+  }
+}

--- a/test/views/declaration/ConsignorEoriNumberViewSpec.scala
+++ b/test/views/declaration/ConsignorEoriNumberViewSpec.scala
@@ -46,7 +46,7 @@ class ConsignorEoriNumberViewSpec extends UnitViewSpec with ExportsTestData with
     val view = createView()
     onJourney(DeclarationType.CLEARANCE) { implicit request =>
       "display answer input" in {
-        val consignorEoriNumber = ConsignorEoriNumber.form().fill(ConsignorEoriNumber(Some(Eori("GB123456789")), Some(YesNoAnswers.yes)))
+        val consignorEoriNumber = ConsignorEoriNumber.form().fill(ConsignorEoriNumber(Some(Eori("GB123456789")), YesNoAnswers.yes))
         val view = createView(form = consignorEoriNumber)
 
         view
@@ -97,7 +97,7 @@ class ConsignorEoriNumberViewSpec extends UnitViewSpec with ExportsTestData with
 
       "handle invalid input" should {
         "display errors when all inputs are incorrect" in {
-          val data = ConsignorEoriNumber(Some(Eori("123456789")), Some(YesNoAnswers.yes))
+          val data = ConsignorEoriNumber(Some(Eori("123456789")), YesNoAnswers.yes)
           val form = ConsignorEoriNumber.form().fillAndValidate(data)
           val view = createView(form = form)
 
@@ -107,7 +107,7 @@ class ConsignorEoriNumberViewSpec extends UnitViewSpec with ExportsTestData with
         }
 
         "display errors when eori contains special characters" in {
-          val data = ConsignorEoriNumber(eori = Some(Eori("12#$%^78")), hasEori = Some(YesNoAnswers.yes))
+          val data = ConsignorEoriNumber(eori = Some(Eori("12#$%^78")), hasEori = YesNoAnswers.yes)
           val form = ConsignorEoriNumber.form().fillAndValidate(data)
           val view = createView(form = form)
 


### PR DESCRIPTION
This page must be mandatory.
Additionally I removed unnecessary controller spec cases plus added missing model spec.
I changed has eori to be not longer optional. This field always must be provided.
The hasEori field is not a part of the backend model, so those changes are compatible with current backend.
