### PR TITLE
BAU - action link item with correct govuk css class

### DIFF
--- a/app/views/components/gds/ActionItemBuilder.scala
+++ b/app/views/components/gds/ActionItemBuilder.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.gds
+
+import play.api.i18n.Messages
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Content
+import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist.ActionItem
+
+object ActionItemBuilder {
+
+  def actionItem(href: String, content: Content, visuallyHiddenText: Option[String])(implicit messages: Messages) =
+    ActionItem(href = href, content = content, visuallyHiddenText = visuallyHiddenText, classes = "govuk-link--no-visited-state")
+}

--- a/app/views/declaration/summary/EoriOrAddress.scala
+++ b/app/views/declaration/summary/EoriOrAddress.scala
@@ -22,6 +22,7 @@ import play.api.i18n.Messages
 import play.api.mvc.Call
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{Empty, HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.summarylist._
+import views.components.gds.ActionItemBuilder._
 
 object EoriOrAddress {
 
@@ -72,7 +73,7 @@ object EoriOrAddress {
         Actions(
           items = actionItems(
             mode,
-            ActionItem(href = changeController.url, content = Text(messages("site.change")), visuallyHiddenText = Some(messages(eoriChangeLabel)))
+            actionItem(href = changeController.url, content = Text(messages("site.change")), visuallyHiddenText = Some(messages(eoriChangeLabel)))
           )
         )
       )
@@ -95,7 +96,7 @@ object EoriOrAddress {
         Actions(
           items = actionItems(
             mode,
-            ActionItem(href = changeController.url, content = Text(messages("site.change")), visuallyHiddenText = Some(messages(addressChangeLabel)))
+            actionItem(href = changeController.url, content = Text(messages("site.change")), visuallyHiddenText = Some(messages(addressChangeLabel)))
           )
         )
       )

--- a/app/views/declaration/summary/containers.scala.html
+++ b/app/views/declaration/summary/containers.scala.html
@@ -21,6 +21,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -84,7 +85,7 @@
             value = Value(Text(messages("site.no"))),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.TransportContainerController.displayContainerSummary(mode).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.transport.containers.change"))

--- a/app/views/declaration/summary/countries_section.scala.html
+++ b/app/views/declaration/summary/countries_section.scala.html
@@ -16,11 +16,10 @@
 
 @import models.declaration.Locations
 @import models.requests.JourneyRequest
-@import models.viewmodels.HtmlTableRow
 @import services.Countries
-@import models.Mode._
 @import views.html.components.gds.summary_list
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.components.gds.ActionItemBuilder._
 
 @this(summaryList: summary_list)
 
@@ -50,7 +49,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.OriginationCountryController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.countries.countryOfDispatch.change"))
@@ -70,7 +69,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.RoutingCountriesSummaryController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.countries.routingCountries.change"))
@@ -90,7 +89,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.DestinationCountryController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.countries.countryOfDestination.change"))

--- a/app/views/declaration/summary/item_section.scala.html
+++ b/app/views/declaration/summary/item_section.scala.html
@@ -19,6 +19,7 @@
 @import models.Mode
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         summaryList: summary_list,
@@ -46,7 +47,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.ProcedureCodesController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.procedureCode.change", item.sequenceId))
@@ -66,7 +67,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.FiscalInformationController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.onwardSupplyRelief.change", item.sequenceId))
@@ -86,7 +87,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.AdditionalFiscalReferencesController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.VATdetails.change", item.sequenceId))
@@ -106,7 +107,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.CommodityDetailsController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.commodityCode.change", item.sequenceId))
@@ -126,7 +127,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.CommodityDetailsController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.goodsDescription.change", item.sequenceId))
@@ -146,7 +147,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.unDangerousGoodsCode.change", item.sequenceId))
@@ -166,7 +167,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.CusCodeController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.cusCode.change", item.sequenceId))
@@ -186,7 +187,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.TaricCodeSummaryController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.taricAdditionalCodes.change", item.sequenceId))
@@ -206,7 +207,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.NactCodeSummaryController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.nationalAdditionalCodes.change", item.sequenceId))
@@ -226,7 +227,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.StatisticalValueController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.itemValue.change", item.sequenceId))
@@ -247,7 +248,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.CommodityMeasureController.displayPage(mode, item.id).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.items.item.supplementaryUnits.change", item.sequenceId))
@@ -268,7 +269,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.CommodityMeasureController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.grossWeight.change", item.sequenceId))
@@ -288,7 +289,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.CommodityMeasureController.displayPage(mode, item.id).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.netWeight.change", item.sequenceId))

--- a/app/views/declaration/summary/locations_section.scala.html
+++ b/app/views/declaration/summary/locations_section.scala.html
@@ -18,6 +18,7 @@
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(summaryList: summary_list)
 
@@ -45,7 +46,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.LocationController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.locations.goodsLocationCode.change"))
@@ -64,7 +65,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.OfficeOfExitController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.locations.officeOfExit.change"))

--- a/app/views/declaration/summary/package_information.scala.html
+++ b/app/views/declaration/summary/package_information.scala.html
@@ -21,6 +21,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -90,7 +91,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.PackageInformationSummaryController.displayPage(mode, itemId).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.packageInformation.changeAll", itemNo))

--- a/app/views/declaration/summary/parties_section.scala.html
+++ b/app/views/declaration/summary/parties_section.scala.html
@@ -23,6 +23,7 @@
 @import views.html.declaration.summary._
 @import forms.common.Eori
 @import forms.declaration.DeclarantDetails
+@import views.components.gds.ActionItemBuilder._
 
 @this(
     summaryList: summary_list,
@@ -100,7 +101,7 @@
                 ),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.DeclarantExporterController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.declarantIsExporter.change"))
@@ -117,7 +118,7 @@
                 value = Value(content = Text(messages(s"declaration.summary.parties.eidr.${isEidr.answer.toLowerCase}"))),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.EntryIntoDeclarantsRecordsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.eidr.change"))
@@ -134,7 +135,7 @@
                 value = Value(content = Text(personPresentingGoods.eori.value)),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.PersonPresentingGoodsDetailsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.personPresentingGoods.change"))
@@ -162,7 +163,7 @@
                 ),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.IsExsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.exs.change"))
@@ -183,7 +184,7 @@
                 ),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.RepresentativeAgentController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.representative.agent.change"))
@@ -211,7 +212,7 @@
                 ),
                 actions = Some(Actions(
                     items = actionItems(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.RepresentativeStatusController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.parties.representative.type.change"))

--- a/app/views/declaration/summary/parties_section_additional_actors.scala.html
+++ b/app/views/declaration/summary/parties_section_additional_actors.scala.html
@@ -20,6 +20,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -65,7 +66,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.AdditionalActorsAddController.displayPage(mode).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.parties.additional.empty.change"))

--- a/app/views/declaration/summary/parties_section_holders.scala.html
+++ b/app/views/declaration/summary/parties_section_holders.scala.html
@@ -20,6 +20,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -65,7 +66,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.DeclarationHolderController.displayPage(mode).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.parties.holders.empty.change"))

--- a/app/views/declaration/summary/references_section.scala.html
+++ b/app/views/declaration/summary/references_section.scala.html
@@ -17,6 +17,7 @@
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(summaryList: summary_list)
 
@@ -38,7 +39,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.DeclarationChoiceController.displayPage(mode).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.references.type.change"))
@@ -57,7 +58,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.DispatchLocationController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.references.location.change"))
@@ -77,7 +78,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.AdditionalDeclarationTypeController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.references.additionalType.change"))
@@ -97,7 +98,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.ConsignmentReferencesController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.references.ducr.change"))
@@ -117,7 +118,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.ConsignmentReferencesController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.references.lrn.change"))

--- a/app/views/declaration/summary/related_documents.scala.html
+++ b/app/views/declaration/summary/related_documents.scala.html
@@ -20,6 +20,7 @@
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -53,7 +54,7 @@
             value = Value(Text(messages("site.no"))),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.PreviousDocumentsController.displayPage(mode).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.transaction.previousDocuments.change"))

--- a/app/views/declaration/summary/supporting_documents.scala.html
+++ b/app/views/declaration/summary/supporting_documents.scala.html
@@ -21,6 +21,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -82,7 +83,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.DocumentsProducedController.displayPage(mode, itemId).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.supportingDocuments.change"))

--- a/app/views/declaration/summary/transaction_section.scala.html
+++ b/app/views/declaration/summary/transaction_section.scala.html
@@ -17,6 +17,7 @@
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         summaryList: summary_list,
@@ -47,7 +48,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transaction.itemAmount.change"))
@@ -66,7 +67,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.TotalNumberOfItemsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transaction.exchangeRate.change"))
@@ -85,7 +86,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.TotalPackageQuantityController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transaction.totalNoOfPackages.change"))
@@ -104,7 +105,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.NatureOfTransactionController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transaction.natureOfTransaction.change"))

--- a/app/views/declaration/summary/transport_section.scala.html
+++ b/app/views/declaration/summary/transport_section.scala.html
@@ -19,6 +19,7 @@
 @import models.requests.JourneyRequest
 @import views.html.components.gds.summary_list
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         summaryList: summary_list,
@@ -70,7 +71,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.TransportLeavingTheBorderController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transport.departure.transportCode.header.change"))
@@ -90,7 +91,7 @@
                   ),
                   actions = actions(Actions(
                       items = Seq(
-                          ActionItem(
+                          actionItem(
                               href = controllers.declaration.routes.DepartureTransportController.displayPage(mode).url,
                               content = Text(messages("site.change")),
                               visuallyHiddenText = Some(messages("declaration.summary.transport.departure.meansOfTransport.header.change"))
@@ -112,7 +113,7 @@
                     ),
                     actions = actions(Actions(
                         items = Seq(
-                            ActionItem(
+                            actionItem(
                                 href = controllers.declaration.routes.BorderTransportController.displayPage(mode).url,
                                 content = Text(messages("site.change")),
                                 visuallyHiddenText = Some(messages("declaration.summary.transport.border.meansOfTransport.header.change"))
@@ -134,7 +135,7 @@
                     ),
                     actions = actions(Actions(
                         items = Seq(
-                            ActionItem(
+                            actionItem(
                                 href = controllers.declaration.routes.BorderTransportController.displayPage(mode).url,
                                 content = Text(messages("site.change")),
                                 visuallyHiddenText = Some(messages("declaration.summary.transport.activeTransportNationality.change"))
@@ -155,7 +156,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.TransportPaymentController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.transport.payment.change"))

--- a/app/views/declaration/summary/union_and_national_codes.scala.html
+++ b/app/views/declaration/summary/union_and_national_codes.scala.html
@@ -21,6 +21,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.declaration.summary.TableCell
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukTable: GovukTable,
@@ -86,7 +87,7 @@
             ),
             actions = actions(Actions(
                 items = Seq(
-                    ActionItem(
+                    actionItem(
                         href = controllers.declaration.routes.AdditionalInformationRequiredController.displayPage(mode, itemId).url,
                         content = Text(messages("site.change")),
                         visuallyHiddenText = Some(messages("declaration.summary.items.item.additionalInformation.change"))

--- a/app/views/declaration/summary/warehouse_section.scala.html
+++ b/app/views/declaration/summary/warehouse_section.scala.html
@@ -20,6 +20,7 @@
 @import models.Mode
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.html.components.gds.summary_list
+@import views.components.gds.ActionItemBuilder._
 
 @this(summaryList: summary_list)
 
@@ -47,7 +48,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.WarehouseIdentificationController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.warehouse.id.change"))
@@ -67,7 +68,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.warehouse.supervisingOffice.change"))
@@ -87,7 +88,7 @@
                 ),
                 actions = actions(Actions(
                     items = Seq(
-                        ActionItem(
+                        actionItem(
                             href = controllers.declaration.routes.InlandTransportDetailsController.displayPage(mode).url,
                             content = Text(messages("site.change")),
                             visuallyHiddenText = Some(messages("declaration.summary.warehouse.inlandModeOfTransport.change"))

--- a/app/views/rejected_notification_errors.scala.html
+++ b/app/views/rejected_notification_errors.scala.html
@@ -19,6 +19,7 @@
 @import views.{BackButton, Title}
 @import views.html.components.gds._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.components.gds.ActionItemBuilder._
 
 @this(
         govukLayout: gdsMainTemplate,
@@ -45,11 +46,10 @@
     val errorMessage = error.pageErrorMessage.getOrElse("")
     val url = routes.SubmissionsController.amendErrors(declaration.id, urlToPageWithError, errorPattern, errorMessage).url
 
-    val action = ActionItem(
+    val action = actionItem(
       href = url,
       content = Text(messages("site.change")),
-      visuallyHiddenText = Some(error.pointer.map(p => messages(p.messageKey, p.sequenceArgs: _*)).getOrElse("")),
-      classes = ""
+      visuallyHiddenText = Some(error.pointer.map(p => messages(p.messageKey, p.sequenceArgs: _*)).getOrElse(""))
     )
 
     Some(Actions(items = Seq(action)))


### PR DESCRIPTION
Noticed on the summary page(s) that the "change" links were not showing the correct "visited" state.  (They were showing as "purple" for visited links - there shouldn't be any difference in appearance between visited and non-visited links).

These change links are created by the govukfrontend `ActionItem` class so I've created a little "builder" class to construct one of those with the appropriate css class.