### PR TITLE
BAU - proposed alternative back button navigation for Additional Info.

### DIFF
--- a/app/controllers/declaration/AdditionalInformationRequiredController.scala
+++ b/app/controllers/declaration/AdditionalInformationRequiredController.scala
@@ -44,7 +44,10 @@ class AdditionalInformationRequiredController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    Ok(additionalInfoReq(mode, itemId, previousAnswer(itemId).withSubmissionErrors()))
+    cachedItems(itemId) match {
+      case items if items.isEmpty => Ok(additionalInfoReq(mode, itemId, previousAnswer(itemId).withSubmissionErrors()))
+      case _                      => navigator.continueTo(mode, controllers.declaration.routes.AdditionalInformationController.displayPage(_, itemId))
+    }
   }
 
   def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -105,6 +105,7 @@ object Navigator {
   val standardItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.StatisticalValueController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -138,6 +139,7 @@ object Navigator {
 
   val clearanceItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case page                          => throw new IllegalArgumentException(s"Navigator back-link route not implemented for $page on clearance")
   }
 
@@ -167,6 +169,7 @@ object Navigator {
   val supplementaryItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.StatisticalValueController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -201,6 +204,7 @@ object Navigator {
   val simplifiedItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.PackageInformationSummaryController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.PackageInformationSummaryController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -236,6 +240,7 @@ object Navigator {
   val occasionalItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.PackageInformationSummaryController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.PackageInformationSummaryController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -263,14 +268,13 @@ object Navigator {
   }
 
   val commonItem: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
-    case FiscalInformation            => controllers.declaration.routes.ProcedureCodesController.displayPage
-    case AdditionalFiscalReference    => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = false)
-    case CommodityDetails             => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = true)
-    case UNDangerousGoodsCode         => controllers.declaration.routes.CommodityDetailsController.displayPage
-    case TaricCode                    => controllers.declaration.routes.TaricCodeSummaryController.displayPage
-    case TaricCodeFirst               => controllers.declaration.routes.CusCodeController.displayPage
-    case StatisticalValue             => controllers.declaration.routes.NactCodeSummaryController.displayPage
-    case AdditionalInformationSummary => controllers.declaration.routes.AdditionalInformationRequiredController.displayPage
+    case FiscalInformation         => controllers.declaration.routes.ProcedureCodesController.displayPage
+    case AdditionalFiscalReference => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = false)
+    case CommodityDetails          => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = true)
+    case UNDangerousGoodsCode      => controllers.declaration.routes.CommodityDetailsController.displayPage
+    case TaricCode                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
+    case TaricCodeFirst            => controllers.declaration.routes.CusCodeController.displayPage
+    case StatisticalValue          => controllers.declaration.routes.NactCodeSummaryController.displayPage
   }
 
   val commonCacheDependent: PartialFunction[DeclarationPage, (ExportsDeclaration, Mode) => Call] = {

--- a/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
@@ -101,6 +101,17 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
       "return 303 (SEE_OTHER)" when {
 
+        "Additional item(s) exist in cache" in {
+          withNewCaching(
+            aDeclarationAfter(request.cacheModel, withItem(anItem(withItemId(itemId), withAdditionalInformation("code", "description"))))
+          )
+
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalInformationController.displayPage(Mode.Normal, itemId)
+        }
+
         "user submits valid Yes answer" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withItem(anItem(withItemId(itemId)))))
 

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -75,24 +75,6 @@ class AdditionalInformationViewSpec extends UnitViewSpec with ExportsTestData wi
         createView().getElementById("section-header").text() must include("supplementary.items")
       }
 
-      "display 'Back' button that links to 'Commodity measure' page" when {
-        "on the Standard journey" in {
-
-          val backButton = createView().getElementById("back-link")
-
-          backButton.text() mustBe messages(backCaption)
-          backButton.attr("href") mustBe routes.AdditionalInformationRequiredController.displayPage(Mode.Normal, itemId).url
-        }
-
-        "on the Simplified journey" in {
-
-          val backButton = createView().getElementById("back-link")
-
-          backButton.text() mustBe messages(backCaption)
-          backButton.attr("href") mustBe routes.AdditionalInformationRequiredController.displayPage(Mode.Normal, itemId).url
-        }
-      }
-
       "display 'Save and continue' button" in {
         val view: Document = createView()
         view must containElement("button").withName(SaveAndContinue.toString)
@@ -103,6 +85,26 @@ class AdditionalInformationViewSpec extends UnitViewSpec with ExportsTestData wi
         view must containElement("button").withName(SaveAndReturn.toString)
       }
 
+    }
+
+    onJourney(DeclarationType.STANDARD, DeclarationType.CLEARANCE, DeclarationType.SUPPLEMENTARY) { implicit request =>
+      "display 'Back' button that links to 'Commodity measure' page" in {
+
+        val backButton = createView().getElementById("back-link")
+
+        backButton.text() mustBe messages(backCaption)
+        backButton.attr("href") mustBe routes.CommodityMeasureController.displayPage(Mode.Normal, itemId).url
+      }
+    }
+
+    onJourney(DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL) { implicit request =>
+      "display 'Back' button that links to 'Package information' page" in {
+
+        val backButton = createView().getElementById("back-link")
+
+        backButton.text() mustBe messages(backCaption)
+        backButton.attr("href") mustBe routes.PackageInformationSummaryController.displayPage(Mode.Normal, itemId).url
+      }
     }
   }
 


### PR DESCRIPTION
Change is that we only navigate back to the "Do you want to add AI (Y/N)?" question when there are no AI in the cache.
This avoids having to delete existing AI from the cache when the user answers "No" - actually, the code still does that but the cache will be empty.

When navigating forward, if there are already AI in the cache then the "Do you want to add AI?" page is skipped.   

