### PR TITLE
[CEDS-2769] Update duplication error messages

### DIFF
--- a/app/controllers/declaration/AdditionalActorsAddController.scala
+++ b/app/controllers/declaration/AdditionalActorsAddController.scala
@@ -80,7 +80,7 @@ class AdditionalActorsAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedActors, DeclarationAdditionalActorsData.maxNumberOfActors, AdditionalActorsFormGroupId)
+      .add(boundForm, cachedActors, DeclarationAdditionalActorsData.maxNumberOfActors, AdditionalActorsFormGroupId, "declaration.additionalActors")
       .fold(
         formWithErrors => Future.successful(BadRequest(declarationAdditionalActorsPage(mode, formWithErrors))),
         updatedActors =>

--- a/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
@@ -66,7 +66,7 @@ class AdditionalFiscalReferencesAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(form, cachedData.references, limit, AdditionalFiscalReferencesFormGroupId)
+      .add(form, cachedData.references, limit, AdditionalFiscalReferencesFormGroupId, "declaration.additionalFiscalReferences")
       .fold(
         formWithErrors => Future.successful(BadRequest(additionalFiscalReferencesPage(mode, itemId, formWithErrors))),
         updatedCache =>

--- a/app/controllers/declaration/AdditionalInformationAddController.scala
+++ b/app/controllers/declaration/AdditionalInformationAddController.scala
@@ -66,7 +66,7 @@ class AdditionalInformationAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData.items, maxNumberOfItems, AdditionalInformationFormGroupId)
+      .add(boundForm, cachedData.items, maxNumberOfItems, AdditionalInformationFormGroupId, "declaration.additionalInformation")
       .fold(
         formWithErrors => Future.successful(BadRequest(additionalInformationPage(mode, itemId, formWithErrors))),
         updatedItems =>

--- a/app/controllers/declaration/AdditionalInformationChangeController.scala
+++ b/app/controllers/declaration/AdditionalInformationChangeController.scala
@@ -88,7 +88,7 @@ class AdditionalInformationChangeController @Inject()(
     val itemsWithoutExisting = cachedData.items.filterNot(_ == existingInformation)
 
     MultipleItemsHelper
-      .add(boundForm, itemsWithoutExisting, maxNumberOfItems, AdditionalInformationFormGroupId)
+      .add(boundForm, itemsWithoutExisting, maxNumberOfItems, AdditionalInformationFormGroupId, "declaration.additionalInformation")
       .fold(
         formWithErrors => Future.successful(BadRequest(changePage(mode, itemId, id, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/DeclarationHolderAddController.scala
+++ b/app/controllers/declaration/DeclarationHolderAddController.scala
@@ -72,7 +72,7 @@ class DeclarationHolderAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData, DeclarationHoldersData.limitOfHolders, DeclarationHolderFormGroupId)
+      .add(boundForm, cachedData, DeclarationHoldersData.limitOfHolders, DeclarationHolderFormGroupId, "declaration.declarationHolder")
       .fold(
         formWithErrors => Future.successful(BadRequest(declarationHolderPage(mode, formWithErrors))),
         updatedCache =>

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -66,7 +66,7 @@ class DeclarationHolderChangeController @Inject()(
     val holdersWithoutExisting: Seq[DeclarationHolder] = cachedHolders.filterNot(_ == existingHolder)
 
     MultipleItemsHelper
-      .add(boundForm, holdersWithoutExisting, DeclarationHoldersData.limitOfHolders, DeclarationHolderFormGroupId)
+      .add(boundForm, holdersWithoutExisting, DeclarationHoldersData.limitOfHolders, DeclarationHolderFormGroupId, "declaration.declarationHolder")
       .fold(
         formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, existingHolder.id, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/DocumentsProducedAddController.scala
+++ b/app/controllers/declaration/DocumentsProducedAddController.scala
@@ -83,7 +83,7 @@ class DocumentsProducedAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData, maxNumberOfItems, DocumentsProducedFormGroupId)
+      .add(boundForm, cachedData, maxNumberOfItems, DocumentsProducedFormGroupId, "declaration.addDocument")
       .fold(
         formWithErrors => Future.successful(BadRequest(documentProducedPage(mode, itemId, formWithErrors))),
         updatedCache =>

--- a/app/controllers/declaration/DocumentsProducedChangeController.scala
+++ b/app/controllers/declaration/DocumentsProducedChangeController.scala
@@ -95,7 +95,7 @@ class DocumentsProducedChangeController @Inject()(
     val documentsWithoutExisting: Seq[DocumentsProduced] = existingDocuments.filterNot(_ == existingDocument)
 
     MultipleItemsHelper
-      .add(boundForm, documentsWithoutExisting, maxNumberOfItems, DocumentsProducedFormGroupId)
+      .add(boundForm, documentsWithoutExisting, maxNumberOfItems, DocumentsProducedFormGroupId, "declaration.addDocument")
       .fold(
         formWithErrors => Future.successful(BadRequest(documentProducedPage(mode, itemId, documentId, formWithErrors))),
         _ => {

--- a/app/controllers/declaration/NactCodeAddController.scala
+++ b/app/controllers/declaration/NactCodeAddController.scala
@@ -82,7 +82,7 @@ class NactCodeAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData, nactCodeLimit, "nactCode")
+      .add(boundForm, cachedData, nactCodeLimit, "nactCode", "declaration.nationalAdditionalCode")
       .fold(
         formWithErrors => Future.successful(BadRequest(nactCodeAdd(mode, itemId, formWithErrors))),
         updatedCache =>

--- a/app/controllers/declaration/PackageInformationAddController.scala
+++ b/app/controllers/declaration/PackageInformationAddController.scala
@@ -58,7 +58,7 @@ class PackageInformationAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData, PackageInformation.limit, fieldId = PackageInformationFormGroupId)
+      .add(boundForm, cachedData, PackageInformation.limit, fieldId = PackageInformationFormGroupId, "declaration.packageInformation")
       .fold(
         formWithErrors => Future.successful(BadRequest(packageInformationPage(mode, itemId, formWithErrors, cachedData))),
         updatedCache =>

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -57,7 +57,13 @@ class PreviousDocumentsChangeController @Inject()(
         val documentsWithoutExisting = request.cacheModel.previousDocuments.map(_.documents).getOrElse(Seq.empty).filterNot(_ == existingDocument)
 
         MultipleItemsHelper
-          .add(boundForm, documentsWithoutExisting, PreviousDocumentsData.maxAmountOfItems, PreviousDocumentsFormGroupId)
+          .add(
+            boundForm,
+            documentsWithoutExisting,
+            PreviousDocumentsData.maxAmountOfItems,
+            PreviousDocumentsFormGroupId,
+            "declaration.previousDocuments"
+          )
           .fold(
             formWithErrors => Future.successful(BadRequest(changePage(mode, id, formWithErrors))),
             updatedDocuments => updateCache(updatedDocuments).map(_ => returnToSummary(mode))

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -57,7 +57,13 @@ class PreviousDocumentsController @Inject()(
         navigator.continueTo(mode, controllers.declaration.routes.ItemsSummaryController.displayAddItemPage)
       } else
       MultipleItemsHelper
-        .add(boundForm, cache.documents, PreviousDocumentsData.maxAmountOfItems, fieldId = PreviousDocumentsFormGroupId)
+        .add(
+          boundForm,
+          cache.documents,
+          PreviousDocumentsData.maxAmountOfItems,
+          fieldId = PreviousDocumentsFormGroupId,
+          "declaration.previousDocuments"
+        )
         .fold(
           formWithErrors => Future.successful(BadRequest(previousDocumentsPage(mode, formWithErrors))),
           updatedCache =>

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -144,7 +144,7 @@ class SealController @Inject()(
   }
 
   private def saveSeal(mode: Mode, boundForm: Form[Seal], cachedContainer: Container)(implicit request: JourneyRequest[AnyContent]): Future[Result] =
-    saveAndContinue(boundForm, cachedContainer.seals, isMandatory = true, Seal.sealsAllowed, "id").fold(
+    saveAndContinue(boundForm, cachedContainer.seals, isMandatory = true, Seal.sealsAllowed, "id", "declaration.seal").fold(
       formWithErrors => Future.successful(BadRequest(addPage(mode, formWithErrors, cachedContainer.id))),
       updatedCache =>
         if (updatedCache != cachedContainer.seals) updateCache(cachedContainer.copy(seals = updatedCache)).map { _ =>

--- a/app/controllers/declaration/TaricCodeAddController.scala
+++ b/app/controllers/declaration/TaricCodeAddController.scala
@@ -80,7 +80,7 @@ class TaricCodeAddController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] =
     MultipleItemsHelper
-      .add(boundForm, cachedData, taricCodeLimit, "taricCode")
+      .add(boundForm, cachedData, taricCodeLimit, "taricCode", "declaration.taricAdditionalCodes")
       .fold(
         formWithErrors => Future.successful(BadRequest(taricCodeAdd(mode, itemId, formWithErrors))),
         updatedCache =>

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -140,7 +140,7 @@ class TransportContainerController @Inject()(
   private def removeContainerYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.transportInformation.container.remove.empty")
 
   private def duplication(id: String, cachedData: Seq[Container]): Seq[FormError] =
-    if (cachedData.exists(_.id == id)) Seq(FormError("id", "supplementary.duplication")) else Seq.empty
+    if (cachedData.exists(_.id == id)) Seq(FormError("id", "declaration.transportInformation.error.duplicate")) else Seq.empty
 
   private def limitOfElems[A](limit: Int, cachedData: Seq[Container]): Seq[FormError] =
     if (cachedData.length >= limit) Seq(FormError("", "supplementary.limit")) else Seq.empty

--- a/app/controllers/util/MultipleItemsHelper.scala
+++ b/app/controllers/util/MultipleItemsHelper.scala
@@ -35,19 +35,28 @@ object MultipleItemsHelper {
     * @tparam A - type of case class represents form
     * @return Either which can contain Form with errors or Sequence ready to insert to db
     */
-  def add[A](form: Form[A], cachedData: Seq[A], limit: Int, fieldId: String = ""): Either[Form[A], Seq[A]] = form.value match {
-    case Some(document) => prepareData(form, document, cachedData, limit, fieldId)
+  def add[A](form: Form[A], cachedData: Seq[A], limit: Int, fieldId: String = "", messageKey: String): Either[Form[A], Seq[A]] = form.value match {
+    case Some(document) => prepareData(form, document, cachedData, limit, fieldId, messageKey)
     case _              => Left(form)
   }
 
-  private def prepareData[A](form: Form[A], document: A, cachedData: Seq[A], limit: Int, fieldId: String): Either[Form[A], Seq[A]] =
-    (duplication(document, cachedData, fieldId) ++ limitOfElems(limit, cachedData, fieldId)) match {
+  private def prepareData[A](
+    form: Form[A],
+    document: A,
+    cachedData: Seq[A],
+    limit: Int,
+    fieldId: String,
+    messageKey: String
+  ): Either[Form[A], Seq[A]] =
+    (duplication(document, cachedData, fieldId, messageKey) ++ limitOfElems(limit, cachedData, fieldId)) match {
       case Seq()  => Right(addElement(document, cachedData))
       case errors => Left(form.copy(errors = errors))
     }
 
-  private def duplication[A](document: A, cachedData: Seq[A], fieldId: String): Seq[FormError] =
-    if (cachedData.contains(document)) Seq(FormError(fieldId, "supplementary.duplication")) else Seq.empty
+  private def duplication[A](document: A, cachedData: Seq[A], fieldId: String, messageKey: String): Seq[FormError] =
+    if (cachedData.contains(document))
+      Seq(FormError(fieldId, s"${messageKey}.error.duplicate"))
+    else Seq.empty
 
   private def limitOfElems[A](limit: Int, cachedData: Seq[A], fieldId: String): Seq[FormError] =
     if (cachedData.length >= limit) Seq(FormError(fieldId, "supplementary.limit")) else Seq.empty
@@ -91,8 +100,15 @@ object MultipleItemsHelper {
     * @tparam A - type of case class represents form
     * @return Form with updated errors or Sequence ready to insert to db
     */
-  def saveAndContinue[A](form: Form[A], cachedData: Seq[A], isMandatory: Boolean, limit: Int, fieldId: String = ""): Either[Form[A], Seq[A]] =
-    if (!isFormEmpty(form)) add(form, cachedData, limit, fieldId)
+  def saveAndContinue[A](
+    form: Form[A],
+    cachedData: Seq[A],
+    isMandatory: Boolean,
+    limit: Int,
+    fieldId: String = "",
+    messageKey: String
+  ): Either[Form[A], Seq[A]] =
+    if (!isFormEmpty(form)) add(form, cachedData, limit, fieldId, messageKey)
     else {
       val mandatoryFieldsError = checkMandatory(isMandatory, cachedData, fieldId)
       if (mandatoryFieldsError.nonEmpty) Left(form.copy(errors = mandatoryFieldsError))

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -383,6 +383,7 @@ declaration.additionalActors.add.another = Do you need to add another party?
 declaration.additionalActors.add.another.empty = Select yes if you need to add another party.
 declaration.additionalActors.remove.empty = Select yes if you need to remove this party.
 declaration.additionalActors.remove.title = Are you sure you want to remove this party?
+declaration.additionalActors.error.duplicate = Additional party already added
 
 
 declaration.eori.empty = Enter an EORI number in the correct format. For example, GB123456789000.
@@ -456,6 +457,7 @@ declaration.declarationHolders.add.another = Do you need to add another authoris
 declaration.declarationHolders.add.another.empty = Select yes if you need to add another authorisation.
 declaration.declarationHolders.remove.empty = Select yes if you want to remove this authorisation.
 declaration.declarationHolder.remove.title = Are you sure you want to remove this authorisation?
+declaration.declarationHolder.error.duplicate = Authorisation details already added
 
 declaration.originationCountry.title = Which country are the goods being dispatched from?
 declaration.originationCountry.empty = Select a country of dispatch.
@@ -584,6 +586,7 @@ declaration.additionalFiscalReferences.add.another = Do you need to add more VAT
 declaration.additionalFiscalReferences.add.another.empty = Select yes if you need to add more VAT details.
 declaration.additionalFiscalReferences.remove.title = Are you sure you want to remove these VAT details?
 declaration.additionalFiscalReferences.remove.empty = Select yes if you want to remove these VAT details.
+declaration.additionalFiscalReferences.error.duplicate = VAT details already added
 
 declaration.addDocument.title = Do you need to add any documents, certificates, licences or authorisations?
 declaration.addDocument.hint = The boxes that need to be completed will be indicated by the {0} and the 4-digit document code you use.
@@ -620,6 +623,7 @@ declaration.addDocument.documentQuantity.error = Enter a quantity in the correct
 declaration.addDocument.error.maximumAmount = Maximum number of documents added.
 declaration.addDocument.error.duplicated = Document details already added.
 declaration.addDocument.error.notDefined = Enter document information.
+declaration.addDocument.error.duplicate = Additional document, licence, certificate, or authorisation already added
 declaration.addDocument.summary.documentTypeCode = Code
 declaration.addDocument.summary.documentIdentifier = Reference
 declaration.addDocument.summary.statusCode = Status code
@@ -744,6 +748,7 @@ declaration.transportInformation.containers.first.title = Are the goods in a con
 declaration.transportInformation.containers.yes = Yes
 declaration.transportInformation.containers.no = No
 declaration.transportInformation.containerId = Enter the container ID
+declaration.transportInformation.error.duplicate = Container ID already added
 
 declaration.invoice.details.title = Invoice and exchange rate details
 declaration.totalAmountInvoiced.error = Enter the total amount invoiced in numbers only.
@@ -808,6 +813,7 @@ declaration.taricAdditionalCodes.add.answer.empty = Select yes if you need to ad
 declaration.taricAdditionalCodes.remove.answer.empty = Select yes if you want to remove this additional code.
 declaration.taricAdditionalCodes.error.empty = Enter a TARIC code.
 declaration.taricAdditionalCodes.error.invalid = Additional code must be 4 alpha numeric characters exactly.
+declaration.taricAdditionalCodes.error.duplicate = Additional code already added
 declaration.taricAdditionalCodes.table.header = Additional code
 declaration.taricAdditionalCodes.remove.hint = Remove additional code {0}.
 declaration.taricAdditionalCodes.help.bodyText = Go to data element 6/16 Commodity Code: Additional TARIC Code in the {0}
@@ -827,6 +833,7 @@ declaration.nationalAdditionalCode.add.answer.empty = Select yes if you need to 
 declaration.nationalAdditionalCode.remove.answer.empty = Select yes if you want to remove this national additional code.
 declaration.nationalAdditionalCode.error.empty = Enter a national additional code.
 declaration.nationalAdditionalCode.error.invalid = Enter a valid national additional code.
+declaration.nationalAdditionalCode.error.duplicate = National additional code already added
 declaration.nationalAdditionalCode.table.header = National additional code
 declaration.nationalAdditionalCode.remove.hint = Remove national additional code {0}.
 declaration.nationalAdditionalCode.help.bodyText = Go to data element 6/17 National Additional Code in the {0}
@@ -873,6 +880,7 @@ declaration.previousDocuments.remove.title = Are you sure you want to remove thi
 declaration.previousDocuments.remove.empty = Select yes if you want to remove this document.
 declaration.previousDocuments.addAnotherDocument = Do you need to add another document?
 declaration.previousDocuments.add.another.empty = Select yes to add another document.
+declaration.previousDocuments.error.duplicate = Previous document already added
 
 declaration.additionalInformationRequired.title = Do you need to add an Additional Information (AI) code?
 declaration.additionalInformationRequired.hint = These are {0} and are determined by the commodity code or procedure code used.
@@ -902,6 +910,7 @@ declaration.additionalInformation.table.headers.description = Required informati
 declaration.additionalInformation.remove.title = Are you sure you want to remove this AI code?
 declaration.additionalInformation.remove.code = Code
 declaration.additionalInformation.remove.description = Required information
+declaration.additionalInformation.error.duplicate = Union or national AI code already added
 
 declaration.natureOfTransaction.header = Consignment information
 declaration.natureOfTransaction.title = What was the nature of the transaction?
@@ -952,6 +961,7 @@ declaration.packageInformation.shippingMarks.lengthError = Shipping marks can be
 declaration.packageInformation.shippingMarks.characterError = Shipping marks can be alphanumeric and up to 42 characters.
 declaration.packageInformation.shippingMarks.empty = Enter shipping marks.
 declaration.packageInformation.empty = Enter at least one value.
+declaration.packageInformation.error.duplicate = Package type already added
 declaration.packageInformation.help-item1 = Package type, go to data element 6/9 Type of Packages
 declaration.packageInformation.help-item2 = Number of this package, go to data element 6/10 Number of Packages
 declaration.packageInformation.help-item3 = Shipping marks, go to data element 6/11 Shipping Marks
@@ -1211,7 +1221,6 @@ declaration.summary.container.securitySeals = Security seals
 declaration.summary.container.change = Change container {0}
 
 supplementary.limit = You cannot add more items.
-supplementary.duplication = You cannot add duplicated value.
 supplementary.continue.error = Use the Add button to add an item.
 supplementary.continue.mandatory = You must add at least one item.
 
@@ -1247,6 +1256,7 @@ declaration.seal.add.first = Does container {0} have any security seals?
 declaration.seal.add.another = Do you need to add another security seal?
 declaration.seal.remove.title = Are you sure you want to remove this security seal for container {0}?
 declaration.seal.remove.hint = Remove security seal {0}.
+declaration.seal.error.duplicate = Seal number already added
 declaration.transport.sealId.empty.error = Enter a seal ID.
 declaration.transport.sealId.error.invalid = Seal ID must not be more than 20 alpha numeric characters.
 

--- a/test/controllers/util/MultipleItemsHelperSpec.scala
+++ b/test/controllers/util/MultipleItemsHelperSpec.scala
@@ -27,7 +27,7 @@ class MultipleItemsHelperSpec extends WordSpec with MustMatchers {
   "MultipleItemsHelper on add method" should {
     "return sequence with value" when {
       "input data is correct" in {
-        MultipleItemsHelper.add(correctForm, Seq(), limit, fieldId = valueFieldName) must be(Right(Seq(correctValue)))
+        MultipleItemsHelper.add(correctForm, Seq(), limit, fieldId = valueFieldName, valueMessageKey) must be(Right(Seq(correctValue)))
       }
     }
 
@@ -35,17 +35,17 @@ class MultipleItemsHelperSpec extends WordSpec with MustMatchers {
       "limit of elements is reached" in {
         val expectedOutput = Left(correctForm.copy(errors = limitError(valueFieldName)))
 
-        MultipleItemsHelper.add(correctForm, Seq(), 0, fieldId = valueFieldName) must be(expectedOutput)
+        MultipleItemsHelper.add(correctForm, Seq(), 0, fieldId = valueFieldName, valueMessageKey) must be(expectedOutput)
       }
 
       "elements is duplicated" in {
         val expectedOutput = Left(correctForm.copy(errors = duplicationError(valueFieldName)))
 
-        MultipleItemsHelper.add(correctForm, Seq(correctValue), limit, fieldId = valueFieldName) must be(expectedOutput)
+        MultipleItemsHelper.add(correctForm, Seq(correctValue), limit, fieldId = valueFieldName, valueMessageKey) must be(expectedOutput)
       }
 
       "input is incorrect" in {
-        MultipleItemsHelper.add(incorrectForm, Seq(), limit, fieldId = valueFieldName) must be(Left(incorrectForm))
+        MultipleItemsHelper.add(incorrectForm, Seq(), limit, fieldId = valueFieldName, valueMessageKey) must be(Left(incorrectForm))
       }
     }
   }
@@ -93,19 +93,25 @@ class MultipleItemsHelperSpec extends WordSpec with MustMatchers {
     "add item when form is not empty" in {
       val expectedOutput = Right(Seq(correctValue))
 
-      MultipleItemsHelper.saveAndContinue(correctForm, Seq(), isMandatory = true, limit, fieldId = valueFieldName) must be(expectedOutput)
+      MultipleItemsHelper.saveAndContinue(correctForm, Seq(), isMandatory = true, limit, fieldId = valueFieldName, valueMessageKey) must be(
+        expectedOutput
+      )
     }
 
     "return form with errors when cache is empty and page is mandatory" in {
       val expectedOutput = Left(testForm.copy(errors = mandatoryError(valueFieldName)))
 
-      MultipleItemsHelper.saveAndContinue(testForm, Seq(), isMandatory = true, limit, fieldId = valueFieldName) must be(expectedOutput)
+      MultipleItemsHelper.saveAndContinue(testForm, Seq(), isMandatory = true, limit, fieldId = valueFieldName, valueMessageKey) must be(
+        expectedOutput
+      )
     }
 
     "return sequence with actual cache when user has data in cache and has empty form" in {
       val cachedData = Seq(TestForm("ABC"))
 
-      MultipleItemsHelper.saveAndContinue(testForm, cachedData, isMandatory = true, limit, fieldId = valueFieldName) must be(Right(cachedData))
+      MultipleItemsHelper.saveAndContinue(testForm, cachedData, isMandatory = true, limit, fieldId = valueFieldName, valueMessageKey) must be(
+        Right(cachedData)
+      )
     }
   }
 
@@ -135,12 +141,13 @@ object MultipleItemsHelperSpec {
   val correctValue = TestForm("Correct value")
   val incorrectValue = TestForm("Incorrect value")
 
-  def duplicationError(id: String = "") = Seq(FormError(id, "supplementary.duplication"))
+  def duplicationError(id: String = "") = Seq(FormError(id, s"${valueMessageKey}.error.duplicate"))
   def limitError(id: String = "") = Seq(FormError(id, "supplementary.limit"))
   def continueError(id: String = "") = Seq(FormError(id, "supplementary.continue.error"))
   def mandatoryError(id: String = "") = Seq(FormError(id, "supplementary.continue.mandatory"))
 
   val valueFieldName = "value"
+  val valueMessageKey = "value"
   val correctJson: JsValue = JsObject(Map(valueFieldName -> JsString(correctValue.value)))
   val incorrectJson: JsValue = JsObject(Map(valueFieldName -> JsString(incorrectValue.value)))
 


### PR DESCRIPTION
Customise the duplicate items error messages to be specific to the
elements/context in which they are triggered.

Previously the error message "You cannot add duplicated value."
was used in all instances where multiple elements could be
specified on a declaration journey. Now we have specific messages
crafted by James Watson for each element.