### PR TITLE
CEDS-2931 Add govuk-link class to all links to correct colour styling

### DIFF
--- a/app/assets/stylesheets/partials/_shame.scss
+++ b/app/assets/stylesheets/partials/_shame.scss
@@ -27,3 +27,7 @@
     font-size: 2.1em;
   }
 }
+
+button.button-link.govuk-link.govuk-link--no-visited-state:focus {
+  background: #fd0!important;
+}

--- a/app/views/components/gds/phaseBanner.scala.html
+++ b/app/views/components/gds/phaseBanner.scala.html
@@ -23,7 +23,7 @@
 
 @backUrl = @{ appConfig.selfBaseUrl.map(url => s"&backUrl=$url${request.uri}").getOrElse("") }
 @betaFeedbackUrl = @{s"${appConfig.giveFeedbackLink}$backUrl"}
-@link = {<a href="@betaFeedbackUrl">@messages("feedback.link")</a>}
+@link = {<a href="@betaFeedbackUrl" class="govuk-link">@messages("feedback.link")</a>}
 
 @feedbackBanner = {
   @Html(messages("feedback", link))

--- a/app/views/components/gds/saveAsDraft.scala.html
+++ b/app/views/components/gds/saveAsDraft.scala.html
@@ -17,4 +17,4 @@
 @import controllers.util.SaveAndReturn
 
 @(messageKey: String = "site.save_and_come_back_later")(implicit messages: Messages)
-<button id="submit_and_return" class="button-link govuk-link govuk-link--no-visited-state" name="@SaveAndReturn.toString">@messages(messageKey)</button>
+<button id="submit_and_return" class="button-link govuk-link govuk-link--no-visited-state focus" name="@SaveAndReturn.toString">@messages(messageKey)</button>

--- a/app/views/declaration/additionalInformtion/additional_information_edit_content.scala.html
+++ b/app/views/declaration/additionalInformtion/additional_information_edit_content.scala.html
@@ -39,7 +39,7 @@
 
 @(mode: Mode, itemId: String, form: Form[AdditionalInformation])(implicit request: JourneyRequest[_], messages: Messages)
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.additionalInformationRequired.hint.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.additionalInformationRequired.hint.link")</a>}
 
 @tariffBody = { @Html(messages("declaration.type.additionalActorsSummaryText", components.details_content_link())) }
 

--- a/app/views/declaration/additionalInformtion/additional_information_required.scala.html
+++ b/app/views/declaration/additionalInformtion/additional_information_required.scala.html
@@ -39,7 +39,7 @@
 
 @(mode: Mode, itemId: String, form: Form[YesNoAnswer])(implicit request: JourneyRequest[_], messages: Messages)
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.additionalInformationRequired.hint.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.additionalInformationRequired.hint.link")</a>}
 
 @govukLayout(
     title = Title("declaration.additionalInformationRequired.title", "declaration.section.5"),

--- a/app/views/declaration/cus_code.scala.html
+++ b/app/views/declaration/cus_code.scala.html
@@ -51,8 +51,8 @@
 
 @tariffBody = { @Html(messages("declaration.cusCode.help.bodyText", components.details_content_link())) }
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.cusCode.header.tradeTariff.link")</a>}
-@ecicsToolLink = {<a target="_blank" href=@appConfig.ecicsToolUrl>@messages("declaration.cusCode.header.ecicsTool.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.cusCode.header.tradeTariff.link")</a>}
+@ecicsToolLink = {<a target="_blank" class="govuk-link" href=@appConfig.ecicsToolUrl>@messages("declaration.cusCode.header.ecicsTool.link")</a>}
 
 @govukLayout(
     title = Title("declaration.cusCode.header", "declaration.section.5"),

--- a/app/views/declaration/documentsProduced/documents_produced_edit_content.scala.html
+++ b/app/views/declaration/documentsProduced/documents_produced_edit_content.scala.html
@@ -42,7 +42,7 @@
 
 @(mode: Mode, itemId: String, form: Form[DocumentsProduced])(implicit request: JourneyRequest[_], messages: Messages)
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.addDocument.hint.traderTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.addDocument.hint.traderTariff.link")</a>}
 
 @tariffBodyDesc = { @Html(messages("declaration.type.consignmentTariffText", components.details_content_link())) }
 

--- a/app/views/declaration/nact_code_add.scala.html
+++ b/app/views/declaration/nact_code_add.scala.html
@@ -42,7 +42,7 @@
 
 @tariffBody = { @Html(messages("declaration.nationalAdditionalCode.help.bodyText", components.details_content_link())) }
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.nationalAdditionalCode.header.tradeTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.nationalAdditionalCode.header.tradeTariff.link")</a>}
 
 @govukLayout(
     title = Title("declaration.nationalAdditionalCode.addnext.header", "declaration.section.5"),

--- a/app/views/declaration/nact_code_add_first.scala.html
+++ b/app/views/declaration/nact_code_add_first.scala.html
@@ -49,7 +49,7 @@
 
 @tariffBody = { @Html(messages("declaration.nationalAdditionalCode.help.bodyText", components.details_content_link())) }
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.nationalAdditionalCode.header.tradeTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.nationalAdditionalCode.header.tradeTariff.link")</a>}
 
 @govukLayout(
     title = Title("declaration.nationalAdditionalCode.addfirst.header", "declaration.section.5"),

--- a/app/views/declaration/not_eligible.scala.html
+++ b/app/views/declaration/not_eligible.scala.html
@@ -29,9 +29,9 @@
 
 @()(implicit request: Request[_], messages: Messages)
 
-@descriptionLink = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu">@messages("notEligible.descriptionLink")</a>}
+@descriptionLink = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu" class="govuk-link">@messages("notEligible.descriptionLink")</a>}
 @supportPhone = {<b>0300 200 3700</b>}
-@enquiriesLink = {<a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries" target="_blank" rel="noopener noreferrer">@messages("general.inquiries.help.link")</a>}
+@enquiriesLink = {<a href="https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries" target="_blank" rel="noopener noreferrer" class="govuk-link">@messages("general.inquiries.help.link")</a>}
 
 @govukLayout(
     title = Title("notEligible.title"),

--- a/app/views/declaration/taric_code_add.scala.html
+++ b/app/views/declaration/taric_code_add.scala.html
@@ -42,7 +42,7 @@
 
 @tariffBody = { @Html(messages("declaration.taricAdditionalCodes.help.bodyText", components.details_content_link())) }
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.taricAdditionalCodes.header.tradeTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.taricAdditionalCodes.header.tradeTariff.link")</a>}
 
 @govukLayout(
     title = Title("declaration.taricAdditionalCodes.addnext.header", "declaration.section.5"),

--- a/app/views/declaration/taric_code_add_first.scala.html
+++ b/app/views/declaration/taric_code_add_first.scala.html
@@ -49,7 +49,7 @@
 
 @tariffBody = { @Html(messages("declaration.taricAdditionalCodes.help.bodyText", components.details_content_link())) }
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.taricAdditionalCodes.header.tradeTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.taricAdditionalCodes.header.tradeTariff.link")</a>}
 
 @govukLayout(
     title = Title("declaration.taricAdditionalCodes.addfirst.header", "declaration.section.5"),

--- a/app/views/declaration/un_dangerous_goods_code.scala.html
+++ b/app/views/declaration/un_dangerous_goods_code.scala.html
@@ -48,7 +48,7 @@
     form: Form[UNDangerousGoodsCode]
 )(implicit request: JourneyRequest[_], messages: Messages)
 
-@tradeTariffLink = {<a target="_blank" href=@appConfig.tradeTariffUrl>@messages("declaration.unDangerousGoodsCode.traderTariff.link")</a>}
+@tradeTariffLink = {<a target="_blank" class="govuk-link" href=@appConfig.tradeTariffUrl>@messages("declaration.unDangerousGoodsCode.traderTariff.link")</a>}
 
 @tariffBody = { @Html(messages("declaration.type.unDangerousGoodsCodeSummaryText", components.details_content_link())) }
 

--- a/test/views/RejectedNotificationErrorsViewSpec.scala
+++ b/test/views/RejectedNotificationErrorsViewSpec.scala
@@ -122,7 +122,7 @@ class RejectedNotificationErrorsViewSpec extends UnitViewSpec with ExportsTestDa
 
         val view: Document = page(declaration, Seq(reason))(request, messages)
 
-        val changeLink = view.getElementsByClass("govuk-link").get(0)
+        val changeLink = view.getElementsByClass("govuk-link").get(1)
 
         changeLink must haveHref(
           controllers.routes.SubmissionsController.amendErrors(declaration.id, reason.url.get, urlPattern, "page-error-message").url

--- a/test/views/declaration/summary/SubmittedDeclarationPageViewSpec.scala
+++ b/test/views/declaration/summary/SubmittedDeclarationPageViewSpec.scala
@@ -45,7 +45,7 @@ class SubmittedDeclarationPageViewSpec extends UnitViewSpec with Stubs with Expo
     val filter = new Predicate[Element] {
       override def test(elm: Element): Boolean =
         elm.text().contains("Print") || elm.text().contains("feedback") ||
-        elm.text().contains("Sign out") || elm.text().contains("page not working")
+          elm.text().contains("Sign out") || elm.text().contains("page not working")
     }
     allLinks.removeIf(filter)
     allLinks

--- a/test/views/declaration/summary/SubmittedDeclarationPageViewSpec.scala
+++ b/test/views/declaration/summary/SubmittedDeclarationPageViewSpec.scala
@@ -44,7 +44,8 @@ class SubmittedDeclarationPageViewSpec extends UnitViewSpec with Stubs with Expo
 
     val filter = new Predicate[Element] {
       override def test(elm: Element): Boolean =
-        elm.text().contains("Print") || elm.text().contains("Sign out") || elm.text().contains("page not working")
+        elm.text().contains("Print") || elm.text().contains("feedback") ||
+        elm.text().contains("Sign out") || elm.text().contains("page not working")
     }
     allLinks.removeIf(filter)
     allLinks
@@ -52,12 +53,12 @@ class SubmittedDeclarationPageViewSpec extends UnitViewSpec with Stubs with Expo
 
   "Summary page" should {
 
-    "should display correct title" in {
+    "display correct title" in {
 
       createView().getElementById("title").text() mustBe messages("declaration.summary.submitted-header")
     }
 
-    "should display correct back link" in {
+    "display correct back link" in {
 
       val backButton = createView().getElementById("back-link")
 


### PR DESCRIPTION
Also done:
- updated CSS for the Save and come back later button styled as a link, so the focus state complies to recommended standards

## Before
<img width="496" alt="Screenshot 2021-01-14 at 14 09 48" src="https://user-images.githubusercontent.com/1692222/104601996-d2555400-5672-11eb-82f7-4b41f95ea334.png">
<img width="673" alt="Screenshot 2021-01-14 at 13 22 42" src="https://user-images.githubusercontent.com/1692222/104602018-daad8f00-5672-11eb-8499-7df4e7fa2417.png">
<img width="685" alt="Screenshot 2021-01-14 at 13 22 33" src="https://user-images.githubusercontent.com/1692222/104602048-e1d49d00-5672-11eb-967a-806f53b35b7c.png">

## After
<img width="544" alt="Screenshot 2021-01-14 at 14 09 23" src="https://user-images.githubusercontent.com/1692222/104602070-e7ca7e00-5672-11eb-92f8-a2c867dfdab4.png">
<img width="598" alt="Screenshot 2021-01-14 at 13 22 14" src="https://user-images.githubusercontent.com/1692222/104602085-ed27c880-5672-11eb-8cdb-d7d0850fc487.png">
<img width="762" alt="Screenshot 2021-01-14 at 13 22 04" src="https://user-images.githubusercontent.com/1692222/104602103-f3b64000-5672-11eb-9266-606a4aa9c57a.png">
