### PR TITLE
[CEDS-2758] Fix back button flow on clearance journey

### DIFF
--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -411,7 +411,7 @@ object Navigator {
     else
       controllers.declaration.routes.RepresentativeStatusController.displayPage(mode)
 
-  private def carrierEoriNumberClearancePreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call = {
+  private def carrierEoriNumberClearancePreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call =
     if (!cacheModel.parties.declarantIsExporter.exists(_.isExporter))
       controllers.declaration.routes.RepresentativeStatusController.displayPage(mode)
     else {
@@ -420,7 +420,6 @@ object Navigator {
       else
         controllers.declaration.routes.ConsignorEoriNumberController.displayPage(mode)
     }
-  }
 
   private def consigneeDetailsPreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call =
     if (cacheModel.parties.carrierDetails.flatMap(_.details.eori).isEmpty)

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -286,7 +286,7 @@ object Navigator {
   }
 
   val standardCacheDependent: PartialFunction[DeclarationPage, (ExportsDeclaration, Mode) => Call] = {
-    case CarrierEoriNumber   => carrierEoriNumberClearancePreviousPage
+    case CarrierEoriNumber   => carrierEoriNumberPreviousPage
     case Document            => previousDocumentsPreviousPageDefault
     case ConsigneeDetails    => consigneeDetailsPreviousPage
     case RepresentativeAgent => representativeAgentPreviousPage
@@ -411,12 +411,16 @@ object Navigator {
     else
       controllers.declaration.routes.RepresentativeStatusController.displayPage(mode)
 
-  private def carrierEoriNumberClearancePreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call =
-    if (cacheModel.parties.declarantIsExporter.exists(_.isExporter))
-      controllers.declaration.routes.DeclarantExporterController.displayPage(mode)
-    else {
+  private def carrierEoriNumberClearancePreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call = {
+    if (!cacheModel.parties.declarantIsExporter.exists(_.isExporter))
       controllers.declaration.routes.RepresentativeStatusController.displayPage(mode)
+    else {
+      if (cacheModel.parties.consignorDetails.flatMap(_.details.address).isDefined)
+        controllers.declaration.routes.ConsignorDetailsController.displayPage(mode)
+      else
+        controllers.declaration.routes.ConsignorEoriNumberController.displayPage(mode)
     }
+  }
 
   private def consigneeDetailsPreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call =
     if (cacheModel.parties.carrierDetails.flatMap(_.details.eori).isEmpty)


### PR DESCRIPTION
After splitting carrier details into two pages the Navigator logic
was incorrectly modified and left out some required checks.