### PR TITLE
CEDS-2537 - fix bug with changing proc code from WH to non-WH required

### DIFF
--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -150,13 +150,15 @@ class ProcedureCodesController @Inject()(
         .transform(removeWarehouseIdentificationForCode)
     }
 
-    def updatedModel(model: ExportsDeclaration): ExportsDeclaration =
+    def updatedModel(model: ExportsDeclaration): ExportsDeclaration = {
+      val updatedModel = model.updatedItem(itemId, item => item.copy(procedureCodes = Some(updatedProcedureCodes)))
       updatedProcedureCodes.procedureCode match {
         case Some(code) =>
-          clearDataForProcedureCode(code, itemId, model).updatedItem(itemId, item => item.copy(procedureCodes = Some(updatedProcedureCodes)))
+          clearDataForProcedureCode(code, itemId, updatedModel)
         case _ =>
-          model.updatedItem(itemId, item => item.copy(procedureCodes = Some(updatedProcedureCodes)))
+          updatedModel
       }
+    }
 
     updateExportsDeclarationSyncDirect(updatedModel(_))
   }

--- a/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
+++ b/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
@@ -333,6 +333,32 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
         updatedLocations.warehouseIdentification mustBe None
       }
 
+      "user changed procedure code indicating warehouse identifier no longer required" in {
+
+        val warehouseIdentification = WarehouseIdentification(Some("WarehouseId"))
+        withNewCaching(
+          aDeclaration(
+            withType(DeclarationType.SUPPLEMENTARY),
+            withItem(anItem(withItemId(itemId), withProcedureCodes(Some("1007"), Seq("0000")))),
+            withWarehouseIdentification(Some(warehouseIdentification))
+          )
+        )
+
+        val correctForm =
+          Seq(("procedureCode", "1234"), saveAndContinueActionUrlEncoded)
+
+        val result = controller.submitProcedureCodes(Mode.Normal, itemId)(postRequestAsFormUrlEncoded(correctForm: _*))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe controllers.declaration.routes.CommodityDetailsController
+          .displayPage(Mode.Normal, "itemId12345")
+
+        verify(mockProcedureCodesPage, times(0)).apply(any(), any(), any(), any())(any(), any())
+
+        val updatedLocations = theCacheModelUpdated.locations
+        updatedLocations.warehouseIdentification mustBe None
+      }
+
       "user save correct data with '0019' procedure code on clearance journey" in {
 
         withNewCaching(


### PR DESCRIPTION
The bug was that I was checking if any item had a "warehouse required" procedure code _before_ applying the changed procedure code.    So changing from a WH-required to non-WH-required was failing to remove the WH data.