### PR TITLE
BAU Add empty action when the feature flag is enabled

### DIFF
--- a/app/views/rejected_notification_errors.scala.html
+++ b/app/views/rejected_notification_errors.scala.html
@@ -53,6 +53,8 @@
     )
 
     Some(Actions(items = Seq(action)))
+  } else if(changeErrorLinkConfig.isEnabled) {
+      Some(Actions(items = Seq.empty))
   } else None
 }
 


### PR DESCRIPTION
This is a fix for the error which appear for some decs on QA.

Error appear only when there is a list of mixed errors with and without url and the first notification doesn't have the url.

If there is a notification error list and it starts without error that contains the change url but next errors contains govukSummaryList try to get the url from non existing place which cause `None.get` error.

When the feature flag is enabled and notification error doesn't have the url we should still generate this column. This can be achieved with passing empty action list to summaryList component