### PR TITLE
CEDS-2538 - remove declaration id from session when viewing submissions

### DIFF
--- a/app/controllers/SubmissionsController.scala
+++ b/app/controllers/SubmissionsController.scala
@@ -51,7 +51,7 @@ class SubmissionsController @Inject()(
 
         result = SubmissionDisplayHelper.createSubmissionsWithSortedNotificationsMap(submissions, notifications)
 
-      } yield Ok(submissionsPage(SubmissionsPagesElements(result, submissionsPages)))
+      } yield Ok(submissionsPage(SubmissionsPagesElements(result, submissionsPages))).removingFromSession(ExportsSessionKeys.declarationId)
     }
 
   def displayDeclarationWithNotifications(id: String): Action[AnyContent] = authenticate.async { implicit request =>


### PR DESCRIPTION
This will fix the bug where the declaration id is in the users session after viewing completed declaration.   Providing the user navigates back to the choice page using the back links.