### PR TITLE
CEDS-2723 Remove indentation from Declaration Type page section header

### DIFF
--- a/app/views/declaration/additionalInformtion/additional_information_required.scala.html
+++ b/app/views/declaration/additionalInformtion/additional_information_required.scala.html
@@ -29,7 +29,7 @@
 @this(
     govukLayout: gdsMainTemplate,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     saveButtons: saveButtons,
     tariffDetails: tariffDetails,
     appConfig: AppConfig,
@@ -48,16 +48,13 @@
     @formHelper(action = controllers.declaration.routes.AdditionalInformationRequiredController.submitForm(mode, (itemId)), 'autoComplete -> "off") {
         @errorSummary(yesNoErrors(form.errors))
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @yesNoRadios(
               form,
               Some(Fieldset(
                   legend = Some(Legend(
-                      content = HtmlContent(
-                          headingContent(
-                              messages("declaration.additionalInformationRequired.title"),
-                              Some(messages("declaration.section.5"))
-                          )
-                      ),
+                      content = Text(messages("declaration.additionalInformationRequired.title")),
                       classes = gdsPageLegend
                   ))
               ))

--- a/app/views/declaration/additionaldeclarationtype/declaration_type_question_standard.scala.html
+++ b/app/views/declaration/additionaldeclarationtype/declaration_type_question_standard.scala.html
@@ -21,22 +21,19 @@
 @import views.html.components.gds._
 @import views.ErrorMapper.radioGroupErrors
 
-@this(govukRadios: GovukRadios, errorSummary: errorSummary, headingContent: headingContent)
+@this(govukRadios: GovukRadios, errorSummary: errorSummary, sectionHeader: sectionHeader)
 
 @(form: Form[AdditionalDeclarationType])(implicit messages: Messages)
 
 @errorSummary(radioGroupErrors("additionalDeclarationType", "PreLodged", form.errors))
 
+@sectionHeader(messages("declaration.section.1"))
+
 @govukRadios(Radios(
     name = "additionalDeclarationType",
     fieldset = Some(Fieldset(
         legend = Some(Legend(
-            content = HtmlContent(
-                headingContent(
-                    messages("declaration.declarationType.header.standard"),
-                    Some(messages("declaration.section.1"))
-                )
-            ),
+            content = Text(messages("declaration.declarationType.header.standard")),
             classes = gdsPageLegend
         ))
     )),

--- a/app/views/declaration/consignor_eori_number.scala.html
+++ b/app/views/declaration/consignor_eori_number.scala.html
@@ -26,14 +26,14 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukRadios: GovukRadios,
-        exportsInputText: exportsInputText,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukRadios: GovukRadios,
+    exportsInputText: exportsInputText,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[ConsignorEoriNumber])(implicit request: JourneyRequest[_], messages: Messages)
@@ -52,16 +52,13 @@
     @formHelper(action = controllers.declaration.routes.ConsignorEoriNumberController.submit(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("hasEori", "Yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = "hasEori",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.consignorEori.title"),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.consignorEori.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/cus_code.scala.html
+++ b/app/views/declaration/cus_code.scala.html
@@ -28,25 +28,25 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukRadios: GovukRadios,
-        govukDetails : GovukDetails,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        exportsInputText: exportsInputText,
-        body: paragraphBody,
-        pageTitle: pageTitle,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        appConfig: AppConfig,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    govukDetails : GovukDetails,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    exportsInputText: exportsInputText,
+    body: paragraphBody,
+    pageTitle: pageTitle,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    appConfig: AppConfig,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(
-        mode: Mode,
-        itemId: String,
-        form: Form[CusCode]
+    mode: Mode,
+    itemId: String,
+    form: Form[CusCode]
 )(implicit request: JourneyRequest[_], messages: Messages)
 
 @tariffBody = { @Html(messages("declaration.cusCode.help.bodyText", components.details_content_link())) }
@@ -61,16 +61,13 @@
     @formHelper(action = routes.CusCodeController.submitForm(mode, itemId), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(hasCusCodeKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @govukRadios(Radios(
             name = hasCusCodeKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.cusCode.header"),
-                            Some(messages("declaration.section.5"))
-                        )
-                    ),
+                    content = Text(messages("declaration.cusCode.header")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/declarant_details.scala.html
+++ b/app/views/declaration/declarant_details.scala.html
@@ -28,7 +28,7 @@
 @this(
     govukLayout: gdsMainTemplate,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     govukRadios: GovukRadios,
     exportsInputText: exportsInputText,
     govukDetails : GovukDetails,
@@ -46,16 +46,13 @@
     @formHelper(action = controllers.declaration.routes.DeclarantDetailsController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(isEoriKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = isEoriKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.declarant.titleQuestion", request.eori),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.declarant.titleQuestion", request.eori)),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/declarant_exporter.scala.html
+++ b/app/views/declaration/declarant_exporter.scala.html
@@ -26,15 +26,15 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-    govukLayout: gdsMainTemplate,
-    errorSummary: errorSummary,
-    headingContent: headingContent,
-    govukRadios: GovukRadios,
-    exportsInputText: exportsInputText,
-    govukDetails : GovukDetails,
-    saveButtons: saveButtons,
-    tariffDetails: tariffDetails,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+        govukLayout: gdsMainTemplate,
+        errorSummary: errorSummary,
+        sectionHeader: sectionHeader,
+        govukRadios: GovukRadios,
+        exportsInputText: exportsInputText,
+        govukDetails : GovukDetails,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[DeclarantIsExporter])(implicit request: JourneyRequest[_], messages: Messages)
@@ -46,16 +46,13 @@
     @formHelper(action = controllers.declaration.routes.DeclarantExporterController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(answerKey, "answer_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = answerKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.declarant.exporter.title"),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.declarant.exporter.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/departure_transport.scala.html
+++ b/app/views/declaration/departure_transport.scala.html
@@ -34,7 +34,7 @@
     pageTitle: pageTitle,
     exportsInputText: exportsInputText,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     saveButtons: saveButtons,
     tariffDetails: tariffDetails,
     formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
@@ -59,16 +59,13 @@
     @formHelper(action = DepartureTransportController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("meansOfTransportOnDepartureType", "Departure_IMOShipIDNumber", form.errors))
 
+        @sectionHeader(messages("declaration.section.6"))
+
         @govukRadios(Radios(
             name = "meansOfTransportOnDepartureType",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.transportInformation.meansOfTransport.departure.title"),
-                            Some(messages("declaration.section.6"))
-                        )
-                    ),
+                    content = Text(messages("declaration.transportInformation.meansOfTransport.departure.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/destinationCountries/country_of_routing.scala.html
+++ b/app/views/declaration/destinationCountries/country_of_routing.scala.html
@@ -33,7 +33,7 @@
         govukDetails : GovukDetails,
         govukFieldset: GovukFieldset,
         errorSummary: errorSummary,
-        headingContent: headingContent,
+        sectionHeader: sectionHeader,
         saveButtons: saveButtons,
         tariffDetails: tariffDetails,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
@@ -54,11 +54,13 @@
     @formHelper(action = controllers.declaration.routes.RoutingCountriesController.submitRoutingCountry(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @components.fields.field_accessible_autocomplete_with_header(
             form("countryCode"),
             s"declaration.${page.id}.question",
             Some(gdsPageLabel),
-            Some("declaration.section.3"),
+            None,
             None,
             messages("declaration.routingCountry.empty"),
             AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode),

--- a/app/views/declaration/destinationCountries/destination_country.scala.html
+++ b/app/views/declaration/destinationCountries/destination_country.scala.html
@@ -54,11 +54,13 @@
     @formHelper(action = controllers.declaration.routes.DestinationCountryController.submit(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @components.fields.field_accessible_autocomplete_with_header(
             form("countryCode"),
             "declaration.destinationCountry.title",
             Some(gdsPageLabel),
-            Some("declaration.section.3"),
+            None,
             None,
             messages("declaration.destinationCountry.empty"),
             AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode),

--- a/app/views/declaration/destinationCountries/origination_country.scala.html
+++ b/app/views/declaration/destinationCountries/origination_country.scala.html
@@ -54,11 +54,13 @@
     @formHelper(action = controllers.declaration.routes.OriginationCountryController.submit(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @components.fields.field_accessible_autocomplete_with_header(
             form("countryCode"),
             "declaration.originationCountry.title",
             Some(gdsPageLabel),
-            Some("declaration.section.3"),
+            None,
             None,
             messages("declaration.originationCountry.empty"),
             AutoCompleteItem.fromCountry(Countries.allCountries, _.countryCode),

--- a/app/views/declaration/destinationCountries/routing_country_question.scala.html
+++ b/app/views/declaration/destinationCountries/routing_country_question.scala.html
@@ -37,7 +37,7 @@
         govukRadios: GovukRadios,
         govukDetails : GovukDetails,
         errorSummary: errorSummary,
-        headingContent: headingContent,
+        sectionHeader: sectionHeader,
         saveButtons: saveButtons,
         tariffDetails: tariffDetails,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
@@ -55,16 +55,13 @@
     @formHelper(action = controllers.declaration.routes.RoutingCountriesController.submitRoutingAnswer(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("answer", "Yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @govukRadios(Radios(
             name = "answer",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.routingQuestion.title", countryOfDestination),
-                            Some(messages("declaration.section.3"))
-                        )
-                    ),
+                    content = Text(messages("declaration.routingQuestion.title", countryOfDestination)),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/dispatch_location.scala.html
+++ b/app/views/declaration/dispatch_location.scala.html
@@ -31,7 +31,7 @@
         govukRadios: GovukRadios,
         govukDetails : GovukDetails,
         errorSummary: errorSummary,
-        headingContent: headingContent,
+        sectionHeader: sectionHeader,
         saveAndContinue: saveAndContinue,
         tariffDetails: tariffDetails,
         formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
@@ -54,16 +54,13 @@
     @formHelper(action = controllers.declaration.routes.DispatchLocationController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("dispatchLocation", "OutsideEU", form.errors))
 
+        @sectionHeader(messages("declaration.section.1"))
+
         @govukRadios(Radios(
             name = "dispatchLocation",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.dispatchLocation.header"),
-                            Some(messages("declaration.section.1"))
-                        )
-                    ),
+                    content = Text(messages("declaration.dispatchLocation.header")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/goods_location.scala.html
+++ b/app/views/declaration/goods_location.scala.html
@@ -26,20 +26,19 @@
 @import views.components.gds.Styles._
 
 @this(
-    govukLayout: gdsMainTemplate,
-    govukButton: GovukButton,
-    errorSummary: errorSummary,
-    exportsInputText: exportsInputText,
-    saveButtons: saveButtons,
-    tariffDetails: tariffDetails,
-    pageTitle: pageTitle,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+        govukLayout: gdsMainTemplate,
+        govukButton: GovukButton,
+        errorSummary: errorSummary,
+        exportsInputText: exportsInputText,
+        saveButtons: saveButtons,
+        tariffDetails: tariffDetails,
+        pageTitle: pageTitle,
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+        sectionHeader: sectionHeader
 )
 
 
 @(mode: Mode, form: Form[GoodsLocationForm])(implicit request: JourneyRequest[_], messages: Messages)
-
-
 
 @govukLayout(
     title = Title("declaration.goodsLocation.title", "declaration.section.3"),
@@ -49,13 +48,15 @@
 
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @exportsInputText(
             field = form("code"),
             labelKey = "declaration.goodsLocation.title",
             hintKey = Some("declaration.goodsLocation.hint"),
             isPageHeading = true,
             headingClasses = gdsPageLabel,
-            sectionHeaderKey = Some("declaration.section.3")
+            sectionHeaderKey = None
         )
 
 

--- a/app/views/declaration/is_exs.scala.html
+++ b/app/views/declaration/is_exs.scala.html
@@ -29,7 +29,7 @@
 @this(
     govukLayout: gdsMainTemplate,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     govukRadios: GovukRadios,
     govukDetails : GovukDetails,
     saveButtons: saveButtons,
@@ -45,16 +45,13 @@
     @formHelper(action = controllers.declaration.routes.IsExsController.submit(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(isExsKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = isExsKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.exs.title"),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.exs.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/nact_code_add_first.scala.html
+++ b/app/views/declaration/nact_code_add_first.scala.html
@@ -35,7 +35,7 @@
     govukRadios: GovukRadios,
     govukDetails : GovukDetails,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     exportsInputText: exportsInputText,
     body: paragraphBody,
     pageTitle: pageTitle,
@@ -58,16 +58,13 @@
     @formHelper(action = NactCodeAddController.submitForm(mode, itemId), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(hasNactCodeKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @govukRadios(Radios(
             name = hasNactCodeKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.nationalAdditionalCode.addfirst.header"),
-                            Some(messages("declaration.section.5"))
-                        )
-                    ),
+                    content = Text(messages("declaration.nationalAdditionalCode.addfirst.header")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/nature_of_transaction.scala.html
+++ b/app/views/declaration/nature_of_transaction.scala.html
@@ -25,14 +25,14 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukRadios: GovukRadios,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[NatureOfTransaction])(implicit request: JourneyRequest[_], messages: Messages)
@@ -46,16 +46,13 @@
     @formHelper(action = controllers.declaration.routes.NatureOfTransactionController.saveTransactionType(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("natureType", "Sale", form.errors))
 
+        @sectionHeader(messages("declaration.section.4"))
+
         @govukRadios(Radios(
             name = "natureType",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.natureOfTransaction.title"),
-                            Some(messages("declaration.section.4"))
-                        )
-                    ),
+                    content = Text(messages("declaration.natureOfTransaction.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/office_of_exit.scala.html
+++ b/app/views/declaration/office_of_exit.scala.html
@@ -28,18 +28,17 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukDetails : GovukDetails,
-        govukRadios: GovukRadios,
-        govukFieldset: GovukFieldset,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukDetails : GovukDetails,
+    govukRadios: GovukRadios,
+    govukFieldset: GovukFieldset,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
-
 
 @(mode: Mode, form: Form[OfficeOfExitInsideUK])(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -61,16 +60,13 @@
     @formHelper(action = controllers.declaration.routes.OfficeOfExitController.saveOffice(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("isUkOfficeOfExit", "Yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.3"))
+
         @govukRadios(Radios(
             name = "isUkOfficeOfExit",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.officeOfExit.title"),
-                            Some(messages("declaration.section.3"))
-                        )
-                    ),
+                    content = Text(messages("declaration.officeOfExit.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/person_presenting_goods_details.scala.html
+++ b/app/views/declaration/person_presenting_goods_details.scala.html
@@ -25,13 +25,14 @@
 @import views.components.gds.Styles._
 
 @this(
-        govukLayout: gdsMainTemplate,
-        exportsInputText: exportsInputText,
-        inputText: exportsInputText,
-        errorSummary: errorSummary,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    exportsInputText: exportsInputText,
+    inputText: exportsInputText,
+    errorSummary: errorSummary,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+    sectionHeader: sectionHeader,
 )
 
 @(mode: Mode, form: Form[PersonPresentingGoodsDetails])(implicit request: JourneyRequest[_], messages: Messages)
@@ -43,19 +44,21 @@
     backButton = Some(BackButton(messages("site.back"), Navigator.backLink(PersonPresentingGoodsDetails, mode)))) {
 
     @formHelper(action = controllers.declaration.routes.PersonPresentingGoodsDetailsController.submitForm(mode), 'autocomplete -> "off") {
-      @errorSummary(form.errors)
+        @errorSummary(form.errors)
 
-      @exportsInputText(
+        @sectionHeader(messages("declaration.section.2"))
+
+        @exportsInputText(
         field = form(fieldName),
         labelKey = "declaration.personPresentingGoodsDetails.title",
         isPageHeading = true,
         headingClasses = gdsPageLabel,
-        sectionHeaderKey = Some("declaration.section.2")
-      )
+        sectionHeaderKey = None
+        )
 
-      @tariffDetails(messages("site.details.summary_text_this"), HtmlContent(tariffBody))
+        @tariffDetails(messages("site.details.summary_text_this"), HtmlContent(tariffBody))
 
-      @saveButtons()
+        @saveButtons()
     }
 }
 

--- a/app/views/declaration/representative_details_agent.scala.html
+++ b/app/views/declaration/representative_details_agent.scala.html
@@ -26,13 +26,15 @@
 @import views.BackButton
 @import views.ErrorMapper.radioGroupErrors
 
-@this(govukLayout: gdsMainTemplate,
+@this(
+        govukLayout: gdsMainTemplate,
         govukRadios: GovukRadios,
         errorSummary: errorSummary,
-        headingContent: headingContent,
+        sectionHeader: sectionHeader,
         tariffDetails: tariffDetails,
         saveButtons: saveButtons,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, form: Form[RepresentativeAgent])(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -45,16 +47,13 @@
     @formHelper(action = RepresentativeAgentController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("representingAgent", "agent_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = "representingAgent",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.representative.agent.title"),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.representative.agent.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/representative_details_agent.scala.html
+++ b/app/views/declaration/representative_details_agent.scala.html
@@ -27,13 +27,13 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukRadios: GovukRadios,
-        errorSummary: errorSummary,
-        sectionHeader: sectionHeader,
-        tariffDetails: tariffDetails,
-        saveButtons: saveButtons,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukRadios: GovukRadios,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    tariffDetails: tariffDetails,
+    saveButtons: saveButtons,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[RepresentativeAgent])(implicit request: JourneyRequest[_], messages: Messages)

--- a/app/views/declaration/representative_details_status.scala.html
+++ b/app/views/declaration/representative_details_status.scala.html
@@ -27,17 +27,19 @@
 @import views.BackButton
 @import views.ErrorMapper.radioGroupErrors
 
-@this(govukLayout: gdsMainTemplate,
+@this(
+        govukLayout: gdsMainTemplate,
         govukButton: GovukButton,
         govukRadios: GovukRadios,
         errorSummary: errorSummary,
-        headingContent: headingContent,
+        sectionHeader: sectionHeader,
         pageTitle: pageTitle,
         exportsInputText: exportsInputText,
         govukInput : GovukInput,
         tariffDetails: tariffDetails,
         saveButtons: saveButtons,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF)
+        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+)
 
 @(mode: Mode, navigationForm: DeclarationPage, form: Form[RepresentativeStatus])(implicit request: JourneyRequest[_], messages: Messages)
 
@@ -50,16 +52,13 @@
     @formHelper(action = RepresentativeStatusController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("statusCode", DirectRepresentative, form.errors))
 
+        @sectionHeader(messages("declaration.section.2"))
+
         @govukRadios(Radios(
             name = "statusCode",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.representative.status.title"),
-                            Some(messages("declaration.section.2"))
-                        )
-                    ),
+                    content = Text(messages("declaration.representative.status.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/representative_details_status.scala.html
+++ b/app/views/declaration/representative_details_status.scala.html
@@ -28,17 +28,17 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukRadios: GovukRadios,
-        errorSummary: errorSummary,
-        sectionHeader: sectionHeader,
-        pageTitle: pageTitle,
-        exportsInputText: exportsInputText,
-        govukInput : GovukInput,
-        tariffDetails: tariffDetails,
-        saveButtons: saveButtons,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    pageTitle: pageTitle,
+    exportsInputText: exportsInputText,
+    govukInput : GovukInput,
+    tariffDetails: tariffDetails,
+    saveButtons: saveButtons,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, navigationForm: DeclarationPage, form: Form[RepresentativeStatus])(implicit request: JourneyRequest[_], messages: Messages)

--- a/app/views/declaration/seal_summary.scala.html
+++ b/app/views/declaration/seal_summary.scala.html
@@ -26,20 +26,20 @@
 @import views.ErrorMapper.yesNoErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        sectionHeader: sectionHeader,
-        headingContent: headingContent,
-        govukFieldset: GovukFieldset,
-        pageTitle: pageTitle,
-        changeLink: link,
-        govukButton: GovukButton,
-        govukTable: GovukTable,
-        errorSummary: errorSummary,
-        yesNoRadios: yesNoRadios,
-        tariffDetails: tariffDetails,
-        spanVisuallyHidden: spanVisuallyHidden,
-        saveButtons: saveButtons,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    sectionHeader: sectionHeader,
+    headingContent: headingContent,
+    govukFieldset: GovukFieldset,
+    pageTitle: pageTitle,
+    changeLink: link,
+    govukButton: GovukButton,
+    govukTable: GovukTable,
+    errorSummary: errorSummary,
+    yesNoRadios: yesNoRadios,
+    tariffDetails: tariffDetails,
+    spanVisuallyHidden: spanVisuallyHidden,
+    saveButtons: saveButtons,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[YesNoAnswer], containerId: String, seals: Seq[Seal])(implicit request: Request[_], messages: Messages)
@@ -50,45 +50,40 @@
 
 @sealsTable = {
     @if(seals.nonEmpty) {
-    @govukTable(Table(
-        rows = seals.zipWithIndex.map{ case(seal, index) =>
-            Seq(
-                TableRow(
-                    content = Text(seal.id),
-                    attributes = Map("id" -> s"removable_elements-row$index-label")
-                ),
-                TableRow(
-                    content = HtmlContent(changeLink(messages("site.remove"), Some(messages("declaration.seal.remove.hint", seal.id)), SealController.submitSealRemove(mode, containerId, seal.id))),
-                    attributes = Map("id" -> s"removable_elements-row$index-remove_button")
+        @govukTable(Table(
+            rows = seals.zipWithIndex.map{ case(seal, index) =>
+                Seq(
+                    TableRow(
+                        content = Text(seal.id),
+                        attributes = Map("id" -> s"removable_elements-row$index-label")
+                    ),
+                    TableRow(
+                        content = HtmlContent(changeLink(messages("site.remove"), Some(messages("declaration.seal.remove.hint", seal.id)), SealController.submitSealRemove(mode, containerId, seal.id))),
+                        attributes = Map("id" -> s"removable_elements-row$index-remove_button")
+                    )
                 )
-            )
-        },
-        head = Some(List(
-            HeadCell(
-                content = Text(messages("declaration.seal.summary.heading")),
-                attributes = Map("id" -> s"removable_elements-heading")
-            ),
-            HeadCell(
-                content = HtmlContent(spanVisuallyHidden(messages("site.remove.header")))
-            )
+            },
+            head = Some(List(
+                HeadCell(
+                    content = Text(messages("declaration.seal.summary.heading")),
+                    attributes = Map("id" -> s"removable_elements-heading")
+                ),
+                HeadCell(
+                    content = HtmlContent(spanVisuallyHidden(messages("site.remove.header")))
+                )
+            ))
         ))
-    ))
-
-}
+    }
 }
 
 @addSealRadios = {
+    @sectionHeader(messages("declaration.section.6"))
     @yesNoRadios(
       form,
       if(seals.isEmpty)
         Some(Fieldset(
             legend = Some(Legend(
-                content = HtmlContent(
-                    headingContent(
-                        messages("declaration.seal.add.first", containerId),
-                        Some(messages("declaration.section.6"))
-                    )
-                ),
+                content = Text(messages("declaration.seal.add.first", containerId)),
                 classes = gdsPageLegend
             ))
         ))
@@ -135,5 +130,4 @@
       @tariffDetails(messages("site.details.summary_text_this"), HtmlContent(tariffBody))
       @saveButtons()
     }
-
 }

--- a/app/views/declaration/statistical_value.scala.html
+++ b/app/views/declaration/statistical_value.scala.html
@@ -26,23 +26,23 @@
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.currencyinput.CurrencyInput
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukDetails : GovukDetails,
-        pageTitle: pageTitle,
-        hmrcCurrencyInput: HmrcCurrencyInput,
-        errorSummary: errorSummary,
-        sectionHeader: sectionHeader,
-        headingContent: headingContent,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukDetails : GovukDetails,
+    pageTitle: pageTitle,
+    hmrcCurrencyInput: HmrcCurrencyInput,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    headingContent: headingContent,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(
-        mode: Mode,
-        itemId: String,
-        form: Form[StatisticalValue]
+    mode: Mode,
+    itemId: String,
+    form: Form[StatisticalValue]
 )(implicit request: JourneyRequest[_], messages: Messages)
 
 @tariffBody = { @Html(messages("declaration.statisticalValue.help.bodyText", components.details_content_link())) }
@@ -58,6 +58,8 @@
     @formHelper(action = routes.StatisticalValueController.submitItemType(mode, itemId), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @unitsHint
 
         @hmrcCurrencyInput(CurrencyInput(
@@ -69,7 +71,7 @@
                 content = HtmlContent(
                     headingContent(
                         messages("declaration.statisticalValue.header"),
-                        Some(messages("declaration.section.5")),
+                        None,
                         classes = "govuk-label--xl"
                     )
                 )

--- a/app/views/declaration/taric_code_add_first.scala.html
+++ b/app/views/declaration/taric_code_add_first.scala.html
@@ -35,7 +35,7 @@
     govukRadios: GovukRadios,
     govukDetails : GovukDetails,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     exportsInputText: exportsInputText,
     body: paragraphBody,
     pageTitle: pageTitle,
@@ -58,16 +58,13 @@
     @formHelper(action = TaricCodeAddController.submitForm(mode, itemId), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(hasTaricCodeKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @govukRadios(Radios(
             name = hasTaricCodeKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.taricAdditionalCodes.addfirst.header"),
-                            Some(messages("declaration.section.5"))
-                        )
-                    ),
+                    content = Text(messages("declaration.taricAdditionalCodes.addfirst.header")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/total_package_quantity.scala.html
+++ b/app/views/declaration/total_package_quantity.scala.html
@@ -34,7 +34,8 @@
     exportsInputText: exportsInputText,
     tariffDetails: tariffDetails,
     saveButtons: saveButtons,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+    sectionHeader: sectionHeader
 )
 
 @(mode: Mode, form: Form[TotalPackageQuantity])(implicit request: JourneyRequest[_], messages: Messages)
@@ -49,13 +50,15 @@
     @formHelper(action = TotalPackageQuantityController.saveTotalPackageQuantity(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.4"))
+
         @exportsInputText(
             labelKey = "declaration.totalPackageQuantity.title",
             field = form("totalPackage"),
             isPageHeading = true,
             headingClasses = gdsPageLabel,
             inputClasses = Some("govuk-input--width-10"),
-            sectionHeaderKey = Some("declaration.section.4")
+            sectionHeaderKey = None
         )
 
         @tariffDetails(messages("site.details.summary_text_this"), HtmlContent(tariffBody))

--- a/app/views/declaration/transport_container_add_first.scala.html
+++ b/app/views/declaration/transport_container_add_first.scala.html
@@ -27,18 +27,18 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukRadios: GovukRadios,
-        govukDetails : GovukDetails,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        exportsInputText: exportsInputText,
-        body: paragraphBody,
-        pageTitle: pageTitle,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    govukDetails : GovukDetails,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    exportsInputText: exportsInputText,
+    body: paragraphBody,
+    pageTitle: pageTitle,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(mode: Mode, form: Form[ContainerFirst])(implicit request: JourneyRequest[_], messages: Messages)
@@ -54,16 +54,13 @@
     @formHelper(action = TransportContainerController.submitAddContainer(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(hasContainerKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.6"))
+
         @govukRadios(Radios(
             name = hasContainerKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.transportInformation.containers.first.title"),
-                            Some(messages("declaration.section.6"))
-                        )
-                    ),
+                    content = Text(messages("declaration.transportInformation.containers.first.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/transport_leaving_the_border.scala.html
+++ b/app/views/declaration/transport_leaving_the_border.scala.html
@@ -26,17 +26,17 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukDetails : GovukDetails,
-        govukRadios: GovukRadios,
-        pageTitle: pageTitle,
-        exportsInputText: exportsInputText,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukDetails : GovukDetails,
+    govukRadios: GovukRadios,
+    pageTitle: pageTitle,
+    exportsInputText: exportsInputText,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(form: Form[TransportLeavingTheBorder], mode: Mode)(implicit request: JourneyRequest[_], messages: Messages)
@@ -51,16 +51,13 @@
     @formHelper(action = TransportLeavingTheBorderController.submitForm(mode), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors("transportLeavingTheBorder", "Border_Sea", form.errors))
 
+        @sectionHeader(messages("declaration.section.6"))
+
         @govukRadios(Radios(
             name = "transportLeavingTheBorder",
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.transport.leavingTheBorder.title"),
-                            Some(messages("declaration.section.6"))
-                        )
-                    ),
+                    content = Text(messages("declaration.transport.leavingTheBorder.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/un_dangerous_goods_code.scala.html
+++ b/app/views/declaration/un_dangerous_goods_code.scala.html
@@ -27,25 +27,25 @@
 @import views.ErrorMapper.radioGroupErrors
 
 @this(
-        govukLayout: gdsMainTemplate,
-        govukButton: GovukButton,
-        govukRadios: GovukRadios,
-        govukDetails : GovukDetails,
-        errorSummary: errorSummary,
-        headingContent: headingContent,
-        exportsInputText: exportsInputText,
-        body: paragraphBody,
-        pageTitle: pageTitle,
-        saveButtons: saveButtons,
-        tariffDetails: tariffDetails,
-        appConfig: AppConfig,
-        formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    govukLayout: gdsMainTemplate,
+    govukButton: GovukButton,
+    govukRadios: GovukRadios,
+    govukDetails : GovukDetails,
+    errorSummary: errorSummary,
+    sectionHeader: sectionHeader,
+    exportsInputText: exportsInputText,
+    body: paragraphBody,
+    pageTitle: pageTitle,
+    saveButtons: saveButtons,
+    tariffDetails: tariffDetails,
+    appConfig: AppConfig,
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
 )
 
 @(
-        mode: Mode,
-        itemId: String,
-        form: Form[UNDangerousGoodsCode]
+    mode: Mode,
+    itemId: String,
+    form: Form[UNDangerousGoodsCode]
 )(implicit request: JourneyRequest[_], messages: Messages)
 
 @tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.unDangerousGoodsCode.traderTariff.link")</a>}
@@ -60,16 +60,13 @@
     @formHelper(action = routes.UNDangerousGoodsCodeController.submitForm(mode, itemId), 'autoComplete -> "off") {
         @errorSummary(radioGroupErrors(hasDangerousGoodsCodeKey, "code_yes", form.errors))
 
+        @sectionHeader(messages("declaration.section.5"))
+
         @govukRadios(Radios(
             name = hasDangerousGoodsCodeKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.unDangerousGoodsCode.header"),
-                            Some(messages("declaration.section.5"))
-                        )
-                    ),
+                    content = Text(messages("declaration.unDangerousGoodsCode.header")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/app/views/declaration/warehouse_identification.scala.html
+++ b/app/views/declaration/warehouse_identification.scala.html
@@ -32,7 +32,8 @@
     saveButtons: saveButtons,
     tariffDetails: tariffDetails,
     pageTitle: pageTitle,
-    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF
+    formHelper: uk.gov.hmrc.play.views.html.helpers.FormWithCSRF,
+    sectionHeader: sectionHeader
 )
 
 
@@ -48,13 +49,15 @@
 
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.6"))
+
         @exportsInputText(
             field = form("identificationNumber"),
             labelKey = "declaration.warehouse.identification.required.title",
             hintKey = Some("declaration.warehouse.identification.label.hint"),
             isPageHeading = true,
             headingClasses = gdsPageLabel,
-            sectionHeaderKey = Some("declaration.section.6")
+            sectionHeaderKey = None
         )
 
 

--- a/app/views/declaration/warehouse_identification_yesno.scala.html
+++ b/app/views/declaration/warehouse_identification_yesno.scala.html
@@ -29,7 +29,7 @@
     govukLayout: gdsMainTemplate,
     govukRadios: GovukRadios,
     errorSummary: errorSummary,
-    headingContent: headingContent,
+    sectionHeader: sectionHeader,
     exportsInputText: exportsInputText,
     pageTitle: pageTitle,
     saveButtons: saveButtons,
@@ -48,16 +48,13 @@
     @formHelper(action = routes.WarehouseIdentificationController.saveIdentificationNumber(mode), 'autoComplete -> "off") {
         @errorSummary(form.errors)
 
+        @sectionHeader(messages("declaration.section.6"))
+
         @govukRadios(Radios(
             name = inWarehouseKey,
             fieldset = Some(Fieldset(
                 legend = Some(Legend(
-                    content = HtmlContent(
-                        headingContent(
-                            messages("declaration.warehouse.identification.optional.title"),
-                            Some(messages("declaration.section.6"))
-                        )
-                    ),
+                    content = Text(messages("declaration.warehouse.identification.optional.title")),
                     classes = gdsPageLegend
                 ))
             )),

--- a/test/views/declaration/AdditionalInformationRequiredViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationRequiredViewSpec.scala
@@ -28,6 +28,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.additionalInformtion.additional_information_required
 import views.tags.ViewTest
@@ -54,7 +55,7 @@ class AdditionalInformationRequiredViewSpec extends UnitViewSpec with ExportsTes
 
     onEveryDeclarationJourney() { implicit request =>
       "display page title" in {
-        createView(form(request.declarationType)).getElementsByTag("h1") must containMessageForElements(
+        createView(form(request.declarationType)).getElementsByClass(Styles.gdsPageLegend) must containMessageForElements(
           "declaration.additionalInformationRequired.title"
         )
       }

--- a/test/views/declaration/ConsignorEoriNumberViewSpec.scala
+++ b/test/views/declaration/ConsignorEoriNumberViewSpec.scala
@@ -27,6 +27,7 @@ import org.scalatest.Matchers._
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.consignor_eori_number
 import views.tags.ViewTest
@@ -62,7 +63,7 @@ class ConsignorEoriNumberViewSpec extends UnitViewSpec with ExportsTestData with
       }
 
       "display page title" in {
-        view.getElementsByClass("govuk-fieldset__heading") must containMessageForElements("declaration.consignorEori.title")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.consignorEori.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/CusCodeViewSpec.scala
+++ b/test/views/declaration/CusCodeViewSpec.scala
@@ -26,6 +26,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.cus_code
 import views.tags.ViewTest
@@ -53,7 +54,7 @@ class CusCodeViewSpec extends UnitViewSpec with ExportsTestData with Stubs with 
 
       val view = createView()
       "display page title" in {
-        view.getElementsByTag("h1") must containMessageForElements("declaration.cusCode.header")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.cusCode.header")
       }
 
       "display section header" in {

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -29,6 +29,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.declarant_details
 import views.tags.ViewTest
@@ -56,7 +57,7 @@ class DeclarantDetailsViewSpec extends UnitViewSpec with ExportsTestData with Co
       "display page title" in {
 
         createView(form(request.declarationType))
-          .getElementsByTag("h1") must containMessageForElements("declaration.declarant.titleQuestion", request.eori)
+          .getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.declarant.titleQuestion", request.eori)
       }
 
       "display section header" in {

--- a/test/views/declaration/DeclarantExporterViewSpec.scala
+++ b/test/views/declaration/DeclarantExporterViewSpec.scala
@@ -28,6 +28,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.declarant_exporter
 import views.tags.ViewTest
@@ -55,7 +56,7 @@ class DeclarantExporterViewSpec extends UnitViewSpec with ExportsTestData with C
     onEveryDeclarationJourney() { implicit request =>
       "display page title" in {
 
-        createView().getElementsByTag("h1") must containMessageForElements("declaration.declarant.exporter.title")
+        createView().getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.declarant.exporter.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/DepartureTransportViewSpec.scala
+++ b/test/views/declaration/DepartureTransportViewSpec.scala
@@ -28,6 +28,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.twirl.api.Html
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.departure_transport
 import views.tags.ViewTest
@@ -66,7 +67,7 @@ class DepartureTransportViewSpec extends UnitViewSpec with CommonMessages with S
       }
 
       "display page title" in {
-        view.getElementsByTag("h1").text() mustBe messages("declaration.transportInformation.meansOfTransport.departure.title")
+        view.getElementsByClass(Styles.gdsPageLegend).text() mustBe messages("declaration.transportInformation.meansOfTransport.departure.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/IsExsViewSpec.scala
+++ b/test/views/declaration/IsExsViewSpec.scala
@@ -28,6 +28,7 @@ import models.requests.JourneyRequest
 import org.jsoup.nodes.Document
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.is_exs
 
@@ -48,7 +49,7 @@ class IsExsViewSpec extends UnitViewSpec with ExportsTestData with CommonMessage
     onClearance { implicit request =>
       "display page title" in {
 
-        createView().getElementsByTag("h1") must containMessageForElements("declaration.exs.title")
+        createView().getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.exs.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/NactCodeAddFirstViewSpec.scala
+++ b/test/views/declaration/NactCodeAddFirstViewSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.MustMatchers
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.nact_code_add_first
 import views.tags.ViewTest
@@ -43,7 +44,7 @@ class NactCodeAddFirstViewSpec extends UnitViewSpec with ExportsTestData with St
     val view = createView()
 
     "display page title" in {
-      view.getElementsByTag("h1") must containMessageForElements("declaration.nationalAdditionalCode.addfirst.header")
+      view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.nationalAdditionalCode.addfirst.header")
     }
 
     "display 'Back' button that links to 'taric codes' page" in {

--- a/test/views/declaration/NatureOfTransactionViewSpec.scala
+++ b/test/views/declaration/NatureOfTransactionViewSpec.scala
@@ -25,6 +25,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.nature_of_transaction
 import views.tags.ViewTest
@@ -58,7 +59,7 @@ class NatureOfTransactionViewSpec extends UnitViewSpec with ExportsTestData with
 
       val view = createView()
       "display page title" in {
-        view.getElementsByTag("h1") must containMessageForElements("declaration.natureOfTransaction.title")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.natureOfTransaction.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/OfficeOfExitViewSpec.scala
+++ b/test/views/declaration/OfficeOfExitViewSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.Matchers._
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.office_of_exit
 import views.tags.ViewTest
@@ -60,7 +61,7 @@ class OfficeOfExitViewSpec extends UnitViewSpec with ExportsTestData with Stubs 
       }
 
       "display page title" in {
-        view.getElementsByClass("govuk-fieldset__heading") must containMessageForElements("declaration.officeOfExit.title")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.officeOfExit.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/RepresentativeDetailsAgentViewSpec.scala
+++ b/test/views/declaration/RepresentativeDetailsAgentViewSpec.scala
@@ -29,6 +29,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.representative_details_agent
 import views.tags.ViewTest
@@ -47,7 +48,7 @@ class RepresentativeDetailsAgentViewSpec extends UnitViewSpec with ExportsTestDa
       val view = createView()
 
       "display page title" in {
-        view.getElementsByTag("h1").first() must containMessage("declaration.representative.agent.title")
+        view.getElementsByClass(Styles.gdsPageLegend).first() must containMessage("declaration.representative.agent.title")
       }
 
       "display two radio buttons with description (not selected)" in {

--- a/test/views/declaration/RepresentativeDetailsStatusViewSpec.scala
+++ b/test/views/declaration/RepresentativeDetailsStatusViewSpec.scala
@@ -26,6 +26,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.representative_details_status
 import views.tags.ViewTest
@@ -46,7 +47,7 @@ class RepresentativeDetailsStatusViewSpec extends UnitViewSpec with ExportsTestD
     val view = createView()
 
     "display page title" in {
-      view.getElementsByTag("h1").first() must containMessage("declaration.representative.status.title")
+      view.getElementsByClass(Styles.gdsPageLegend).first() must containMessage("declaration.representative.status.title")
     }
 
     "display two radio buttons with description (not selected)" in {

--- a/test/views/declaration/SealSummaryViewSpec.scala
+++ b/test/views/declaration/SealSummaryViewSpec.scala
@@ -25,6 +25,7 @@ import org.jsoup.nodes.Document
 import org.scalatest.MustMatchers
 import play.api.data.Form
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.seal_summary
 import views.tags.ViewTest
@@ -47,7 +48,7 @@ class SealSummaryViewSpec extends UnitViewSpec with Stubs with MustMatchers with
     "display page title for no seals" in {
       val noSealsView = createView(seals = Seq.empty)
       val title = messages("declaration.seal.add.first", containerId)
-      noSealsView.getElementsByTag("h1").text() must be(title)
+      noSealsView.getElementsByClass(Styles.gdsPageLegend).text() must be(title)
       noSealsView.title() must include(title)
     }
 

--- a/test/views/declaration/TaricCodeAddFirstViewSpec.scala
+++ b/test/views/declaration/TaricCodeAddFirstViewSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.MustMatchers
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.taric_code_add_first
 import views.tags.ViewTest
@@ -43,7 +44,7 @@ class TaricCodeAddFirstViewSpec extends UnitViewSpec with ExportsTestData with S
     val view = createView()
 
     "display page title" in {
-      view.getElementsByTag("h1") must containMessageForElements("declaration.taricAdditionalCodes.addfirst.header")
+      view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.taricAdditionalCodes.addfirst.header")
     }
 
     "display 'Back' button that links to 'CUS codes' page" in {

--- a/test/views/declaration/TransportContainerAddFirstViewSpec.scala
+++ b/test/views/declaration/TransportContainerAddFirstViewSpec.scala
@@ -25,6 +25,7 @@ import org.scalatest.MustMatchers
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.transport_container_add_first
 import views.tags.ViewTest
@@ -42,7 +43,7 @@ class TransportContainerAddFirstViewSpec extends UnitViewSpec with ExportsTestDa
     val view = createView()
 
     "display page title" in {
-      view.getElementsByTag("h1") must containMessageForElements("declaration.transportInformation.containers.first.title")
+      view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.transportInformation.containers.first.title")
     }
 
     "display section header" in {

--- a/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
+++ b/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
@@ -25,6 +25,7 @@ import models.Mode
 import models.requests.JourneyRequest
 import org.jsoup.nodes.Document
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.transport_leaving_the_border
 
@@ -37,7 +38,7 @@ class TransportLeavingTheBorderViewSpec extends UnitViewSpec with Stubs with Inj
 
     onEveryDeclarationJourney() { implicit request =>
       "display page title" in {
-        view.getElementsByTag("h1") must containMessageForElements("declaration.transport.leavingTheBorder.title")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.transport.leavingTheBorder.title")
       }
 
       "display section header" in {

--- a/test/views/declaration/UNDangerousGoodsCodeViewSpec.scala
+++ b/test/views/declaration/UNDangerousGoodsCodeViewSpec.scala
@@ -25,6 +25,7 @@ import org.jsoup.nodes.Document
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.un_dangerous_goods_code
 import views.tags.ViewTest
@@ -52,7 +53,7 @@ class UNDangerousGoodsCodeViewSpec extends UnitViewSpec with ExportsTestData wit
 
       val view = createView()
       "display page title" in {
-        view.getElementsByTag("h1") must containMessageForElements("declaration.unDangerousGoodsCode.header")
+        view.getElementsByClass(Styles.gdsPageLegend) must containMessageForElements("declaration.unDangerousGoodsCode.header")
       }
 
       "display section header" in {

--- a/test/views/declaration/WarehouseIdentificationYesNoViewSpec.scala
+++ b/test/views/declaration/WarehouseIdentificationYesNoViewSpec.scala
@@ -28,6 +28,7 @@ import play.api.i18n.{Messages, MessagesApi}
 import play.api.test.Helpers.stubMessages
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.warehouse_identification_yesno
 import views.tags.ViewTest
@@ -67,7 +68,7 @@ class WarehouseIdentificationYesNoViewSpec extends UnitViewSpec with ExportsTest
       }
 
       "have the correct page title" in {
-        view.getElementsByTag("h1").text() mustBe "declaration.warehouse.identification.optional.title"
+        view.getElementsByClass(Styles.gdsPageLegend).text() mustBe "declaration.warehouse.identification.optional.title"
       }
 
       "display radio button with Yes option" in {

--- a/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
+++ b/test/views/declaration/destinationCountries/RoutingCountryQuestionViewSpec.scala
@@ -23,6 +23,7 @@ import models.Mode
 import play.api.data.Form
 import services.cache.ExportsTestData
 import unit.tools.Stubs
+import views.components.gds.Styles
 import views.declaration.spec.UnitViewSpec
 import views.html.declaration.destinationCountries.routing_country_question
 
@@ -49,7 +50,7 @@ class RoutingCountryQuestionViewSpec extends UnitViewSpec with Stubs with Export
 
     "have page question" in {
 
-      view.getElementsByClass("govuk-fieldset__heading").text() mustBe messages("declaration.routingQuestion.title", countryOfDestination)
+      view.getElementsByClass(Styles.gdsPageLegend).text() mustBe messages("declaration.routingQuestion.title", countryOfDestination)
     }
 
     "have Yes/No answers" in {


### PR DESCRIPTION
This is an example on how to fix the issue in CEDS-2723.

Note:
This is done for a single page for standard declaration ONLY.
For this particular page there are separate templates for each
declaration type.