### PR TITLE
CEDS-2768 Update duplication errors on multiple field pages

### DIFF
--- a/app/controllers/declaration/AdditionalInformationChangeController.scala
+++ b/app/controllers/declaration/AdditionalInformationChangeController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.AdditionalInformation
@@ -87,7 +88,7 @@ class AdditionalInformationChangeController @Inject()(
     val itemsWithoutExisting = cachedData.items.filterNot(_ == existingInformation)
 
     MultipleItemsHelper
-      .add(boundForm, itemsWithoutExisting, maxNumberOfItems)
+      .add(boundForm, itemsWithoutExisting, maxNumberOfItems, AdditionalInformationFormGroupId)
       .fold(
         formWithErrors => Future.successful(BadRequest(changePage(mode, itemId, id, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.DeclarationHolderAddController.DeclarationHolderFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.DeclarationHolder
@@ -65,7 +66,7 @@ class DeclarationHolderChangeController @Inject()(
     val holdersWithoutExisting: Seq[DeclarationHolder] = cachedHolders.filterNot(_ == existingHolder)
 
     MultipleItemsHelper
-      .add(boundForm, holdersWithoutExisting, DeclarationHoldersData.limitOfHolders)
+      .add(boundForm, holdersWithoutExisting, DeclarationHoldersData.limitOfHolders, DeclarationHolderFormGroupId)
       .fold(
         formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, existingHolder.id, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/DocumentsProducedChangeController.scala
+++ b/app/controllers/declaration/DocumentsProducedChangeController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.DocumentsProducedAddController.DocumentsProducedFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.additionaldocuments.DocumentsProduced
@@ -94,7 +95,7 @@ class DocumentsProducedChangeController @Inject()(
     val documentsWithoutExisting: Seq[DocumentsProduced] = existingDocuments.filterNot(_ == existingDocument)
 
     MultipleItemsHelper
-      .add(boundForm, documentsWithoutExisting, maxNumberOfItems)
+      .add(boundForm, documentsWithoutExisting, maxNumberOfItems, DocumentsProducedFormGroupId)
       .fold(
         formWithErrors => Future.successful(BadRequest(documentProducedPage(mode, itemId, documentId, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -17,6 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.{Document, PreviousDocumentsData}
@@ -56,7 +57,7 @@ class PreviousDocumentsChangeController @Inject()(
         val documentsWithoutExisting = request.cacheModel.previousDocuments.map(_.documents).getOrElse(Seq.empty).filterNot(_ == existingDocument)
 
         MultipleItemsHelper
-          .add(boundForm, documentsWithoutExisting, PreviousDocumentsData.maxAmountOfItems)
+          .add(boundForm, documentsWithoutExisting, PreviousDocumentsData.maxAmountOfItems, PreviousDocumentsFormGroupId)
           .fold(
             formWithErrors => Future.successful(BadRequest(changePage(mode, id, formWithErrors))),
             updatedDocuments => updateCache(updatedDocuments).map(_ => returnToSummary(mode))

--- a/app/views/declaration/documentsProduced/documents_produced_edit_content.scala.html
+++ b/app/views/declaration/documentsProduced/documents_produced_edit_content.scala.html
@@ -122,38 +122,38 @@
             labelKey = "declaration.addDocument.documentTypeCode",
             hintKey = Some("declaration.addDocument.documentTypeCode.hint"),
             inputClasses = Some("govuk-input--width-4")
-        ),
+        )
         @exportsInputText(
             field = form(documentIdentifierKey),
             labelKey = "declaration.addDocument.documentIdentifier",
             hintKey = Some("declaration.addDocument.documentIdentifier.hint"),
             inputClasses = Some("govuk-input--width-30")
-        ),
+        )
         @exportsInputText(
             field = form(documentStatusKey),
             labelKey = "declaration.addDocument.documentStatus",
             hintKey = Some("declaration.addDocument.documentStatus.hint"),
             inputClasses = Some("govuk-input--width-2")
-        ),
+        )
         @exportsInputText(
             field = form(documentStatusReasonKey),
             labelKey = "declaration.addDocument.documentStatusReason",
             hintKey = Some("declaration.addDocument.documentStatusReason.hint"),
             inputClasses = Some("govuk-input--width-30")
-        ),
+        )
         @exportsInputTextArea(
             field = form(issuingAuthorityNameKey),
             labelKey = "declaration.addDocument.issuingAuthorityName",
             hintKey = Some("declaration.addDocument.issuingAuthorityName.hint"),
             inputClasses = Some("govuk-input--width-20")
-        ),
+        )
         @exportsDateInput(
             fieldName = dateOfValidityKey,
             form = form,
             labelKey = "declaration.addDocument.dateOfValidity",
             hintKey = Some("declaration.addDocument.dateOfValidity.hint")
-        ),
-        @measurementUnitAndQualifier,
+        )
+        @measurementUnitAndQualifier
         @exportsInputText(
             field = form(s"$documentWriteOffKey.$documentQuantityKey"),
             labelKey = "declaration.addDocument.documentQuantity",


### PR DESCRIPTION
Remove commas from Additional Documentation page.
Include field ID on Change controllers for the following pages:
- /add-previous-documents, 
- /additional-documentation, 
- /add-authorisation-required, 
- /additional-information.