### PR TITLE
CEDS-2612 - remove fixed font size for "more info" sections

### DIFF
--- a/app/assets/stylesheets/partials/_autocomplete.scss
+++ b/app/assets/stylesheets/partials/_autocomplete.scss
@@ -7,3 +7,7 @@ body {
 table {
   font-size: 1em;
 }
+
+svg.autocomplete__dropdown-arrow-down {
+  top : 0.6rem;
+}

--- a/app/assets/stylesheets/partials/_exports.scss
+++ b/app/assets/stylesheets/partials/_exports.scss
@@ -75,14 +75,6 @@ button:focus {
   outline: 3px solid #ffbf47;
 }
 
-.govuk-details summary {
- font-size : 19px;
-}
-
-.govuk-details div {
- font-size : 19px;
-}
-
 .blue-line {
   height: 1px;
   color: $blue;

--- a/app/assets/stylesheets/partials/_lists.scss
+++ b/app/assets/stylesheets/partials/_lists.scss
@@ -19,7 +19,6 @@
 }
 
 .dashed-list-title {
-  font-size: 16px;
   line-height: 1.5;
   margin-bottom: 0;
 }


### PR DESCRIPTION
Same fix for dashed list (contents) on start page
Auto-complete drop-down arrow top relative to font size