### PR TITLE
CEDS-2678 Fix issue with text overflowing in panel on confirmation page

### DIFF
--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -21,3 +21,9 @@
     font-size: 1.5em;
   }
 }
+
+@media screen and (min-width: 40.0625em){
+  .govuk-panel.govuk-panel--confirmation .govuk-panel__title {
+    font-size: 2.1em;
+  }
+}


### PR DESCRIPTION
This solution overrides 3em font size which seems to be too large for
non-mobile screens. Value 2.1em is the maximum where the text is not yet
overflowing.