### PR TITLE
CEDS-2529 - auto-complete font size

### DIFF
--- a/app/assets/stylesheets/partials/_currency_input.scss
+++ b/app/assets/stylesheets/partials/_currency_input.scss
@@ -1,9 +1,9 @@
 
 span.currency-prefix {
   position: absolute;
-  padding: 8px;
-  margin-left: 2px;
+  margin-top: .5rem;
+  margin-left: .5rem;
 }
 input.currency-prefix {
-  padding-left: 30px;
+  padding-left: 1.2rem;
 }

--- a/app/assets/stylesheets/partials/_gdsBase.scss
+++ b/app/assets/stylesheets/partials/_gdsBase.scss
@@ -64,3 +64,23 @@ govuk-back-link-div class to add that space below (or instead of) the back-link
 .govuk-back-link-div {
   margin-bottom: 40px;
 }
+
+
+/*
+====================================
+CSS to support browser font sizes for auto-complete component
+====================================
+*/
+@media all {
+  .autocomplete__hint,
+  .autocomplete__input,
+  .autocomplete__option {
+    font-size: 1.1875rem;
+    line-height: 1.31579;
+  }
+}
+
+.autocomplete__option {
+  font-size: 1.1875rem;
+  line-height: 1.31579;
+}

--- a/app/views/components/gds/exportsInputTextWithPrefix.scala.html
+++ b/app/views/components/gds/exportsInputTextWithPrefix.scala.html
@@ -27,7 +27,7 @@
         inputClass: String = "govuk-input",
         hintKey: Option[String] = None,
         prefixLabelKey: Option[String] = None,
-        prefixClass: String = "inputBefore",
+        prefixClass: String = "",
         sectionHeaderKey: Option[String] = None
 )(implicit messages: Messages)
 

--- a/app/views/declaration/additionalActors/additional_actors_add.scala.html
+++ b/app/views/declaration/additionalActors/additional_actors_add.scala.html
@@ -45,7 +45,7 @@
 @inputField(partyType: String) = @{Some(exportsInputText(
     field = form(s"eori$partyType"),
     labelClasses = "govuk-label",
-    inputClasses = Some("govuk-input govuk-!-width-one-third"),
+    inputClasses = Some("govuk-input govuk-!-width-two-thirds"),
     labelKey = "declaration.additionalActors.eori"
     ))
 }

--- a/app/views/declaration/cus_code.scala.html
+++ b/app/views/declaration/cus_code.scala.html
@@ -87,7 +87,7 @@
                     conditionalHtml = Some(exportsInputText(
                         field = form(cusCodeKey),
                         labelClasses = "govuk-label",
-                        inputClasses = Some("govuk-input govuk-!-width-one-third"),
+                        inputClasses = Some("govuk-input govuk-input--width-10"),
                         labelKey = "declaration.cusCode.label"
                     )),
                     checked = form(hasCusCodeKey).value.contains(AllowedCUSCodeAnswers.yes)

--- a/app/views/declaration/un_dangerous_goods_code.scala.html
+++ b/app/views/declaration/un_dangerous_goods_code.scala.html
@@ -83,7 +83,7 @@
                     conditionalHtml = Some(exportsInputText(
                           field = form(dangerousGoodsCodeKey),
                           labelClasses = "govuk-label",
-                          inputClasses = Some("govuk-input govuk-!-width-one-third"),
+                          inputClasses = Some("govuk-input govuk-input--width-10"),
                           labelKey = "declaration.unDangerousGoodsCode.label"
                     )),
                     checked = form(hasDangerousGoodsCodeKey).value.contains(AllowedUNDangerousGoodsCodeAnswers.yes)


### PR DESCRIPTION
Fixes some of the minor issues identified in CEDS-2529
- size of auto-complete text
- position of currency character within input field
- width of input fields for CUS and UN codes