### PR TITLE
CEDS-2614 Change Summary pages to full width

### DIFF
--- a/app/views/declaration/summary/amend_summary_page.scala.html
+++ b/app/views/declaration/summary/amend_summary_page.scala.html
@@ -42,7 +42,9 @@
 
 @govukLayout(
  title = Title("declaration.summary.amend-header"),
- backButton = Some(BackButton(messages("site.back"), controllers.routes.SubmissionsController.displayListOfSubmissions()))) {
+ backButton = Some(BackButton(messages("site.back"), controllers.routes.SubmissionsController.displayListOfSubmissions())),
+ useCustomContentWidth = true
+) {
 
  @pageTitle(messages("declaration.summary.amend-header"))
 

--- a/app/views/declaration/summary/draft_summary_page.scala.html
+++ b/app/views/declaration/summary/draft_summary_page.scala.html
@@ -42,7 +42,9 @@
 
 @govukLayout(
     title = Title("declaration.summary.saved-header"),
-    backButton = Some(BackButton(messages("site.back"), controllers.routes.SavedDeclarationsController.displayDeclarations()))) {
+    backButton = Some(BackButton(messages("site.back"), controllers.routes.SavedDeclarationsController.displayDeclarations())),
+    useCustomContentWidth = true
+) {
 
     @pageTitle(messages("declaration.summary.saved-header"))
 

--- a/app/views/declaration/summary/normal_summary_page.scala.html
+++ b/app/views/declaration/summary/normal_summary_page.scala.html
@@ -45,7 +45,9 @@
 
 @govukLayout(
     title = Title("declaration.summary.normal-header"),
-    backButton = Some(BackButton(messages("site.back"), controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal)))) {
+    backButton = Some(BackButton(messages("site.back"), controllers.declaration.routes.TransportContainerController.displayContainerSummary(Mode.Normal))),
+    useCustomContentWidth = true
+) {
 
     @formHelper(action = routes.SummaryController.submitDeclaration(), 'autoComplete -> "off") {
         @errorSummary(legalDeclarationForm.errors)

--- a/app/views/declaration/summary/submitted_declaration_page.scala.html
+++ b/app/views/declaration/summary/submitted_declaration_page.scala.html
@@ -53,7 +53,9 @@
 
 @govukLayout(
     title = Title("declaration.summary.submitted-header"),
-    backButton = Some(BackButton(messages("site.back"), backLink))) {
+    backButton = Some(BackButton(messages("site.back"), backLink)),
+    useCustomContentWidth = true
+) {
 
     @pageTitle(messages("declaration.summary.submitted-header"))
 

--- a/app/views/declaration/summary/summary_page_no_data.scala.html
+++ b/app/views/declaration/summary/summary_page_no_data.scala.html
@@ -27,7 +27,9 @@
 @()(implicit request: Request[_], messages: Messages)
 
 @govukLayout(
-    title = Title("declaration.summary.noData.header")){
+    title = Title("declaration.summary.noData.header"),
+    useCustomContentWidth = true
+) {
 
     @pageTitle(messages("declaration.summary.noData.header"))
 


### PR DESCRIPTION
This change is to make Summary pages more accessible when used with
double-sized font.
Many words were split into multiple lines which was an issue.