### PR TITLE
CEDS-2668 Fix contact-frontend url

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -62,10 +62,10 @@ class AppConfig @Inject()(
   lazy val customsDeclareExportsBaseUrl = servicesConfig.baseUrl("customs-declare-exports")
 
   lazy val giveFeedbackLink = {
-    val contactFrontendBaseUrl = servicesConfig.baseUrl("contact-frontend")
+    val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
     val contactFrontendServiceId = loadConfig("microservice.services.contact-frontend.serviceId")
 
-    s"$contactFrontendBaseUrl/contact/beta-feedback-unauthenticated?service=$contactFrontendServiceId"
+    s"$contactFrontendUrl?service=$contactFrontendServiceId"
   }
 
   lazy val declarations = servicesConfig.getConfString(

--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -61,6 +61,7 @@ class AppConfig @Inject()(
 
   lazy val customsDeclareExportsBaseUrl = servicesConfig.baseUrl("customs-declare-exports")
 
+  lazy val selfBaseUrl: Option[String] = runModeConfiguration.getOptional[String]("platform.frontend.host")
   lazy val giveFeedbackLink = {
     val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
     val contactFrontendServiceId = loadConfig("microservice.services.contact-frontend.serviceId")

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -21,9 +21,7 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@protocol = @{ if(request.secure) "https" else "http" }
-@betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}&backUrl=$protocol://${request.host}${request.uri}"}
-
+@betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}&backURL=${request.uri}"}
 @link = {<a href="@betaFeedbackUrl">@messages("feedback.link")</a>}
 
 @feedbackBanner = {

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -21,7 +21,8 @@
 
 @(phase: String)(implicit request: Request[_], messages: Messages)
 
-@betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}&backURL=${request.uri}"}
+@backUrl = @{ appConfig.selfBaseUrl.map(url => s"&backUrl=$url${request.uri}").getOrElse("") }
+@betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}$backUrl"}
 @link = {<a href="@betaFeedbackUrl">@messages("feedback.link")</a>}
 
 @feedbackBanner = {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -81,8 +81,7 @@ microservice {
     }
 
     contact-frontend {
-      host = localhost
-      port = 9250
+      url = "http://localhost:9250/contact/beta-feedback-unauthenticated"
       serviceId = "Exports-Declarations"
     }
 
@@ -135,10 +134,6 @@ assets {
   version = "3.8.0"
   url = "http://localhost:9032/assets/"
   url = ${?ASSETS_URL}
-}
-
-contact-frontend {
-  host = "http://localhost:9250"
 }
 
 urls {

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -174,3 +174,6 @@ timeoutDialog {
 tracking-consent-frontend {
   gtm.container = "a"
 }
+
+# Default value for local environment
+platform.frontend.host = "http://localhost:6791"

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -76,7 +76,7 @@ class AppConfigSpec extends UnitSpec {
         |microservice.services.contact-frontend.url=/contact-frontend-url
         |microservice.services.contact-frontend.serviceId=DeclarationServiceId
         |mongodb.timeToLive=24h
-
+        |platform.frontend.host="self/base-url"
       """.stripMargin
     )
   private val emptyConfig: Config = ConfigFactory.empty()
@@ -196,6 +196,11 @@ class AppConfigSpec extends UnitSpec {
       validAppConfig.fetchSubmissions must be("/submissions")
     }
 
+    "have selfBaseUrl" in {
+      validAppConfig.selfBaseUrl must be(defined)
+      validAppConfig.selfBaseUrl.get must be("self/base-url")
+    }
+
     "have link for 'give feedback'" in {
       validAppConfig.giveFeedbackLink must be("/contact-frontend-url?service=DeclarationServiceId")
     }
@@ -215,90 +220,96 @@ class AppConfigSpec extends UnitSpec {
     "have draft lifetime" in {
       validAppConfig.draftTimeToLive must be(FiniteDuration(30, TimeUnit.DAYS))
     }
-  }
 
-  "empty Choice options when list-of-available-journeys is not defined" in {
-    emptyAppConfig.availableJourneys().size must be(1)
-    emptyAppConfig.availableJourneys() must contain(Choice.AllowedChoiceValues.Submissions)
-  }
-
-  "empty Declaration type options when list-of-available-declarations is not defined" in {
-    emptyAppConfig.availableDeclarations().size must be(1)
-    emptyAppConfig.availableDeclarations() must contain(DeclarationType.STANDARD.toString)
-  }
-
-  "throw an exception" when {
-
-    "gtm.container is missing" in {
-      intercept[Exception](emptyAppConfig.gtmContainer).getMessage must be("Could not find config key 'tracking-consent-frontend.gtm.container'")
+    "have single Choice options when list-of-available-journeys is not defined" in {
+      emptyAppConfig.availableJourneys().size must be(1)
+      emptyAppConfig.availableJourneys() must contain(Choice.AllowedChoiceValues.Submissions)
     }
 
-    "google-analytics.host is missing" in {
-      intercept[Exception](emptyAppConfig.analyticsHost).getMessage must be("Missing configuration key: google-analytics.host")
+    "have single Declaration type options when list-of-available-declarations is not defined" in {
+      emptyAppConfig.availableDeclarations().size must be(1)
+      emptyAppConfig.availableDeclarations() must contain(DeclarationType.STANDARD.toString)
     }
 
-    "google-analytics.token is missing" in {
-      intercept[Exception](emptyAppConfig.analyticsToken).getMessage must be("Missing configuration key: google-analytics.token")
+    "empty selfBaseUrl when the key is missing" in {
+      emptyAppConfig.selfBaseUrl must be(None)
     }
 
-    "auth.host is missing" in {
-      intercept[Exception](emptyAppConfig.authUrl).getMessage must be("Could not find config key 'auth.host'")
-    }
+    "throw an exception" when {
 
-    "urls.login is missing" in {
-      intercept[Exception](emptyAppConfig.loginUrl).getMessage must be("Missing configuration key: urls.login")
-    }
+      "gtm.container is missing" in {
+        intercept[Exception](emptyAppConfig.gtmContainer).getMessage must be("Could not find config key 'tracking-consent-frontend.gtm.container'")
+      }
 
-    "urls.loginContinue is missing" in {
-      intercept[Exception](emptyAppConfig.loginContinueUrl).getMessage must be("Missing configuration key: urls.loginContinue")
-    }
+      "google-analytics.host is missing" in {
+        intercept[Exception](emptyAppConfig.analyticsHost).getMessage must be("Missing configuration key: google-analytics.host")
+      }
 
-    "customs-declare-exports.host is missing" in {
-      intercept[Exception](emptyAppConfig.customsDeclareExportsBaseUrl).getMessage must be("Could not find config key 'customs-declare-exports.host'")
-    }
+      "google-analytics.token is missing" in {
+        intercept[Exception](emptyAppConfig.analyticsToken).getMessage must be("Missing configuration key: google-analytics.token")
+      }
 
-    "submit declaration uri is missing" in {
-      intercept[Exception](emptyAppConfig.declarations).getMessage must be(
-        "Missing configuration for Customs Declarations Exports submit declaration URI"
-      )
-    }
+      "auth.host is missing" in {
+        intercept[Exception](emptyAppConfig.authUrl).getMessage must be("Could not find config key 'auth.host'")
+      }
 
-    "cancel declaration uri is missing" in {
-      intercept[Exception](emptyAppConfig.cancelDeclaration).getMessage must be(
-        "Missing configuration for Customs Declaration Export cancel declaration URI"
-      )
-    }
+      "urls.login is missing" in {
+        intercept[Exception](emptyAppConfig.loginUrl).getMessage must be("Missing configuration key: urls.login")
+      }
 
-    "fetch mrn status uri is missing" in {
-      intercept[Exception](emptyAppConfig.fetchMrnStatus).getMessage must be(
-        "Missing configuration for Customs Declaration Export fetch mrn status URI"
-      )
-    }
+      "urls.loginContinue is missing" in {
+        intercept[Exception](emptyAppConfig.loginContinueUrl).getMessage must be("Missing configuration key: urls.loginContinue")
+      }
 
-    "fetchSubmissions uri is missing" in {
-      intercept[Exception](emptyAppConfig.fetchSubmissions).getMessage must be(
-        "Missing configuration for Customs Declaration Exports fetch submission URI"
-      )
-    }
+      "customs-declare-exports.host is missing" in {
+        intercept[Exception](emptyAppConfig.customsDeclareExportsBaseUrl).getMessage must be(
+          "Could not find config key 'customs-declare-exports.host'"
+        )
+      }
 
-    "fetch notifications uri is missing" in {
-      intercept[Exception](emptyAppConfig.fetchNotifications).getMessage must be(
-        "Missing configuration for Customs Declarations Exports fetch notification URI"
-      )
-    }
+      "submit declaration uri is missing" in {
+        intercept[Exception](emptyAppConfig.declarations).getMessage must be(
+          "Missing configuration for Customs Declarations Exports submit declaration URI"
+        )
+      }
 
-    "link for 'give feedback' is missing" in {
-      intercept[Exception](emptyAppConfig.giveFeedbackLink).getMessage must be(
-        "Missing configuration key: microservice.services.contact-frontend.url"
-      )
-    }
+      "cancel declaration uri is missing" in {
+        intercept[Exception](emptyAppConfig.cancelDeclaration).getMessage must be(
+          "Missing configuration for Customs Declaration Export cancel declaration URI"
+        )
+      }
 
-    "countryCodesJsonFilename is missing" in {
-      intercept[Exception](emptyAppConfig.countryCodesJsonFilename).getMessage must be("Missing configuration key: countryCodesJsonFilename")
-    }
+      "fetch mrn status uri is missing" in {
+        intercept[Exception](emptyAppConfig.fetchMrnStatus).getMessage must be(
+          "Missing configuration for Customs Declaration Export fetch mrn status URI"
+        )
+      }
 
-    "countryCodesCsvFilename is missing" in {
-      intercept[Exception](emptyAppConfig.countriesCsvFilename).getMessage must be("Missing configuration key: countryCodesCsvFilename")
+      "fetchSubmissions uri is missing" in {
+        intercept[Exception](emptyAppConfig.fetchSubmissions).getMessage must be(
+          "Missing configuration for Customs Declaration Exports fetch submission URI"
+        )
+      }
+
+      "fetch notifications uri is missing" in {
+        intercept[Exception](emptyAppConfig.fetchNotifications).getMessage must be(
+          "Missing configuration for Customs Declarations Exports fetch notification URI"
+        )
+      }
+
+      "link for 'give feedback' is missing" in {
+        intercept[Exception](emptyAppConfig.giveFeedbackLink).getMessage must be(
+          "Missing configuration key: microservice.services.contact-frontend.url"
+        )
+      }
+
+      "countryCodesJsonFilename is missing" in {
+        intercept[Exception](emptyAppConfig.countryCodesJsonFilename).getMessage must be("Missing configuration key: countryCodesJsonFilename")
+      }
+
+      "countryCodesCsvFilename is missing" in {
+        intercept[Exception](emptyAppConfig.countriesCsvFilename).getMessage must be("Missing configuration key: countryCodesCsvFilename")
+      }
     }
   }
 

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -73,8 +73,7 @@ class AppConfigSpec extends UnitSpec {
         |microservice.services.customs-declare-exports-movements.host=localhostm
         |microservice.services.customs-declare-exports-movements.port=9876
         |microservice.services.customs-declare-exports-movements.save-movement-uri=/save-movement-submission
-        |microservice.services.contact-frontend.host=localhost
-        |microservice.services.contact-frontend.port=9250
+        |microservice.services.contact-frontend.url=/contact-frontend-url
         |microservice.services.contact-frontend.serviceId=DeclarationServiceId
         |mongodb.timeToLive=24h
 
@@ -198,7 +197,7 @@ class AppConfigSpec extends UnitSpec {
     }
 
     "have link for 'give feedback'" in {
-      validAppConfig.giveFeedbackLink must be("http://localhost:9250/contact/beta-feedback-unauthenticated?service=DeclarationServiceId")
+      validAppConfig.giveFeedbackLink must be("/contact-frontend-url?service=DeclarationServiceId")
     }
 
     "have countryCodesJsonFilename" in {
@@ -289,7 +288,9 @@ class AppConfigSpec extends UnitSpec {
     }
 
     "link for 'give feedback' is missing" in {
-      intercept[Exception](emptyAppConfig.giveFeedbackLink).getMessage must be("Could not find config key 'contact-frontend.host'")
+      intercept[Exception](emptyAppConfig.giveFeedbackLink).getMessage must be(
+        "Missing configuration key: microservice.services.contact-frontend.url"
+      )
     }
 
     "countryCodesJsonFilename is missing" in {

--- a/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -17,7 +17,7 @@
 package unit.controllers.declaration
 
 import controllers.declaration.CarrierDetailsController
-import forms.common.{Address, Eori}
+import forms.common.Address
 import forms.declaration.EntityDetails
 import forms.declaration.carrier.CarrierDetails
 import models.DeclarationType._

--- a/test/views/components/gds/PhaseBannerSpec.scala
+++ b/test/views/components/gds/PhaseBannerSpec.scala
@@ -55,7 +55,7 @@ class PhaseBannerSpec extends UnitViewSpec with BeforeAndAfterEach {
 
     "display feedback link with correct href" in {
       createBanner().getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
-        s"$giveFeedbackLinkTest&backUrl=http://localhost$requestPath"
+        s"$giveFeedbackLinkTest&backURL=$requestPath"
       )
     }
   }

--- a/test/views/components/gds/PhaseBannerSpec.scala
+++ b/test/views/components/gds/PhaseBannerSpec.scala
@@ -35,6 +35,7 @@ class PhaseBannerSpec extends UnitViewSpec with BeforeAndAfterEach {
   private val requestPath = "/customs-declare-exports/any-page"
   private implicit val fakeRequest = FakeRequest("GET", requestPath)
 
+  private val selfBaseUrlTest = "selfBaseUrlTest"
   private val giveFeedbackLinkTest = "giveFeedbackLinkTest"
 
   private def createBanner(): Html = bannerPartial("")(fakeRequest, messages)
@@ -43,6 +44,7 @@ class PhaseBannerSpec extends UnitViewSpec with BeforeAndAfterEach {
     super.beforeEach()
 
     reset(appConfig)
+    when(appConfig.selfBaseUrl).thenReturn(Some(selfBaseUrlTest))
     when(appConfig.giveFeedbackLink).thenReturn(giveFeedbackLinkTest)
   }
 
@@ -53,10 +55,18 @@ class PhaseBannerSpec extends UnitViewSpec with BeforeAndAfterEach {
 
   "phaseBanner" should {
 
-    "display feedback link with correct href" in {
-      createBanner().getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
-        s"$giveFeedbackLinkTest&backURL=$requestPath"
-      )
+    "display feedback link with correct href" when {
+
+      "selfBaseUrl is defined" in {
+        createBanner().getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(
+          s"$giveFeedbackLinkTest&backUrl=$selfBaseUrlTest$requestPath"
+        )
+      }
+
+      "selfBaseUrl is not defined" in {
+        when(appConfig.selfBaseUrl).thenReturn(None)
+        createBanner().getElementsByClass("govuk-phase-banner__text").first().getElementsByTag("a").first() must haveHref(s"$giveFeedbackLinkTest")
+      }
     }
   }
 

--- a/test/views/declaration/CarrierEoriNumberViewSpec.scala
+++ b/test/views/declaration/CarrierEoriNumberViewSpec.scala
@@ -20,9 +20,9 @@ import base.Injector
 import forms.common.Eori
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.carrier.CarrierEoriNumber
-import models.{DeclarationType, Mode}
-import models.requests.JourneyRequest
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD}
+import models.Mode
+import models.requests.JourneyRequest
 import org.jsoup.nodes.Document
 import org.scalatest.Matchers._
 import play.api.data.Form

--- a/test/views/declaration/fiscalInformation/FiscalInformationViewSpec.scala
+++ b/test/views/declaration/fiscalInformation/FiscalInformationViewSpec.scala
@@ -23,8 +23,7 @@ import models.Mode
 import models.requests.JourneyRequest
 import org.jsoup.nodes.Document
 import play.api.data.Form
-import play.api.i18n.{Messages, MessagesApi}
-import play.api.test.Helpers.stubMessages
+import play.api.i18n.MessagesApi
 import services.cache.ExportsTestData
 import unit.tools.Stubs
 import views.components.gds.Styles


### PR DESCRIPTION
There are 2 issues that are fixed in this PR:

1. `backURL` should have capitalized 'URL'
2. In other environments, the link to contact-frontend was incorrect.
    It should be using url, similarly to how we link to Movements in
    Declarations service.
