### PR TITLE
CEDS-2493 - fix layout of previous documents in CYA summary page

### DIFF
--- a/app/views/declaration/summary/related_documents.scala.html
+++ b/app/views/declaration/summary/related_documents.scala.html
@@ -21,6 +21,7 @@
 @import views.html.components.gds.link
 @import views.html.components.gds.summary_list
 @import views.components.gds.ActionItemBuilder._
+@import views.declaration.summary.TableCell
 
 @this(
         govukTable: GovukTable,
@@ -73,9 +74,7 @@
                 TableRow(
                     content = Text(document.documentReference)
                 ),
-                TableRow(
-                    content = HtmlContent(change(document))
-                )
+                TableCell.changeLink(change(document))
             )
         ),
         head = Some(List(


### PR DESCRIPTION
Nothing to do with the 2-step changes