### PR TITLE
CEDS-2109 Remove the Secure and HttpOnly config

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -33,8 +33,6 @@ play.filters.csrf.contentType.whiteList = ["application/xml", "application/json"
 play.http.requestHandler = "uk.gov.hmrc.play.bootstrap.http.RequestHandler"
 play.http.errorHandler = "handlers.ErrorHandler"
 play.http.filters = "uk.gov.hmrc.play.bootstrap.filters.FrontendFilters"
-play.http.flash.secure = true
-play.http.flash.httpOnly = true
 
 # Play Modules
 # ~~~~


### PR DESCRIPTION
This is due to the Acceptance tests failing due to not being able to set
the secure PLAY_FLASH cookie when using the `http` protocol
Instead these configs need to be added to the relevat `app-config` repos