### PR TITLE
[CEDS-2941] Dynamically load the Footer Links

### DIFF
--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -16,6 +16,7 @@
 
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import uk.gov.hmrc.hmrcfrontend.views.html.helpers.HmrcTrackingConsentSnippet
+@import uk.gov.hmrc.hmrcfrontend.views.html.helpers.hmrcStandardFooter
 @import uk.gov.hmrc.hmrcfrontend.views.html.components.HmrcReportTechnicalIssue
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.reporttechnicalissue.ReportTechnicalIssue
 @import uk.gov.hmrc.hmrcfrontend.views.viewmodels.language.{En, Cy}
@@ -25,7 +26,6 @@
 @import config.TimeoutDialogConfig
 @import config.BetaBannerConfig
 @import models.requests.AuthenticatedRequest
-@import scala.collection.immutable.Seq
 @import config.AppConfig
 
 @this(
@@ -39,6 +39,7 @@
   betaBannerConfig: BetaBannerConfig,
   hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
   hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
+  hmrcFooter: hmrcStandardFooter,
   appConfig: AppConfig
 )
 
@@ -64,12 +65,12 @@
     <script src="@routes.Assets.versioned("javascripts/show-hide-content.js")" type="text/javascript"></script>
 
     @if(useTimeoutDialog) {
-        <script src='@routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
         <script src='@routes.Assets.versioned("javascripts/timeoutDialog.js")'> </script>
-        <script>window.HMRCFrontend.initAll();</script>
     }
 
     <script src='@routes.Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
+    <script src='@routes.Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
+    <script>window.HMRCFrontend.initAll();</script>
     <script>window.GOVUKFrontend.initAll();</script>
 }
 
@@ -102,14 +103,6 @@
     )
 }
 
-@footer = @{
-    Seq(
-        FooterItem(href = Some("help/cookies"), text = Some("Cookies")),
-        FooterItem(href = Some("help/privacy"), text = Some("Privacy Policy")),
-        FooterItem(href = Some("help/terms-and-conditions"), text = Some("Terms and conditions")),
-        FooterItem(href = Some("help"), text = Some("Help using GOV.UK"))
-)}
-
 @if(useCustomContentWidth) {
   @govukFlexibleLayout(
     pageTitle = Some(title.toString),
@@ -118,7 +111,7 @@
     bodyEndBlock = None,
     scriptsBlock = Some(scripts),
     headerBlock = Some(siteHeader()),
-    footerItems = footer
+    footerBlock = Some(hmrcFooter())
   )(content)
 } else {
   @govukLayout(
@@ -128,7 +121,7 @@
     bodyEndBlock = None,
     scriptsBlock = Some(scripts),
     headerBlock = Some(siteHeader()),
-    footerItems = footer
+    footerBlock = Some(hmrcFooter())
   )(content)
 }
 


### PR DESCRIPTION
On our GDS Design System main template, we manually
add all the footer items which are now out of date.

Changing to use the HMRC frontend lib to add them
dynamically.