### PR TITLE
CEDS-2755 Add a Pointer Based URL logic

### DIFF
--- a/conf/code-lists/errors-dms-rej-list.csv
+++ b/conf/code-lists/errors-dms-rej-list.csv
@@ -106,7 +106,7 @@ CDS40012,Data element has invalid format,,
 CDS40013,Data element contains invalid value,Data element contains invalid value,
 CDS40040,Non existing value,,
 CDS40044,Disallowed Document,,
-CDS40045,Missing document,,/customs-declare-exports/declaration/items/ITEM_ID/add-document
+CDS40045,Missing document,,/customs-declare-exports/declaration/items/[ITEM_ID]/add-document
 CDS40046,Condition not fulfilled,,
 CDS40047,Prohibition,,
 CDS40048,Provisional measure closed,,


### PR DESCRIPTION
In some instances the WCO Declaration pointer will be returned but it
can map to two different pages on our user journey, which is depending on the
declaration type and the questions answered.

This means that we need to dynamically send the user to the correct page
based on the above.

This is an approach that keep the responsibility of this task/decision
in the RejectionReason class.