### PR TITLE
CEDS-2595 Accessibility: empty table headers

### DIFF
--- a/app/views/declaration/additional_fiscal_references.scala.html
+++ b/app/views/declaration/additional_fiscal_references.scala.html
@@ -38,6 +38,7 @@
         sectionHeader: sectionHeader,
         pageTitle: pageTitle,
         exportsInputText: exportsInputText,
+        spanVisuallyHidden: spanVisuallyHidden,
         tariffDetails: tariffDetails,
         addButton: addButton,
         saveButtons: saveButtons,
@@ -72,7 +73,9 @@
                 HeadCell(
                     content = Text(messages("declaration.additionalFiscalReferences.numbers.header"))
                 ),
-                HeadCell()
+                HeadCell(
+                    content = HtmlContent(spanVisuallyHidden(messages("site.remove.header")))
+                )
             )),
             attributes = Map("id" -> "removable_elements")
         ))

--- a/app/views/declaration/procedure_codes.scala.html
+++ b/app/views/declaration/procedure_codes.scala.html
@@ -33,6 +33,7 @@
         errorSummary: errorSummary,
         sectionHeader: sectionHeader,
         exportsInputText: exportsInputText,
+        spanVisuallyHidden: spanVisuallyHidden,
         tariffDetails: tariffDetails,
         saveButtons: saveButtons,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
@@ -62,7 +63,9 @@
                 HeadCell(
                     content = Text(messages("declaration.procedureCodes.additionalProcedureCode.table.header"))
                 ),
-                HeadCell()
+                HeadCell(
+                    content = HtmlContent(spanVisuallyHidden(messages("site.remove.header")))
+                )
             ))
         ))
     }

--- a/app/views/saved_declarations.scala.html
+++ b/app/views/saved_declarations.scala.html
@@ -17,7 +17,7 @@
 @import forms.Choice
 @import forms.Choice.AllowedChoiceValues.ContinueDec
 @import views.{BackButton, Title}
-@import views.html.components.gds.{gdsMainTemplate, link, pageTitle, pagination}
+@import views.html.components.gds.{gdsMainTemplate, link, pageTitle, pagination, spanVisuallyHidden}
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.ViewDates.formatDateAtTime
 @import java.time.ZoneId
@@ -26,6 +26,7 @@
   govukLayout: gdsMainTemplate,
   pageTitle: pageTitle,
   link: link,
+  spanVisuallyHidden: spanVisuallyHidden,
   govukTable: GovukTable
 )
 
@@ -75,7 +76,7 @@
         head = Some(Seq(
           HeadCell(content = Text(messages("saved.declarations.ducr"))),
           HeadCell(content = Text(messages("saved.declarations.dateSaved"))),
-          HeadCell()
+          HeadCell(content = HtmlContent(spanVisuallyHidden(messages("site.remove.header"))))
         )),
         rows = savedDeclarations
       ))

--- a/test/views/SavedDeclarationsViewSpec.scala
+++ b/test/views/SavedDeclarationsViewSpec.scala
@@ -64,6 +64,7 @@ class SavedDeclarationsViewSpec extends UnitViewSpec with Injector with ViewMatc
 
       tableHead(view)(0).text() mustBe messages(ducr)
       tableHead(view)(1).text() mustBe messages(dateSaved)
+      tableHead(view)(2).text() mustBe messages("site.remove.header")
 
       numberOfTableRows(view) mustBe 0
 

--- a/test/views/declaration/AdditionalActorsSummaryViewSpec.scala
+++ b/test/views/declaration/AdditionalActorsSummaryViewSpec.scala
@@ -97,6 +97,7 @@ class AdditionalActorsSummaryViewSpec extends UnitViewSpec with ExportsTestData 
         // check table header
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe messages("declaration.additionalActors.table.party")
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe messages("declaration.additionalActors.table.eori")
+        view.select("table>thead>tr>th:nth-child(3)").text() mustBe messages("site.remove.header")
 
         // check row
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() mustBe messages("declaration.partyType.CS")
@@ -114,6 +115,7 @@ class AdditionalActorsSummaryViewSpec extends UnitViewSpec with ExportsTestData 
         // check table header
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe messages("declaration.additionalActors.table.party")
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe messages("declaration.additionalActors.table.eori")
+        view.select("table>thead>tr>th:nth-child(3)").text() mustBe messages("site.remove.header")
 
         // check rows
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() mustBe messages("declaration.partyType.CS")

--- a/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/AdditionalFiscalReferencesViewSpec.scala
@@ -97,6 +97,14 @@ class AdditionalFiscalReferencesViewSpec extends UnitViewSpec with Stubs with Co
     onEveryDeclarationJourney() { implicit request =>
       val view = createView(references = Seq(AdditionalFiscalReference("FR", "12345")))
 
+      "display table header" in {
+        view.getElementsByTag("th").get(0).text() mustBe messages("declaration.additionalFiscalReferences.numbers.header")
+      }
+
+      "have visually hidden header for Remove links" in {
+        view.getElementsByTag("th").get(1).text() mustBe messages("site.remove.header")
+      }
+
       "display references" in {
         view.text() must include("FR12345")
 

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -124,6 +124,18 @@ class AdditionalInformationViewSpec extends UnitViewSpec with ExportsTestData wi
             .get(1) must containMessage("declaration.additionalInformation.table.headers.description")
         }
 
+        "has visually hidden Change Link header" in {
+          view
+            .select("#additional_information thead tr th")
+            .get(2) must containMessage("site.change.header")
+        }
+
+        "has visually hidden Remove Link header" in {
+          view
+            .select("#additional_information thead tr th")
+            .get(3) must containMessage("site.remove.header")
+        }
+
         "has row with 'Code' in " in {
           view.select("#additional_information-row0-code").first().text() mustBe "12345"
         }

--- a/test/views/declaration/DeclarationHolderSummaryViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderSummaryViewSpec.scala
@@ -106,6 +106,8 @@ class DeclarationHolderSummaryViewSpec extends UnitViewSpec with ExportsTestData
         // check table header
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe messages("declaration.declarationHolders.table.type")
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe messages("declaration.declarationHolders.table.eori")
+        view.select("table>thead>tr>th:nth-child(3)").text() mustBe messages("site.change.header")
+        view.select("table>thead>tr>th:nth-child(4)").text() mustBe messages("site.remove.header")
 
         // check row
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() must include("ACE")
@@ -125,6 +127,8 @@ class DeclarationHolderSummaryViewSpec extends UnitViewSpec with ExportsTestData
         // check table header
         view.select("table>thead>tr>th:nth-child(1)").text() mustBe messages("declaration.declarationHolders.table.type")
         view.select("table>thead>tr>th:nth-child(2)").text() mustBe messages("declaration.declarationHolders.table.eori")
+        view.select("table>thead>tr>th:nth-child(3)").text() mustBe messages("site.change.header")
+        view.select("table>thead>tr>th:nth-child(4)").text() mustBe messages("site.remove.header")
 
         // check rows
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() must include("ACE")

--- a/test/views/declaration/DocumentsProducedViewSpec.scala
+++ b/test/views/declaration/DocumentsProducedViewSpec.scala
@@ -147,6 +147,14 @@ class DocumentsProducedViewSpec extends UnitViewSpec with CommonMessages with St
             header.getElementsByClass("govuk-table__header").get(1) must containMessage("declaration.addDocument.summary.documentIdentifier")
           }
 
+          "have visually hidden header for Change links" in {
+            header.getElementsByClass("govuk-table__header").get(3) must containMessage("site.change.header")
+          }
+
+          "have visually hidden header for Remove links" in {
+            header.getElementsByClass("govuk-table__header").get(4) must containMessage("site.remove.header")
+          }
+
         }
 
         "have data row" that {

--- a/test/views/declaration/NactCodesViewSpec.scala
+++ b/test/views/declaration/NactCodesViewSpec.scala
@@ -82,6 +82,14 @@ class NactCodesViewSpec extends UnitViewSpec with ExportsTestData with Stubs wit
         view.getElementsByTag("h1") must containMessageForElements("declaration.nationalAdditionalCode.header.plural", "2")
       }
 
+      "display table headers" in {
+        view.getElementsByTag("th").get(0).text() mustBe messages("declaration.nationalAdditionalCode.table.header")
+      }
+
+      "have visually hidden header for Remove links" in {
+        view.getElementsByTag("th").get(1).text() mustBe messages("site.remove.header")
+      }
+
       "display existing NACT codes table" in {
         codes.zipWithIndex.foreach {
           case (code, index) => {

--- a/test/views/declaration/PackageInformationViewSpec.scala
+++ b/test/views/declaration/PackageInformationViewSpec.scala
@@ -129,7 +129,7 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
         view.select("table>thead>tr>th:nth-child(2)") must containMessageForElements("declaration.packageInformation.table.heading.numberOfPackages")
         view.select("table>thead>tr>th:nth-child(3)") must containMessageForElements("declaration.packageInformation.table.heading.shippingMarks")
         // remove button column
-        view.select("form>table>thead>tr>td").text() must be("")
+        view.select("table>thead>tr>th:nth-child(4)") must containMessageForElements("site.remove.header")
 
         // check row
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() mustBe "Packet (PA)"
@@ -151,7 +151,7 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
         view.select("table>thead>tr>th:nth-child(2)") must containMessageForElements("declaration.packageInformation.table.heading.numberOfPackages")
         view.select("table>thead>tr>th:nth-child(3)") must containMessageForElements("declaration.packageInformation.table.heading.shippingMarks")
         // remove button column
-        view.select("form>table>thead>tr>td").text() must be("")
+        view.select("table>thead>tr>th:nth-child(4)") must containMessageForElements("site.remove.header")
 
         // check rows
         view.select(".govuk-table__body > tr:nth-child(1) > td:nth-child(1)").text() mustBe "Packet (PA)"

--- a/test/views/declaration/PreviousDocumentsSummaryViewSpec.scala
+++ b/test/views/declaration/PreviousDocumentsSummaryViewSpec.scala
@@ -87,6 +87,16 @@ class PreviousDocumentsSummaryViewSpec extends UnitViewSpec with ExportsDeclarat
         view.getElementsByClass("govuk-table__header").get(2) must containMessage("declaration.previousDocuments.goodsItemIdentifier.summary.label")
       }
 
+      "have visually hidden header for Change links" in {
+        val view = createView()
+        view.getElementsByClass("govuk-table__header").get(3) must containMessage("site.change.header")
+      }
+
+      "have visually hidden header for Remove links" in {
+        val view = createView()
+        view.getElementsByClass("govuk-table__header").get(4) must containMessage("site.remove.header")
+      }
+
       "display documents in table" in {
 
         val view = createView()

--- a/test/views/declaration/ProcedureCodesViewSpec.scala
+++ b/test/views/declaration/ProcedureCodesViewSpec.scala
@@ -119,5 +119,17 @@ class ProcedureCodesViewSpec extends UnitViewSpec with ExportsTestData with Stub
       view.getElementById("procedureCode").attr("value") mustBe "Test"
       view.getElementById("additionalProcedureCode").attr("value") mustBe "Test"
     }
+
+    "display table headers" in {
+      val view = createView(codes = Seq("1234", "567"))
+
+      view.getElementsByTag("th").get(0).text() mustBe messages("declaration.procedureCodes.additionalProcedureCode.table.header")
+    }
+
+    "have visually hidden header for Remove links" in {
+      val view = createView(codes = Seq("1234", "567"))
+
+      view.getElementsByTag("th").get(1).text() mustBe messages("site.remove.header")
+    }
   }
 }

--- a/test/views/declaration/SealSummaryViewSpec.scala
+++ b/test/views/declaration/SealSummaryViewSpec.scala
@@ -65,6 +65,14 @@ class SealSummaryViewSpec extends UnitViewSpec with Stubs with MustMatchers with
       noSealsView.title() must include(title)
     }
 
+    "display table with headers" in {
+      view.getElementsByTag("th").get(0).text() mustBe messages("declaration.seal.summary.heading")
+    }
+
+    "have visually hidden headers for Remove links" in {
+      view.getElementsByTag("th").get(1).text() mustBe messages("site.remove.header")
+    }
+
     "display summary of seals" in {
       view.getElementById("removable_elements-row0-label").text() must be(sealId)
     }

--- a/test/views/declaration/TaricCodesViewSpec.scala
+++ b/test/views/declaration/TaricCodesViewSpec.scala
@@ -79,6 +79,14 @@ class TaricCodesViewSpec extends UnitViewSpec with ExportsTestData with Stubs wi
         view.getElementsByTag("h1") must containMessageForElements("declaration.taricAdditionalCodes.header.plural", "2")
       }
 
+      "display table headers" in {
+        view.getElementsByTag("th").get(0).text() mustBe messages("declaration.taricAdditionalCodes.table.header")
+      }
+
+      "have visually hidden header for Remove links" in {
+        view.getElementsByTag("th").get(1).text() mustBe messages("site.remove.header")
+      }
+
       "display existing NACT codes table" in {
         codes.zipWithIndex.foreach {
           case (code, index) => {

--- a/test/views/declaration/TransportContainerSummaryViewSpec.scala
+++ b/test/views/declaration/TransportContainerSummaryViewSpec.scala
@@ -57,6 +57,20 @@ class TransportContainerSummaryViewSpec extends UnitViewSpec with ExportsTestDat
       multiContainerView.title() must include(messages("declaration.transportInformation.containers.multiple.title", 2))
     }
 
+    "display table with headers" in {
+      val tableHead = view.getElementsByTag("th")
+
+      tableHead.get(0).text() mustBe messages("declaration.transportInformation.containerId.title")
+      tableHead.get(1).text() mustBe messages("declaration.seal.summary.heading")
+    }
+
+    "have visually hidden headers for Change and Remove links" in {
+      val tableHead = view.getElementsByTag("th")
+
+      tableHead.get(2).text() mustBe messages("site.change.header")
+      tableHead.get(3).text() mustBe messages("site.remove.header")
+    }
+
     "display summary of container with seals" in {
       view.getElementById("containers-row0-container").text() must be(containerId)
       view.getElementById("containers-row0-seals").text() must be(sealId)

--- a/test/views/declaration/declarationitems/ItemsSummaryViewSpec.scala
+++ b/test/views/declaration/declarationitems/ItemsSummaryViewSpec.scala
@@ -96,6 +96,15 @@ class ItemsSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs 
 
         view must containElementWithID("item_table")
 
+        val tableHead = view.getElementsByTag("th")
+
+        tableHead.get(0).text() mustBe messages("declaration.itemsSummary.itemNumber")
+        tableHead.get(1).text() mustBe messages("declaration.itemsSummary.procedureCode")
+        tableHead.get(2).text() mustBe messages("declaration.itemsSummary.commodityCode")
+        tableHead.get(3).text() mustBe messages("declaration.itemsSummary.noOfPackages")
+        tableHead.get(4).text() mustBe messages("site.change.header")
+        tableHead.get(5).text() mustBe messages("site.remove.header")
+
         val rows = view.getElementsByTag("tr")
         rows must have(size(3))
 
@@ -139,6 +148,15 @@ class ItemsSummaryViewSpec extends UnitViewSpec with ExportsTestData with Stubs 
         )
 
         view must containElementWithID("item_table")
+
+        val tableHead = view.getElementsByTag("th")
+
+        tableHead.get(0).text() mustBe messages("declaration.itemsSummary.itemNumber")
+        tableHead.get(1).text() mustBe messages("declaration.itemsSummary.procedureCode")
+        tableHead.get(2).text() mustBe messages("declaration.itemsSummary.commodityCode")
+        tableHead.get(3).text() mustBe messages("declaration.itemsSummary.noOfPackages")
+        tableHead.get(4).text() mustBe messages("site.change.header")
+        tableHead.get(5).text() mustBe messages("site.remove.header")
 
         val rows = view.getElementsByTag("tr")
         rows must have(size(2))

--- a/test/views/declaration/summary/ContainersViewSpec.scala
+++ b/test/views/declaration/summary/ContainersViewSpec.scala
@@ -61,6 +61,7 @@ class ContainersViewSpec extends UnitViewSpec with ExportsTestData with Injector
       table.getElementsByTag("caption").text() mustBe messages("declaration.summary.container")
       table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.summary.container.id")
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.summary.container.securitySeals")
+      table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe firstContainerID

--- a/test/views/declaration/summary/PackageInformationViewSpec.scala
+++ b/test/views/declaration/summary/PackageInformationViewSpec.scala
@@ -56,6 +56,7 @@ class PackageInformationViewSpec extends UnitViewSpec with ExportsTestData with 
       table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.summary.items.item.packageInformation.type")
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.summary.items.item.packageInformation.number")
       table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("declaration.summary.items.item.packageInformation.markings")
+      table.getElementsByClass("govuk-table__header").get(3).text() mustBe messages("site.change.header")
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe "Open-ended box and pallet (PB)"

--- a/test/views/declaration/summary/PartiesSectionAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionAdditionalActorsViewSpec.scala
@@ -62,7 +62,6 @@ class PartiesSectionAdditionalActorsViewSpec extends UnitViewSpec with ExportsTe
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.additionalActors.eori")
       table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
-
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe messages("declaration.partyType.CS")
       row1.getElementsByClass("govuk-table__cell").get(1).text() mustBe eori1

--- a/test/views/declaration/summary/PartiesSectionAdditionalActorsViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionAdditionalActorsViewSpec.scala
@@ -60,6 +60,8 @@ class PartiesSectionAdditionalActorsViewSpec extends UnitViewSpec with ExportsTe
 
       table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.additionalActors.partyType")
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.additionalActors.eori")
+      table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
+
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe messages("declaration.partyType.CS")

--- a/test/views/declaration/summary/PartiesSectionHoldersViewSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionHoldersViewSpec.scala
@@ -60,6 +60,7 @@ class PartiesSectionHoldersViewSpec extends UnitViewSpec with ExportsTestData wi
 
       table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.summary.parties.holders.type")
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.summary.parties.holders.eori")
+      table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() must include(authorisationTypeCode1)

--- a/test/views/declaration/summary/RelatedDocumentsViewSpec.scala
+++ b/test/views/declaration/summary/RelatedDocumentsViewSpec.scala
@@ -56,6 +56,7 @@ class RelatedDocumentsViewSpec extends UnitViewSpec with ExportsTestData with In
         table.getElementsByTag("caption").text() mustBe messages("declaration.summary.transaction.previousDocuments")
         table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.summary.transaction.previousDocuments.type")
         table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.summary.transaction.previousDocuments.reference")
+        table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
         val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
         row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe "Proforma Invoice - 325"

--- a/test/views/declaration/summary/SupportingDocumentsViewSpec.scala
+++ b/test/views/declaration/summary/SupportingDocumentsViewSpec.scala
@@ -58,6 +58,7 @@ class SupportingDocumentsViewSpec extends UnitViewSpec with ExportsTestData with
 
       table.getElementsByClass("govuk-table__header").get(0).text() mustBe messages("declaration.summary.items.item.supportingDocuments.code")
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages("declaration.summary.items.item.supportingDocuments.information")
+      table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe "typ1"

--- a/test/views/declaration/summary/UnionAndNationalCodesViewSpec.scala
+++ b/test/views/declaration/summary/UnionAndNationalCodesViewSpec.scala
@@ -58,6 +58,7 @@ class UnionAndNationalCodesViewSpec extends UnitViewSpec with ExportsTestData wi
       table.getElementsByClass("govuk-table__header").get(1).text() mustBe messages(
         "declaration.summary.items.item.additionalInformation.information"
       )
+      table.getElementsByClass("govuk-table__header").get(2).text() mustBe messages("site.change.header")
 
       val row1 = table.getElementsByClass("govuk-table__body").first().getElementsByClass("govuk-table__row").get(0)
       row1.getElementsByClass("govuk-table__cell").get(0).text() mustBe "12345"


### PR DESCRIPTION
Use visually hidden header for 'Remove' link column on the following tables:

- procedure-codes
- saved-declarations
- additional-fiscal-references

