### PR TITLE
CEDS-2537 - remove warehouse answer when removing item

### DIFF
--- a/app/controllers/declaration/ItemsSummaryController.scala
+++ b/app/controllers/declaration/ItemsSummaryController.scala
@@ -153,8 +153,15 @@ class ItemsSummaryController @Inject()(
           request.cacheModel.items.filterNot(_ == itemToDelete).zipWithIndex.map {
             case (item, index) => item.copy(sequenceId = index + 1)
           }
-        exportsCacheService.update(request.cacheModel.copy(items = updatedItems))
+        val updatedModel = removeWarehouseIdentification(request.cacheModel.copy(items = updatedItems))
+        exportsCacheService.update(updatedModel)
 
       case None => Future.successful(None)
     }
+
+  private def removeWarehouseIdentification(declaration: ExportsDeclaration) =
+    if (declaration.`type` == DeclarationType.CLEARANCE || declaration.requiresWarehouseId)
+      declaration
+    else
+      declaration.copy(locations = declaration.locations.copy(warehouseIdentification = None))
 }

--- a/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import controllers.declaration.ItemsSummaryController
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers
-import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData, CommodityMeasure, FiscalInformation}
+import forms.declaration._
 import models.DeclarationType._
 import models.declaration.{ExportItem, ProcedureCodesData}
 import models.{ExportsDeclaration, Mode}
@@ -468,6 +468,70 @@ class ItemsSummaryControllerSpec extends ControllerWithoutFormSpec with OptionVa
           }
         }
       }
+    }
+
+    onJourney(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL) { request =>
+      "warehouse identification answer is updated" when {
+
+        val removeItemForm = Json.obj("yesNo" -> YesNoAnswers.yes)
+
+        val warehouseItem = anItem(withItemId("warehouseItem"), withProcedureCodes(Some("0007"), Seq("000")))
+        val declaration = aDeclaration(
+          withType(request.declarationType),
+          withItem(cachedItem),
+          withItem(warehouseItem),
+          withWarehouseIdentification(Some(WarehouseIdentification(Some("id"))))
+        )
+
+        "user removes item contain 'warehouse procedure code'" should {
+
+          "remove the Item from cache" in {
+
+            withNewCaching(declaration)
+
+            controller.removeItem(Mode.Normal, "warehouseItem")(postRequest(removeItemForm)).futureValue
+
+            val items = declarationPassedToUpdateCache.items
+            items.size mustBe 1
+
+            declarationPassedToUpdateCache.locations.warehouseIdentification mustBe None
+          }
+
+        }
+      }
+
+    }
+
+    onJourney(CLEARANCE) { request =>
+      "warehouse identification answer is retained" when {
+
+        val removeItemForm = Json.obj("yesNo" -> YesNoAnswers.yes)
+
+        val warehouseItem = anItem(withItemId("warehouseItem"), withProcedureCodes(Some("0007"), Seq("000")))
+        val declaration = aDeclaration(
+          withType(request.declarationType),
+          withItem(cachedItem),
+          withItem(warehouseItem),
+          withWarehouseIdentification(Some(WarehouseIdentification(Some("id"))))
+        )
+
+        "user removes item contain 'warehouse procedure code'" should {
+
+          "remove the Item from cache" in {
+
+            withNewCaching(declaration)
+
+            controller.removeItem(Mode.Normal, "warehouseItem")(postRequest(removeItemForm)).futureValue
+
+            val items = declarationPassedToUpdateCache.items
+            items.size mustBe 1
+
+            declarationPassedToUpdateCache.locations.warehouseIdentification mustBe Some(WarehouseIdentification(Some("id")))
+          }
+
+        }
+      }
+
     }
   }
 }


### PR DESCRIPTION
After removing an item we need to check if any of the remaining items contain a procedure code that would require the user to enter a warehouse id.  If there are none, then we remove any previously supplied warehouse answer as that question will now be skipped.