### PR TITLE
BAU form group wrapper component

### DIFF
--- a/app/controllers/util/MultipleItemsHelper.scala
+++ b/app/controllers/util/MultipleItemsHelper.scala
@@ -31,25 +31,26 @@ object MultipleItemsHelper {
     * @param form - multiple item form
     * @param cachedData - cached data which contains sequence of added items
     * @param limit - maximum limit of items
+    * @param fieldId - (optional) - field id of the HTML element to which the error should be attached
     * @tparam A - type of case class represents form
     * @return Either which can contain Form with errors or Sequence ready to insert to db
     */
-  def add[A](form: Form[A], cachedData: Seq[A], limit: Int, field: String = ""): Either[Form[A], Seq[A]] = form.value match {
-    case Some(document) => prepareData(form, document, cachedData, limit, field)
+  def add[A](form: Form[A], cachedData: Seq[A], limit: Int, fieldId: String = ""): Either[Form[A], Seq[A]] = form.value match {
+    case Some(document) => prepareData(form, document, cachedData, limit, fieldId)
     case _              => Left(form)
   }
 
-  private def prepareData[A](form: Form[A], document: A, cachedData: Seq[A], limit: Int, field: String): Either[Form[A], Seq[A]] =
-    (duplication(document, cachedData, field) ++ limitOfElems(limit, cachedData)) match {
+  private def prepareData[A](form: Form[A], document: A, cachedData: Seq[A], limit: Int, fieldId: String): Either[Form[A], Seq[A]] =
+    (duplication(document, cachedData, fieldId) ++ limitOfElems(limit, cachedData, fieldId)) match {
       case Seq()  => Right(addElement(document, cachedData))
       case errors => Left(form.copy(errors = errors))
     }
 
-  private def duplication[A](document: A, cachedData: Seq[A], field: String): Seq[FormError] =
-    if (cachedData.contains(document)) Seq(FormError(field, "supplementary.duplication")) else Seq.empty
+  private def duplication[A](document: A, cachedData: Seq[A], fieldId: String): Seq[FormError] =
+    if (cachedData.contains(document)) Seq(FormError(fieldId, "supplementary.duplication")) else Seq.empty
 
-  private def limitOfElems[A](limit: Int, cachedData: Seq[A]): Seq[FormError] =
-    if (cachedData.length >= limit) Seq(FormError("", "supplementary.limit")) else Seq.empty
+  private def limitOfElems[A](limit: Int, cachedData: Seq[A], fieldId: String): Seq[FormError] =
+    if (cachedData.length >= limit) Seq(FormError(fieldId, "supplementary.limit")) else Seq.empty
 
   private def addElement[A](document: A, cachedData: Seq[A]): Seq[A] = cachedData :+ document
 
@@ -62,20 +63,21 @@ object MultipleItemsHelper {
     * @param form - multiple item form
     * @param cachedData - cached data which contains sequence of added items
     * @param isMandatory - defines that screen is mandatory
+    * @param fieldId - (optional) - field id of the HTML element to which the error should be attached
     * @tparam A - type of case class represents form
     * @return Form with updated errors
     */
-  def continue[A](form: Form[A], cachedData: Seq[A], isMandatory: Boolean): Form[A] = {
-    val errors = checkInputs(form) ++ checkMandatory(isMandatory, cachedData)
+  def continue[A](form: Form[A], cachedData: Seq[A], isMandatory: Boolean, fieldId: String = ""): Form[A] = {
+    val errors = checkInputs(form, fieldId) ++ checkMandatory(isMandatory, cachedData, fieldId)
     form.copy(errors = errors)
   }
 
-  private def checkInputs[A](form: Form[A]): Seq[FormError] =
-    if (!isFormEmpty(form)) Seq(FormError("", "supplementary.continue.error"))
+  private def checkInputs[A](form: Form[A], fieldId: String): Seq[FormError] =
+    if (!isFormEmpty(form)) Seq(FormError(fieldId, "supplementary.continue.error"))
     else Seq.empty
 
-  private def checkMandatory[A](isMandatory: Boolean, cachedData: Seq[A]): Seq[FormError] =
-    if (isMandatory && cachedData.isEmpty) Seq(FormError("", "supplementary.continue.mandatory"))
+  private def checkMandatory[A](isMandatory: Boolean, cachedData: Seq[A], fieldId: String): Seq[FormError] =
+    if (isMandatory && cachedData.isEmpty) Seq(FormError(fieldId, "supplementary.continue.mandatory"))
     else Seq.empty
 
   /**
@@ -85,19 +87,20 @@ object MultipleItemsHelper {
     * @param cachedData - cached data which contains sequence of added items
     * @param isMandatory - defines that screen is mandatory
     * @param limit - limit of elements allowed for page
+    * @param fieldId - (optional) - field id of the HTML element to which the error should be attached
     * @tparam A - type of case class represents form
     * @return Form with updated errors or Sequence ready to insert to db
     */
-  def saveAndContinue[A](form: Form[A], cachedData: Seq[A], isMandatory: Boolean, limit: Int, field: String = ""): Either[Form[A], Seq[A]] =
-    if (!isFormEmpty(form)) add(form, cachedData, limit, field)
+  def saveAndContinue[A](form: Form[A], cachedData: Seq[A], isMandatory: Boolean, limit: Int, fieldId: String = ""): Either[Form[A], Seq[A]] =
+    if (!isFormEmpty(form)) add(form, cachedData, limit, fieldId)
     else {
-      val mandatoryFieldsError = checkMandatory(isMandatory, cachedData)
+      val mandatoryFieldsError = checkMandatory(isMandatory, cachedData, fieldId)
       if (mandatoryFieldsError.nonEmpty) Left(form.copy(errors = mandatoryFieldsError))
       else Right(cachedData)
     }
 
   private def isFormEmpty[A](form: Form[A]): Boolean =
-    retrieveData(form).filter { case (_, value) => value.nonEmpty }.isEmpty
+    !retrieveData(form).exists { case (_, value) => value.nonEmpty }
 
   private def retrieveData[A](form: Form[A]): Map[String, String] =
     form.data.filter { case (name, _) => name != "csrfToken" }

--- a/app/views/components/gds/formGroupWrapper.scala.html
+++ b/app/views/components/gds/formGroupWrapper.scala.html
@@ -1,0 +1,36 @@
+@*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@this()
+
+@(field: Field)(content: Html)(implicit messages: Messages)
+
+@formGroupClasses = @{
+  if(field.hasErrors) "govuk-form-group govuk-form-group--error" else "govuk-form-group"
+}
+
+@errorMessage = {
+  @if(field.hasErrors) {
+    <span id=@{s"${field.id}-error"} class="govuk-error-message">
+      <span class="govuk-visually-hidden">Error:</span> @messages(field.error.map(_.message).getOrElse(""))
+    </span>
+  }
+}
+
+<div id=@{s"${field.id}"} class="@formGroupClasses">
+  @errorMessage
+  @content
+</div>

--- a/test/views/components/gds/FormGroupWrapperSpec.scala
+++ b/test/views/components/gds/FormGroupWrapperSpec.scala
@@ -1,0 +1,96 @@
+/*
+ * Copyright 2020 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.components.gds
+
+import base.Injector
+import org.jsoup.nodes.Document
+import play.api.data.Forms._
+import play.api.data.{Field, Form}
+import play.twirl.api.{Html, HtmlFormat}
+import views.declaration.spec.UnitViewSpec
+import views.html.components.gds.formGroupWrapper
+
+import scala.collection.JavaConverters.{asScalaIterator, asScalaSet}
+
+class FormGroupWrapperSpec extends UnitViewSpec with Injector {
+
+  private val testFieldKey = "testKey"
+  private val testErrorMessageKey = "error.required"
+  private val formWithoutError = Form(single(testFieldKey -> text()))
+  private val formWithError = Form(single(testFieldKey -> text())).withError(testFieldKey, testErrorMessageKey)
+
+  private val formGroupWrapper = instanceOf[formGroupWrapper]
+  private def createViewComponent(field: Field)(content: Html): Document =
+    formGroupWrapper(field)(content)(messages)
+
+  private val htmlContent = HtmlFormat.raw("HTML Test Content")
+
+  "FormGroupWrapper" when {
+
+    "provided with field without errors" should {
+
+      val formGroupWrapperView = createViewComponent(formWithoutError(testFieldKey))(htmlContent)
+
+      "contain correct form group classes" in {
+
+        val expectedClassNames = Seq("govuk-form-group")
+
+        val actualClassNames = asScalaSet(formGroupWrapperView.getElementById(testFieldKey).classNames()).toSeq
+
+        actualClassNames mustBe expectedClassNames
+      }
+
+      "contain no span element with error message" in {
+
+        asScalaIterator(formGroupWrapperView.getElementsByTag("span").iterator()).toSeq mustBe empty
+      }
+
+      "contain provided content" in {
+
+        formGroupWrapperView must containHtml(htmlContent.body)
+      }
+    }
+
+    "provided with field containing errors" should {
+
+      val formGroupWrapperViewWithError = createViewComponent(formWithError(testFieldKey))(htmlContent)
+
+      "contain correct form group classes" in {
+
+        val expectedClassNames = Seq("govuk-form-group", "govuk-form-group--error")
+
+        val actualClassNames = asScalaSet(formGroupWrapperViewWithError.getElementById(testFieldKey).classNames()).toSeq
+
+        actualClassNames mustBe expectedClassNames
+      }
+
+      "contain span element with error message" in {
+
+        val spanElement = formGroupWrapperViewWithError.getElementById(s"$testFieldKey-error")
+
+        asScalaSet(spanElement.classNames()).toSeq mustBe Seq("govuk-error-message")
+        spanElement must containMessage(testErrorMessageKey)
+      }
+
+      "contain provided content" in {
+
+        formGroupWrapperViewWithError must containHtml(htmlContent.body)
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
This PR is a preparation for CEDS-2768.
Because it is not a functional change I decided to do it as "BAU".

The component simply allows to wrap any html content and
provides an option to give it an id. This is done in order to handle
form errors.
The second part is a small change to MultipleItemsHelper, to allow
the client to provide the field id that will have `FormErrors` 
associated with it.