### PR TITLE
CEDS-2478 Prevent multiple form submissions

### DIFF
--- a/app/assets/javascripts/preventMultipleFormSubmissions.js
+++ b/app/assets/javascripts/preventMultipleFormSubmissions.js
@@ -1,0 +1,15 @@
+(() => {
+    let frm = document.querySelector('form')
+    if (frm) {
+        var allowSubmit = true;
+        frm.onsubmit = () => {
+            if (allowSubmit) {
+                allowSubmit = false;
+                return true;
+            }
+            else {
+                return false;
+            }
+        }
+    }
+})();

--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -109,3 +109,5 @@
     footerItems = footer
   )(contentBlock)
 }
+
+<script src='@routes.Assets.versioned("javascripts/preventMultipleFormSubmissions.js")'></script>


### PR DESCRIPTION
This was a problem when adding export items, where we could have added
50+ empty items, simply by clicking multiple times

There was also a problem on the summary page where we could submit the
final declaration multiple times.