### PR TITLE
CEDS-2668 Add script to start contact-frontend service

### DIFF
--- a/run-contact-frontend-sm_local.sh
+++ b/run-contact-frontend-sm_local.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sm --stop CONTACT_FRONTEND
+sm --start CONTACT --appendArgs '{"CONTACT_FRONTEND":["-DbackUrlDestinationWhitelist=http://localhost:6791,http://localhost:6793,http://localhost:6796"]}'


### PR DESCRIPTION
This script runs contact-frontend service and provides Exports UI
frontend services to its backUrlDestinationWhitelist. This is to allow
for backUrl functionality.