### PR TITLE
CEDS 2926 update character count to use GOV.UK accessible component

### DIFF
--- a/app/forms/declaration/CommodityDetails.scala
+++ b/app/forms/declaration/CommodityDetails.scala
@@ -31,9 +31,9 @@ object CommodityDetails extends DeclarationPage {
 
   val combinedNomenclatureCodeKey = "combinedNomenclatureCode"
   val descriptionOfGoodsKey = "descriptionOfGoods"
+  val descriptionOfGoodsMaxLength = 280
 
   private val combinedNomenclatureCodeMaxLength = 8
-  private val descriptionOfGoodsMaxLength = 280
 
   private def mappingCombinedNomenclatureCodeRequired: Mapping[Option[String]] =
     optional(

--- a/app/views/components/gds/exportsInputCharacterCount.scala.html
+++ b/app/views/components/gds/exportsInputCharacterCount.scala.html
@@ -1,0 +1,52 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import forms.declaration.CommodityDetails
+@import uk.gov.hmrc.govukfrontend.views.html.components._
+@import views.components.gds.Styles._
+
+@this(govukCharacterCount: GovukCharacterCount)
+
+@(
+  field: Field,
+  labelKey: String,
+  hintKey: Option[String] = None,
+  isPageHeading: Boolean = false,
+  headingClasses: String = gdsPageLabel,
+  labelClasses: String = "govuk-label--m",
+  inputClasses: String = "",
+  maxLength: Option[Int] = None
+)(implicit messages: Messages)
+
+@buildLabel = @{
+  if(isPageHeading) {
+    Label(content = Text(messages(labelKey)), isPageHeading = true, classes = headingClasses)
+  } else {
+    Label(content = Text(messages(labelKey)), classes = labelClasses)
+  }
+}
+
+@govukCharacterCount(CharacterCount(
+  id = field.id,
+  name = field.name,
+  value = field.value,
+  maxLength = maxLength,
+  label = buildLabel,
+  hint = hintKey.map(key => Hint(content = Text(messages(key)))),
+  errorMessage = field.error.map(err => ErrorMessage(content = Text(messages(err.message)))),
+  classes = inputClasses
+))
+

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -29,7 +29,7 @@
         govukDetails : GovukDetails,
         pageTitle: pageTitle,
         inputText: exportsInputText,
-        inputTextArea: exportsInputTextArea,
+        govukCharacterCount : GovukCharacterCount,
         errorSummary: errorSummary,
         sectionHeader: sectionHeader,
         saveButtons: saveButtons,
@@ -78,11 +78,18 @@
             content = HtmlContent(commodityDetailsInformation)
         ))
 
-        @inputTextArea(
-            field = form(CommodityDetails.descriptionOfGoodsKey),
-            labelKey = "declaration.commodityDetails.description.header",
-            hintKey = Some("declaration.commodityDetails.description.header.hint")
-        )
+        @govukCharacterCount(CharacterCount(
+            id = "with-hint",
+            name = "with-hint",
+            maxLength = Some(280),
+            label = Label(
+                classes = "govuk-label govuk-label--m",
+              content = Text(messages("declaration.commodityDetails.description.header"))
+            ),
+            hint = Some(Hint(
+              content = Text(messages("declaration.commodityDetails.description.header.hint"))
+            ))
+        ))
 
         @tariffDetails(messages("declaration.type.consignmentTariff_summary_text"), HtmlContent(tariffBody))
 

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -29,7 +29,7 @@
         govukDetails : GovukDetails,
         pageTitle: pageTitle,
         inputText: exportsInputText,
-        govukCharacterCount : GovukCharacterCount,
+        characterCount: exportsInputCharacterCount,
         errorSummary: errorSummary,
         sectionHeader: sectionHeader,
         saveButtons: saveButtons,
@@ -48,8 +48,8 @@
 @classificationTeamLink = {<a class="govuk-link govuk-link--no-visited-state" target="_blank" href=@appConfig.classificationHelpUrl>@messages("declaration.commodityDetails.how.classificationTeam")</a>}
 
 @commodityDetailsInformation = {
-@Html(messages("declaration.commodityDetails.how.step1", tradeTariffLink))
-@Html(messages("declaration.commodityDetails.how.summary", classificationTeamLink))
+    @Html(messages("declaration.commodityDetails.how.step1", tradeTariffLink))
+    @Html(messages("declaration.commodityDetails.how.summary", classificationTeamLink))
 }
 
 @tariffBodyDesc = { @Html(messages("declaration.type.consignmentTariffText", components.details_content_link())) }
@@ -78,18 +78,12 @@
             content = HtmlContent(commodityDetailsInformation)
         ))
 
-        @govukCharacterCount(CharacterCount(
-            id = "with-hint",
-            name = "with-hint",
-            maxLength = Some(280),
-            label = Label(
-                classes = "govuk-label govuk-label--m",
-              content = Text(messages("declaration.commodityDetails.description.header"))
-            ),
-            hint = Some(Hint(
-              content = Text(messages("declaration.commodityDetails.description.header.hint"))
-            ))
-        ))
+        @characterCount(
+            field = form(CommodityDetails.descriptionOfGoodsKey),
+            labelKey = "declaration.commodityDetails.description.header",
+            hintKey = Some("declaration.commodityDetails.description.header.hint"),
+            maxLength = Some(CommodityDetails.descriptionOfGoodsMaxLength)
+        )
 
         @tariffDetails(messages("declaration.type.consignmentTariff_summary_text"), HtmlContent(tariffBody))
 


### PR DESCRIPTION
The current implementation fails WCAG single A legal requirements because the character limit is not announced at any point or that you have exceeded the count limit. You are only presented with a page error if you exceed the count. The GOV.UK component addresses all these issues and fixes them https://design-system.service.gov.uk/components/character-count/