### PR TITLE
CEDS-2561 - Change navigation behaviour for "Additional Information"

### DIFF
--- a/app/controllers/declaration/AdditionalInformationRemoveController.scala
+++ b/app/controllers/declaration/AdditionalInformationRemoveController.scala
@@ -64,7 +64,7 @@ class AdditionalInformationRemoveController @Inject()(
               formData.answer match {
                 case YesNoAnswers.yes =>
                   removeAdditionalInformation(itemId, information)
-                    .map(_ => returnToSummary(mode, itemId))
+                    .map(declaration => afterRemove(mode, itemId, declaration))
                 case YesNoAnswers.no =>
                   Future.successful(returnToSummary(mode, itemId))
               }
@@ -74,6 +74,12 @@ class AdditionalInformationRemoveController @Inject()(
     }
 
   }
+
+  private def afterRemove(mode: Mode, itemId: String, declaration: Option[ExportsDeclaration])(implicit request: JourneyRequest[AnyContent]) =
+    declaration.flatMap(_.itemBy(itemId)).flatMap(_.additionalInformation).map(_.items) match {
+      case Some(items) if items.nonEmpty => returnToSummary(mode, itemId)
+      case _                             => navigator.continueTo(mode, routes.AdditionalInformationRequiredController.displayPage(_, itemId))
+    }
 
   private def returnToSummary(mode: Mode, itemId: String)(implicit request: JourneyRequest[AnyContent]) =
     navigator.continueTo(mode, routes.AdditionalInformationController.displayPage(_, itemId))

--- a/app/controllers/declaration/AdditionalInformationRequiredController.scala
+++ b/app/controllers/declaration/AdditionalInformationRequiredController.scala
@@ -44,7 +44,10 @@ class AdditionalInformationRequiredController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    Ok(additionalInfoReq(mode, itemId, previousAnswer(itemId).withSubmissionErrors()))
+    cachedItems(itemId) match {
+      case items if items.isEmpty => Ok(additionalInfoReq(mode, itemId, previousAnswer(itemId).withSubmissionErrors()))
+      case _                      => navigator.continueTo(mode, controllers.declaration.routes.AdditionalInformationController.displayPage(_, itemId))
+    }
   }
 
   def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -105,6 +105,7 @@ object Navigator {
   val standardItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.StatisticalValueController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -138,6 +139,7 @@ object Navigator {
 
   val clearanceItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case page                          => throw new IllegalArgumentException(s"Navigator back-link route not implemented for $page on clearance")
   }
 
@@ -167,6 +169,7 @@ object Navigator {
   val supplementaryItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.StatisticalValueController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.CommodityMeasureController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.CommodityMeasureController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -201,6 +204,7 @@ object Navigator {
   val simplifiedItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.PackageInformationSummaryController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.PackageInformationSummaryController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -236,6 +240,7 @@ object Navigator {
   val occasionalItemPage: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
     case PackageInformation            => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case AdditionalInformationRequired => controllers.declaration.routes.PackageInformationSummaryController.displayPage
+    case AdditionalInformationSummary  => controllers.declaration.routes.PackageInformationSummaryController.displayPage
     case CusCode                       => controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage
     case NactCode                      => controllers.declaration.routes.NactCodeSummaryController.displayPage
     case NactCodeFirst                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
@@ -263,14 +268,13 @@ object Navigator {
   }
 
   val commonItem: PartialFunction[DeclarationPage, (Mode, String) => Call] = {
-    case FiscalInformation            => controllers.declaration.routes.ProcedureCodesController.displayPage
-    case AdditionalFiscalReference    => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = false)
-    case CommodityDetails             => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = true)
-    case UNDangerousGoodsCode         => controllers.declaration.routes.CommodityDetailsController.displayPage
-    case TaricCode                    => controllers.declaration.routes.TaricCodeSummaryController.displayPage
-    case TaricCodeFirst               => controllers.declaration.routes.CusCodeController.displayPage
-    case StatisticalValue             => controllers.declaration.routes.NactCodeSummaryController.displayPage
-    case AdditionalInformationSummary => controllers.declaration.routes.AdditionalInformationRequiredController.displayPage
+    case FiscalInformation         => controllers.declaration.routes.ProcedureCodesController.displayPage
+    case AdditionalFiscalReference => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = false)
+    case CommodityDetails          => controllers.declaration.routes.FiscalInformationController.displayPage(_, _, fastForward = true)
+    case UNDangerousGoodsCode      => controllers.declaration.routes.CommodityDetailsController.displayPage
+    case TaricCode                 => controllers.declaration.routes.TaricCodeSummaryController.displayPage
+    case TaricCodeFirst            => controllers.declaration.routes.CusCodeController.displayPage
+    case StatisticalValue          => controllers.declaration.routes.NactCodeSummaryController.displayPage
   }
 
   val commonCacheDependent: PartialFunction[DeclarationPage, (ExportsDeclaration, Mode) => Call] = {

--- a/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
@@ -101,6 +101,17 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
       "return 303 (SEE_OTHER)" when {
 
+        "Additional item(s) exist in cache" in {
+          withNewCaching(
+            aDeclarationAfter(request.cacheModel, withItem(anItem(withItemId(itemId), withAdditionalInformation("code", "description"))))
+          )
+
+          val result = controller.displayPage(Mode.Normal, itemId)(getRequest())
+
+          await(result) mustBe aRedirectToTheNextPage
+          thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalInformationController.displayPage(Mode.Normal, itemId)
+        }
+
         "user submits valid Yes answer" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withItem(anItem(withItemId(itemId)))))
 

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -75,24 +75,6 @@ class AdditionalInformationViewSpec extends UnitViewSpec with ExportsTestData wi
         createView().getElementById("section-header").text() must include("supplementary.items")
       }
 
-      "display 'Back' button that links to 'Commodity measure' page" when {
-        "on the Standard journey" in {
-
-          val backButton = createView().getElementById("back-link")
-
-          backButton.text() mustBe messages(backCaption)
-          backButton.attr("href") mustBe routes.AdditionalInformationRequiredController.displayPage(Mode.Normal, itemId).url
-        }
-
-        "on the Simplified journey" in {
-
-          val backButton = createView().getElementById("back-link")
-
-          backButton.text() mustBe messages(backCaption)
-          backButton.attr("href") mustBe routes.AdditionalInformationRequiredController.displayPage(Mode.Normal, itemId).url
-        }
-      }
-
       "display 'Save and continue' button" in {
         val view: Document = createView()
         view must containElement("button").withName(SaveAndContinue.toString)
@@ -103,6 +85,26 @@ class AdditionalInformationViewSpec extends UnitViewSpec with ExportsTestData wi
         view must containElement("button").withName(SaveAndReturn.toString)
       }
 
+    }
+
+    onJourney(DeclarationType.STANDARD, DeclarationType.CLEARANCE, DeclarationType.SUPPLEMENTARY) { implicit request =>
+      "display 'Back' button that links to 'Commodity measure' page" in {
+
+        val backButton = createView().getElementById("back-link")
+
+        backButton.text() mustBe messages(backCaption)
+        backButton.attr("href") mustBe routes.CommodityMeasureController.displayPage(Mode.Normal, itemId).url
+      }
+    }
+
+    onJourney(DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL) { implicit request =>
+      "display 'Back' button that links to 'Package information' page" in {
+
+        val backButton = createView().getElementById("back-link")
+
+        backButton.text() mustBe messages(backCaption)
+        backButton.attr("href") mustBe routes.PackageInformationSummaryController.displayPage(Mode.Normal, itemId).url
+      }
     }
   }
 


### PR DESCRIPTION
Two changes
1. After removing the last item from the list, redirect back to the "Do you want to add?" screen rather than the summary controller which then re-directs to the "Add" page

2. Only display the "Do you want to add?" page if there are no items in the cache.  This makes the backwards/forwards navigation more logical for users.