### PR TITLE
CEDS-2509 Avoid breaking up secions when printing

### DIFF
--- a/app/assets/stylesheets/partials/_gdsBase.scss
+++ b/app/assets/stylesheets/partials/_gdsBase.scss
@@ -42,7 +42,8 @@ from the view and the page (url/page number, etc.)
 ====================================
 */
 @media print {
-  @page { margin:0 }
+  @page { margin: 10px }
+  .govuk-section-break { page-break-inside : avoid }
   .govuk-link { display: none; }
   footer { display: none; }
 }

--- a/app/views/declaration/summary/accepted_declaration_page.scala.html
+++ b/app/views/declaration/summary/accepted_declaration_page.scala.html
@@ -61,21 +61,21 @@
 
     @printThisPage
 
-    @references_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@references_section(Mode.Print, request.cacheModel)</div>
 
-    @parties_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@parties_section(Mode.Print, request.cacheModel)</div>
 
-    @countries_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@countries_section(Mode.Print, request.cacheModel)</div>
 
-    @locations_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@locations_section(Mode.Print, request.cacheModel)</div>
 
-    @transaction_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@transaction_section(Mode.Print, request.cacheModel)</div>
 
-    @items_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@items_section(Mode.Print, request.cacheModel)</div>
 
-    @warehouse_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@warehouse_section(Mode.Print, request.cacheModel)</div>
 
-    @transport_section(Mode.Print, request.cacheModel)
+    <div class="govuk-section-break">@transport_section(Mode.Print, request.cacheModel)</div>
 
     @printThisPage
 }


### PR DESCRIPTION
From my experimentations I could not make Firefox read the `@page size`
property. According documentation only this is not yet a standard,
instead a few browsers support it, with Chrome being one of them.