### PR TITLE
CEDS-2678 Fix issue with text overflowing in panel on confirmation page

### DIFF
--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -14,3 +14,10 @@
     display: revert;
   }
 }
+
+// reduce breaking font size on smaller screens on confirmation page
+@media screen and (max-width: 40.0625em){
+  .govuk-panel.govuk-panel--confirmation .govuk-panel__title {
+    font-size: 1.5em;
+  }
+}


### PR DESCRIPTION
This solution reduces font so that the text fits inside the panel before
switching into mobile mode.

Special thanks to @russellthorn for his help.