### PR TITLE
CEDS-2977_Implement_verified_email_check

### DIFF
--- a/app/config/AppConfig.scala
+++ b/app/config/AppConfig.scala
@@ -64,6 +64,8 @@ class AppConfig @Inject()(
 
   lazy val customsDeclareExportsBaseUrl = servicesConfig.baseUrl("customs-declare-exports")
 
+  lazy val emailFrontendUrl: String = loadConfig("urls.emailFrontendUrl")
+
   lazy val selfBaseUrl: Option[String] = runModeConfiguration.getOptional[String]("platform.frontend.host")
   lazy val giveFeedbackLink = {
     val contactFrontendUrl = loadConfig("microservice.services.contact-frontend.url")
@@ -95,6 +97,11 @@ class AppConfig @Inject()(
   lazy val fetchMrnStatus = servicesConfig.getConfString(
     "customs-declare-exports.fetch-ead",
     throw new IllegalStateException("Missing configuration for Customs Declaration Export fetch mrn status URI")
+  )
+
+  lazy val fetchVerifiedEmail = servicesConfig.getConfString(
+    "customs-declare-exports.fetch-verified-email",
+    throw new IllegalStateException("Missing configuration for Customs Declaration Exports fetch verified email URI")
   )
 
   lazy val languageTranslationEnabled =

--- a/app/controllers/ChoiceController.scala
+++ b/app/controllers/ChoiceController.scala
@@ -16,10 +16,11 @@
 
 package controllers
 
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, VerifiedEmailAction}
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
 import forms.Choice._
+
 import javax.inject.Inject
 import play.api.data.Form
 import play.api.i18n.I18nSupport
@@ -27,10 +28,14 @@ import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.choice_page
 
-class ChoiceController @Inject()(authenticate: AuthAction, mcc: MessagesControllerComponents, choicePage: choice_page)
-    extends FrontendController(mcc) with I18nSupport {
+class ChoiceController @Inject()(
+  authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
+  mcc: MessagesControllerComponents,
+  choicePage: choice_page
+) extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(previousChoice: Option[Choice]): Action[AnyContent] = authenticate { implicit request =>
+  def displayPage(previousChoice: Option[Choice]): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     def pageForPreviousChoice(previousChoice: Option[Choice]) = {
       val form = Choice.form()
       choicePage(previousChoice.fold(form)(form.fill))
@@ -38,7 +43,7 @@ class ChoiceController @Inject()(authenticate: AuthAction, mcc: MessagesControll
     Ok(pageForPreviousChoice(previousChoice))
   }
 
-  def submitChoice(): Action[AnyContent] = authenticate { implicit request =>
+  def submitChoice(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/RejectedNotificationsController.scala
+++ b/app/controllers/RejectedNotificationsController.scala
@@ -17,7 +17,8 @@
 package controllers
 
 import connectors.CustomsDeclareExportsConnector
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, VerifiedEmailAction}
+
 import javax.inject.{Inject, Singleton}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -30,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class RejectedNotificationsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   mcc: MessagesControllerComponents,
   rejectedReasons: RejectionReasons,
@@ -37,7 +39,7 @@ class RejectedNotificationsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(id: String): Action[AnyContent] = authenticate.async { implicit request =>
+  def displayPage(id: String): Action[AnyContent] = (authenticate andThen verifyEmail).async { implicit request =>
     customsDeclareExportsConnector.findDeclaration(id).flatMap {
       case Some(declaration) =>
         customsDeclareExportsConnector.findNotifications(id).map { notifications =>

--- a/app/controllers/RemoveSavedDeclarationsController.scala
+++ b/app/controllers/RemoveSavedDeclarationsController.scala
@@ -18,8 +18,9 @@ package controllers
 
 import config.AppConfig
 import connectors.CustomsDeclareExportsConnector
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, VerifiedEmailAction}
 import forms.RemoveDraftDeclaration.form
+
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -30,6 +31,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RemoveSavedDeclarationsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   mcc: MessagesControllerComponents,
   removeDeclarationPage: remove_declaration,
@@ -37,14 +39,14 @@ class RemoveSavedDeclarationsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(id: String): Action[AnyContent] = authenticate.async { implicit request =>
+  def displayPage(id: String): Action[AnyContent] = (authenticate andThen verifyEmail).async { implicit request =>
     customsDeclareExportsConnector.findDeclaration(id) flatMap {
       case Some(declaration) => Future.successful(Ok(removeDeclarationPage(declaration, form)))
       case _                 => Future.successful(Redirect(controllers.routes.SavedDeclarationsController.displayDeclarations()))
     }
   }
 
-  def removeDeclaration(id: String): Action[AnyContent] = authenticate.async { implicit request =>
+  def removeDeclaration(id: String): Action[AnyContent] = (authenticate andThen verifyEmail).async { implicit request =>
     val removeAction = form.bindFromRequest()
 
     removeAction

--- a/app/controllers/UnverifiedEmailController.scala
+++ b/app/controllers/UnverifiedEmailController.scala
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers
+
+import config.AppConfig
+import controllers.actions.AuthAction
+import play.api.i18n.I18nSupport
+import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+import views.html.unverified_email
+
+import javax.inject.{Inject, Singleton}
+
+@Singleton
+class UnverifiedEmailController @Inject()(
+  authenticate: AuthAction,
+  mcc: MessagesControllerComponents,
+  unverified_email: unverified_email,
+  appConfig: AppConfig
+) extends FrontendController(mcc) with I18nSupport {
+
+  val informUser: Action[AnyContent] = authenticate { implicit req =>
+    Ok(unverified_email(appConfig.emailFrontendUrl))
+  }
+}

--- a/app/controllers/actions/ItemAction.scala
+++ b/app/controllers/actions/ItemAction.scala
@@ -37,7 +37,9 @@ case class ItemAction(itemId: String)(implicit val executionContext: ExecutionCo
     }
 }
 
-class ItemActionBuilder @Inject()(authorized: AuthAction, journeyAction: JourneyAction)(implicit val executionContext: ExecutionContext) {
+class ItemActionBuilder @Inject()(authorized: AuthAction, verifyEmail: VerifiedEmailAction, journeyAction: JourneyAction)(
+  implicit val executionContext: ExecutionContext
+) {
 
-  def apply(itemId: String) = authorized andThen journeyAction andThen ItemAction(itemId)
+  def apply(itemId: String) = authorized andThen verifyEmail andThen journeyAction andThen ItemAction(itemId)
 }

--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import com.google.inject.Inject
 import models.DeclarationType.DeclarationType
-import models.requests.{AuthenticatedRequest, JourneyRequest}
+import models.requests.{JourneyRequest, VerifiedEmailRequest}
 import play.api.Logger
 import play.api.mvc.{ActionRefiner, Result, Results}
 import services.cache.ExportsCacheService
@@ -28,13 +28,13 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 class JourneyAction @Inject()(cacheService: ExportsCacheService)(implicit val exc: ExecutionContext)
-    extends ActionRefiner[AuthenticatedRequest, JourneyRequest] {
+    extends ActionRefiner[VerifiedEmailRequest, JourneyRequest] {
 
   private val logger = Logger(this.getClass)
 
   override protected def executionContext: ExecutionContext = exc
 
-  private def refiner[A](request: AuthenticatedRequest[A], types: Seq[DeclarationType]): Future[Either[Result, JourneyRequest[A]]] = {
+  private def refiner[A](request: VerifiedEmailRequest[A], types: Seq[DeclarationType]): Future[Either[Result, JourneyRequest[A]]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
     request.declarationId match {
       case Some(id) =>
@@ -49,14 +49,14 @@ class JourneyAction @Inject()(cacheService: ExportsCacheService)(implicit val ex
         Future.successful(Left(Results.Redirect(controllers.routes.StartController.displayStartPage())))
     }
   }
-  override def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, JourneyRequest[A]]] =
+  override def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, JourneyRequest[A]]] =
     refiner(request, Seq.empty[DeclarationType])
 
-  def apply(type1: DeclarationType, others: DeclarationType*): ActionRefiner[AuthenticatedRequest, JourneyRequest] = apply(others.toSeq.+:(type1))
+  def apply(type1: DeclarationType, others: DeclarationType*): ActionRefiner[VerifiedEmailRequest, JourneyRequest] = apply(others.toSeq.+:(type1))
 
-  def apply(types: Seq[DeclarationType]): ActionRefiner[AuthenticatedRequest, JourneyRequest] =
-    new ActionRefiner[AuthenticatedRequest, JourneyRequest] {
-      override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, JourneyRequest[A]]] = refiner(request, types)
+  def apply(types: Seq[DeclarationType]): ActionRefiner[VerifiedEmailRequest, JourneyRequest] =
+    new ActionRefiner[VerifiedEmailRequest, JourneyRequest] {
+      override protected def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, JourneyRequest[A]]] = refiner(request, types)
       override protected def executionContext: ExecutionContext = exc
     }
 }

--- a/app/controllers/actions/VerifiedEmailAction.scala
+++ b/app/controllers/actions/VerifiedEmailAction.scala
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package controllers.actions
+
+import com.google.inject.ImplementedBy
+import connectors.CustomsDeclareExportsConnector
+import controllers.routes
+import models.requests.{AuthenticatedRequest, VerifiedEmailRequest}
+import models.EORI
+import play.api.mvc.{ActionRefiner, MessagesControllerComponents, Result}
+import play.api.mvc.Results.Redirect
+import uk.gov.hmrc.http.HeaderCarrier
+import uk.gov.hmrc.play.HeaderCarrierConverter
+
+import javax.inject.{Inject, Singleton}
+import scala.concurrent.{ExecutionContext, Future}
+
+@ImplementedBy(classOf[VerifiedEmailActionImpl])
+trait VerifiedEmailAction extends ActionRefiner[AuthenticatedRequest, VerifiedEmailRequest]
+
+@Singleton
+class VerifiedEmailActionImpl @Inject()(backendConnector: CustomsDeclareExportsConnector, mcc: MessagesControllerComponents)
+    extends VerifiedEmailAction {
+
+  implicit val executionContext: ExecutionContext = mcc.executionContext
+  private lazy val onError = Redirect(routes.UnverifiedEmailController.informUser)
+
+  override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] = {
+
+    val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
+
+    backendConnector.getVerifiedEmailAddress(EORI(request.user.eori))(hc, executionContext).map { maybeVerifiedEmail =>
+      maybeVerifiedEmail
+        .map(verifiedEmail => VerifiedEmailRequest(request, verifiedEmail.address))
+        .toRight(onError)
+    }
+  }
+}

--- a/app/controllers/declaration/AdditionalActorsRemoveController.scala
+++ b/app/controllers/declaration/AdditionalActorsRemoveController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarationAdditionalActors
+
 import javax.inject.Inject
 import models.declaration.DeclarationAdditionalActorsData
 import models.requests.JourneyRequest
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalActorsRemoveController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,14 +47,14 @@ class AdditionalActorsRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     findActor(id) match {
       case Some(actor) => Ok(removePage(mode, id, actor, removeYesNoForm.withSubmissionErrors()))
       case _           => navigator.continueTo(mode, routes.AdditionalActorsSummaryController.displayPage)
     }
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     findActor(id) match {
       case Some(actor) =>
         removeYesNoForm

--- a/app/controllers/declaration/AdditionalActorsSummaryController.scala
+++ b/app/controllers/declaration/AdditionalActorsSummaryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.{DeclarationType, Mode}
 import play.api.data.Form
@@ -31,6 +32,7 @@ import views.html.declaration.additionalActors.additional_actors_summary
 
 class AdditionalActorsSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +43,7 @@ class AdditionalActorsSummaryController @Inject()(
   val validTypes =
     Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
     request.cacheModel.parties.declarationAdditionalActorsData match {
       case Some(data) if data.actors.nonEmpty =>
         Ok(additionalActorsPage(mode, anotherYesNoForm.withSubmissionErrors(), data.actors))
@@ -49,7 +51,7 @@ class AdditionalActorsSummaryController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val actors = request.cacheModel.parties.declarationAdditionalActorsData.map(_.actors).getOrElse(Seq.empty)
     anotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.AdditionalDeclarationType
 import forms.declaration.additionaldeclarationtype._
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalDeclarationTypeController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +43,7 @@ class AdditionalDeclarationTypeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val form = extractFormType(request).form().withSubmissionErrors()
     request.cacheModel.additionalDeclarationType match {
       case Some(data) => Ok(declarationTypePage(mode, form.fill(data)))
@@ -49,7 +51,7 @@ class AdditionalDeclarationTypeController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val decType = extractFormType(request).form().bindFromRequest()
 
     decType

--- a/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
@@ -16,13 +16,14 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.declaration.AdditionalFiscalReferencesAddController.AdditionalFiscalReferencesFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.AdditionalFiscalReference.form
 import forms.declaration.AdditionalFiscalReferencesData._
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalFiscalReferencesAddController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,12 +47,12 @@ class AdditionalFiscalReferencesAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     Ok(additionalFiscalReferencesPage(mode, itemId, frm))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = form().bindFromRequest()
 
     boundForm.fold(

--- a/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper.remove
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalFiscalReferencesRemoveController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,33 +47,34 @@ class AdditionalFiscalReferencesRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    findAdditionalFiscalReference(itemId, id) match {
-      case Some(reference) => Ok(removePage(mode, itemId, id, reference, removalYesNoForm.withSubmissionErrors()))
-      case _               => returnToSummary(mode, itemId)
-    }
+  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      findAdditionalFiscalReference(itemId, id) match {
+        case Some(reference) => Ok(removePage(mode, itemId, id, reference, removalYesNoForm.withSubmissionErrors()))
+        case _               => returnToSummary(mode, itemId)
+      }
   }
 
-  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    findAdditionalFiscalReference(itemId, id) match {
-      case Some(reference) =>
-        removalYesNoForm
-          .bindFromRequest()
-          .fold(
-            (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(removePage(mode, itemId, id, reference, formWithErrors))),
-            formData => {
-              formData.answer match {
-                case YesNoAnswers.yes =>
-                  removeAdditionalFiscalReference(itemId, reference)
-                    .map(declaration => redirectAfterRemove(mode, itemId, declaration))
-                case YesNoAnswers.no =>
-                  Future.successful(returnToSummary(mode, itemId))
+  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
+    implicit request =>
+      findAdditionalFiscalReference(itemId, id) match {
+        case Some(reference) =>
+          removalYesNoForm
+            .bindFromRequest()
+            .fold(
+              (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(removePage(mode, itemId, id, reference, formWithErrors))),
+              formData => {
+                formData.answer match {
+                  case YesNoAnswers.yes =>
+                    removeAdditionalFiscalReference(itemId, reference)
+                      .map(declaration => redirectAfterRemove(mode, itemId, declaration))
+                  case YesNoAnswers.no =>
+                    Future.successful(returnToSummary(mode, itemId))
+                }
               }
-            }
-          )
-      case _ => Future.successful(returnToSummary(mode, itemId))
-    }
-
+            )
+        case _ => Future.successful(returnToSummary(mode, itemId))
+      }
   }
 
   private def removalYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.additionalFiscalReferences.remove.empty")
@@ -101,5 +104,4 @@ class AdditionalFiscalReferencesRemoveController @Inject()(
       model.updatedItem(itemId, item => item.copy(additionalFiscalReferencesData = Some(updatedInformation)))
     })
   }
-
 }

--- a/app/controllers/declaration/AdditionalInformationAddController.scala
+++ b/app/controllers/declaration/AdditionalInformationAddController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
+
 import javax.inject.Inject
 import models.declaration.AdditionalInformationData
 import models.declaration.AdditionalInformationData.maxNumberOfItems
@@ -38,6 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationAddController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,11 +48,11 @@ class AdditionalInformationAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     Ok(additionalInformationPage(mode, itemId, form().withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = form().bindFromRequest()
 
     boundForm.fold(

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.Mode
 import models.requests.JourneyRequest
@@ -32,6 +33,7 @@ import views.html.declaration.additionalInformation.additional_information
 
 class AdditionalInformationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -39,7 +41,7 @@ class AdditionalInformationController @Inject()(
   additionalInformationPage: additional_information
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = anotherYesNoForm.withSubmissionErrors()
     cachedAdditionalInformationData(itemId) match {
       case Some(data) if data.items.nonEmpty =>
@@ -51,7 +53,7 @@ class AdditionalInformationController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     anotherYesNoForm
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.CommodityDetails
 import forms.declaration.CommodityDetails.form
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class CommodityDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class CommodityDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form(request.declarationType).withSubmissionErrors()
     request.cacheModel.itemBy(itemId).flatMap(_.commodityDetails) match {
       case Some(commodityDetails) => Ok(commodityDetailsPage(mode, itemId, frm.fill(commodityDetails)))
@@ -50,7 +52,7 @@ class CommodityDetailsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form(request.declarationType)
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CommodityMeasureController.scala
+++ b/app/controllers/declaration/CommodityMeasureController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.CommodityMeasure
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class CommodityMeasureController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,14 +45,14 @@ class CommodityMeasureController @Inject()(
 
   private def form()(implicit request: JourneyRequest[_]) = CommodityMeasure.form(request.declarationType).withSubmissionErrors()
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.commodityMeasure) match {
       case Some(data) => Ok(commodityMeasurePage(mode, itemId, form().fill(data)))
       case _          => Ok(commodityMeasurePage(mode, itemId, form()))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ConfirmationController.scala
+++ b/app/controllers/declaration/ConfirmationController.scala
@@ -16,7 +16,8 @@
 
 package controllers.declaration
 
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, VerifiedEmailAction}
+
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -25,16 +26,17 @@ import views.html.declaration.{draft_confirmation_page, submission_confirmation_
 
 class ConfirmationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   mcc: MessagesControllerComponents,
   submissionConfirmationPage: submission_confirmation_page,
   draftConfirmationPage: draft_confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
-  def displaySubmissionConfirmation(): Action[AnyContent] = authenticate { implicit request =>
+  def displaySubmissionConfirmation(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     Ok(submissionConfirmationPage())
   }
 
-  def displayDraftConfirmation(): Action[AnyContent] = authenticate { implicit request =>
+  def displayDraftConfirmation(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     Ok(draftConfirmationPage())
   }
 }

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.ConsigneeDetails
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -36,6 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class ConsigneeDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +46,7 @@ class ConsigneeDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = ConsigneeDetails.form().withSubmissionErrors()
     request.cacheModel.parties.consigneeDetails match {
       case Some(data) => Ok(consigneeDetailsPage(mode, frm.fill(data)))
@@ -52,7 +54,7 @@ class ConsigneeDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     ConsigneeDetails
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.ConsignmentReferences
 import forms.declaration.ConsignmentReferences.form
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentReferencesController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class ConsignmentReferencesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.consignmentReferences match {
       case Some(data) => Ok(consignmentReferencesPage(mode, frm.fill(data)))
@@ -50,7 +52,7 @@ class ConsignmentReferencesController @Inject()(
     }
   }
 
-  def submitConsignmentReferences(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitConsignmentReferences(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(
@@ -71,5 +73,4 @@ class ConsignmentReferencesController @Inject()(
     updateExportsDeclarationSyncDirect(model => {
       model.copy(consignmentReferences = Some(formData))
     })
-
 }

--- a/app/controllers/declaration/ConsignorDetailsController.scala
+++ b/app/controllers/declaration/ConsignorDetailsController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.consignor.ConsignorDetails
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignorDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +45,7 @@ class ConsignorDetailsController @Inject()(
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
     val frm = ConsignorDetails.form().withSubmissionErrors()
     request.cacheModel.parties.consignorDetails match {
       case Some(data) => Ok(consignorDetailsPage(mode, frm.fill(data)))
@@ -51,7 +53,7 @@ class ConsignorDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
     ConsignorDetails
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/ConsignorEoriNumberController.scala
+++ b/app/controllers/declaration/ConsignorEoriNumberController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.consignor.ConsignorEoriNumber.form
 import forms.declaration.consignor.{ConsignorDetails, ConsignorEoriNumber}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignorEoriNumberController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -45,7 +47,7 @@ class ConsignorEoriNumberController @Inject()(
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.consignorDetails match {
       case Some(data) => Ok(consignorEoriDetailsPage(mode, frm.fill(ConsignorEoriNumber(data))))
@@ -53,7 +55,7 @@ class ConsignorEoriNumberController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/DeclarantExporterController.scala
+++ b/app/controllers/declaration/DeclarantExporterController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.DeclarantIsExporter
 import forms.declaration.DeclarantIsExporter.form
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarantExporterController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +43,7 @@ class DeclarantExporterController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.declarantIsExporter match {
       case Some(data) => Ok(declarantExporterPage(mode, frm.fill(data)))
@@ -49,7 +51,7 @@ class DeclarantExporterController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(
@@ -79,6 +81,5 @@ class DeclarantExporterController @Inject()(
         model.copy(parties = model.parties.copy(declarantIsExporter = Some(answer), exporterDetails = None, representativeDetails = None))
       } else
         model.copy(parties = model.parties.copy(declarantIsExporter = Some(answer)))
-
     })
 }

--- a/app/controllers/declaration/DeclarationHolderAddController.scala
+++ b/app/controllers/declaration/DeclarationHolderAddController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util._
 import controllers.util.DeclarationHolderHelper._
 import forms.declaration.DeclarationHolder
 import forms.declaration.DeclarationHolder.form
+
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationHolderAddController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,11 +47,11 @@ class DeclarationHolderAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     Ok(declarationHolderPage(mode, form.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
     boundForm.fold(formWithErrors => {
       Future.successful(BadRequest(declarationHolderPage(mode, formWithErrors)))

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper._
 import controllers.util.MultipleItemsHelper
 import forms.declaration.DeclarationHolder
 import forms.declaration.DeclarationHolder.form
+
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationHolderChangeController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,12 +47,12 @@ class DeclarationHolderChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val holder = DeclarationHolder.fromId(id)
     Ok(declarationHolderChangePage(mode, id, form.fill(holder).withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
     boundForm.fold(
       formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, id, formWithErrors))),

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.DeclarationType.{SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
@@ -34,6 +35,7 @@ import views.html.declaration.declarationHolder.declaration_holder_summary
 
 class DeclarationHolderController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,13 +43,13 @@ class DeclarationHolderController @Inject()(
   declarationHolderPage: declaration_holder_summary
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val holders = cachedHolders
     if (holders.isEmpty) navigator.continueTo(mode, nextPageWhenNoHolders)
     else Ok(declarationHolderPage(mode, addAnotherYesNoForm.withSubmissionErrors(), holders))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val holders = cachedHolders
     addAnotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/DeclarationHolderRemoveController.scala
+++ b/app/controllers/declaration/DeclarationHolderRemoveController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarationHolder
+
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
@@ -31,12 +32,13 @@ import play.api.mvc._
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_remove
-import scala.concurrent.{ExecutionContext, Future}
 
+import scala.concurrent.{ExecutionContext, Future}
 import controllers.util.DeclarationHolderHelper
 
 class DeclarationHolderRemoveController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,12 +47,12 @@ class DeclarationHolderRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val holder = DeclarationHolder.fromId(id)
     Ok(holderRemovePage(mode, holder, removeYesNoForm.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val holderToRemove = DeclarationHolder.fromId(id)
     removeYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/DestinationCountryController.scala
+++ b/app/controllers/declaration/DestinationCountryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.countries.Countries
 import forms.declaration.countries.Countries.DestinationCountryPage
+
 import javax.inject.{Inject, Singleton}
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class DestinationCountryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class DestinationCountryController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val form = (request.cacheModel.locations.destinationCountry match {
       case Some(destinationCountry) =>
         Countries.form(DestinationCountryPage).fill(destinationCountry)
@@ -52,7 +54,7 @@ class DestinationCountryController @Inject()(
     Ok(destinationCountryPage(mode, form))
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     Countries
       .form(DestinationCountryPage)
       .bindFromRequest()

--- a/app/controllers/declaration/DispatchLocationController.scala
+++ b/app/controllers/declaration/DispatchLocationController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.DispatchLocation
 import forms.declaration.DispatchLocation.AllowedDispatchLocations
+
 import javax.inject.Inject
 import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.{ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DispatchLocationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class DispatchLocationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = DispatchLocation.form().withSubmissionErrors()
     request.cacheModel.dispatchLocation match {
       case Some(data) => Ok(dispatchLocationPage(mode, frm.fill(data)))
@@ -50,7 +52,7 @@ class DispatchLocationController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     DispatchLocation
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/DocumentsProducedAddController.scala
+++ b/app/controllers/declaration/DocumentsProducedAddController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.declaration.DocumentsProducedAddController.DocumentsProducedFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.additionaldocuments.DocumentsProduced
 import forms.declaration.additionaldocuments.DocumentsProduced.{form, globalErrors}
+
 import javax.inject.Inject
 import models.declaration.DocumentsProducedData
 import models.declaration.DocumentsProducedData.maxNumberOfItems
@@ -38,6 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DocumentsProducedAddController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,11 +48,11 @@ class DocumentsProducedAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     Ok(documentProducedPage(mode, itemId, form().withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = globalErrors(form().bindFromRequest())
 
     boundForm.fold(

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.Mode
 import models.requests.JourneyRequest
@@ -32,6 +33,7 @@ import views.html.declaration.documentsProduced.documents_produced
 
 class DocumentsProducedController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -39,7 +41,7 @@ class DocumentsProducedController @Inject()(
   documentProducedPage: documents_produced
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = anotherYesNoForm.withSubmissionErrors()
     cachedDocuments(itemId) match {
       case documents if documents.nonEmpty => Ok(documentProducedPage(mode, itemId, frm, documents))
@@ -47,7 +49,7 @@ class DocumentsProducedController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     anotherYesNoForm
       .bindFromRequest()
       .fold(
@@ -64,5 +66,4 @@ class DocumentsProducedController @Inject()(
 
   private def cachedDocuments(itemId: String)(implicit request: JourneyRequest[AnyContent]) =
     request.cacheModel.itemBy(itemId).flatMap(_.documentsProducedData).map(_.documents).getOrElse(Seq.empty)
-
 }

--- a/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
+++ b/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -35,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class EntryIntoDeclarantsRecordsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +44,7 @@ class EntryIntoDeclarantsRecordsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.isEntryIntoDeclarantsRecords match {
       case Some(data) => Ok(entryIntoDeclarantsRecordsPage(mode, frm.fill(data)))
@@ -51,7 +52,7 @@ class EntryIntoDeclarantsRecordsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(
@@ -75,5 +76,4 @@ class EntryIntoDeclarantsRecordsController @Inject()(
       controllers.declaration.routes.PersonPresentingGoodsDetailsController.displayPage
     else
       controllers.declaration.routes.DeclarantDetailsController.displayPage
-
 }

--- a/app/controllers/declaration/ExporterDetailsController.scala
+++ b/app/controllers/declaration/ExporterDetailsController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.exporter.ExporterDetails
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ExporterDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +43,7 @@ class ExporterDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.exporterDetails match {
       case Some(data) => Ok(exporterDetailsPage(mode, frm.fill(data)))
@@ -49,7 +51,7 @@ class ExporterDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ExporterEoriNumberController.scala
+++ b/app/controllers/declaration/ExporterEoriNumberController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.exporter.{ExporterDetails, ExporterEoriNumber}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ExporterEoriNumberController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -42,7 +44,7 @@ class ExporterEoriNumberController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = ExporterEoriNumber.form().withSubmissionErrors()
     request.cacheModel.parties.exporterDetails match {
       case Some(data) => Ok(exporterEoriDetailsPage(mode, frm.fill(ExporterEoriNumber(data))))
@@ -50,7 +52,7 @@ class ExporterEoriNumberController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     ExporterEoriNumber
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/InlandTransportDetailsController.scala
+++ b/app/controllers/declaration/InlandTransportDetailsController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.InlandModeOfTransportCode
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class InlandTransportDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -45,7 +47,7 @@ class InlandTransportDetailsController @Inject()(
 
   private val validJourneys = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.inlandModeOfTransportCode match {
       case Some(data) => Ok(inlandTransportDetailsPage(mode, frm.fill(data)))
@@ -53,7 +55,7 @@ class InlandTransportDetailsController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     InlandModeOfTransportCode
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/IsExsController.scala
+++ b/app/controllers/declaration/IsExsController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{IsExs, UNDangerousGoodsCode}
+
 import javax.inject.Inject
 import models.DeclarationType.{CLEARANCE, DeclarationType}
 import models.declaration.{ExportItem, Parties}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class IsExsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,7 +47,7 @@ class IsExsController @Inject()(
 
   private val allowedJourney: DeclarationType = CLEARANCE
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(allowedJourney)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(allowedJourney)) { implicit request =>
     val frm = IsExs.form.withSubmissionErrors()
     request.cacheModel.parties.isExs match {
       case Some(data) => Ok(isExsPage(mode, frm.fill(data)))
@@ -53,7 +55,7 @@ class IsExsController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(allowedJourney)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(allowedJourney)).async { implicit request =>
     IsExs.form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ItemsSummaryController.scala
+++ b/app/controllers/declaration/ItemsSummaryController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.{FormAction, SaveAndReturn}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.declaration.ExportItem
 import models.requests.JourneyRequest
@@ -36,6 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class ItemsSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -50,14 +52,14 @@ class ItemsSummaryController @Inject()(
   private def itemSummaryForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.itemsSummary.addAnotherItem.error.empty")
   private def removeItemForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.itemsRemove.error.empty")
 
-  def displayAddItemPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayAddItemPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     if (request.cacheModel.items.isEmpty)
       Ok(addItemPage(mode))
     else
       navigator.continueTo(mode, controllers.declaration.routes.ItemsSummaryController.displayItemsSummaryPage)
   }
 
-  def addFirstItem(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def addFirstItem(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val actionTypeOpt = FormAction.bindFromRequest()
 
     actionTypeOpt match {
@@ -68,7 +70,7 @@ class ItemsSummaryController @Inject()(
     }
   }
 
-  def displayItemsSummaryPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def displayItemsSummaryPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     removeEmptyItems().map(updatedModel => {
       updatedModel.fold(navigator.continueTo(mode, controllers.declaration.routes.ItemsSummaryController.displayAddItemPage))(
         model =>
@@ -81,7 +83,7 @@ class ItemsSummaryController @Inject()(
   }
 
   //TODO Should we add validation for POST without items?
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val incorrectItems: Seq[FormError] = buildIncorrectItemsErrors(request)
 
     itemSummaryForm
@@ -134,14 +136,15 @@ class ItemsSummaryController @Inject()(
     exportsCacheService.update(request.cacheModel.copy(items = itemsWithAnswers))
   }
 
-  def displayRemoveItemConfirmationPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    request.cacheModel.itemBy(itemId) match {
-      case Some(item) => Ok(removeItemPage(mode, removeItemForm, item))
-      case None       => navigator.continueTo(mode, routes.ItemsSummaryController.displayItemsSummaryPage)
-    }
+  def displayRemoveItemConfirmationPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      request.cacheModel.itemBy(itemId) match {
+        case Some(item) => Ok(removeItemPage(mode, removeItemForm, item))
+        case None       => navigator.continueTo(mode, routes.ItemsSummaryController.displayItemsSummaryPage)
+      }
   }
 
-  def removeItem(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def removeItem(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     removeItemForm
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/LocationController.scala
+++ b/app/controllers/declaration/LocationController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.GoodsLocationForm
+
 import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
@@ -32,6 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class LocationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   mcc: MessagesControllerComponents,
   goodsLocationPage: goods_location,
@@ -41,7 +43,7 @@ class LocationController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
   import forms.declaration.GoodsLocationForm._
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.goodsLocation match {
       case Some(data) => Ok(goodsLocationPage(mode, frm.fill(data.toForm)))
@@ -49,7 +51,7 @@ class LocationController @Inject()(
     }
   }
 
-  def saveLocation(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveLocation(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/NatureOfTransactionController.scala
+++ b/app/controllers/declaration/NatureOfTransactionController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.NatureOfTransaction
 import forms.declaration.NatureOfTransaction._
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class NatureOfTransactionController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -42,7 +44,7 @@ class NatureOfTransactionController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.natureOfTransaction match {
       case Some(data) => Ok(natureOfTransactionPage(mode, frm.fill(data)))
@@ -50,7 +52,7 @@ class NatureOfTransactionController @Inject()(
     }
   }
 
-  def saveTransactionType(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveTransactionType(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form().bindFromRequest
       .fold(
         (formWithErrors: Form[NatureOfTransaction]) => Future.successful(BadRequest(natureOfTransactionPage(mode, formWithErrors))),

--- a/app/controllers/declaration/NotEligibleController.scala
+++ b/app/controllers/declaration/NotEligibleController.scala
@@ -16,7 +16,8 @@
 
 package controllers.declaration
 
-import controllers.actions.AuthAction
+import controllers.actions.{AuthAction, VerifiedEmailAction}
+
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -25,16 +26,17 @@ import views.html.declaration.{not_declarant, not_eligible}
 
 class NotEligibleController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   mcc: MessagesControllerComponents,
   notEligiblePage: not_eligible,
   notDeclarantPage: not_declarant
 ) extends FrontendController(mcc) with I18nSupport {
 
-  def displayNotEligible(): Action[AnyContent] = authenticate { implicit request =>
+  def displayNotEligible(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     Ok(notEligiblePage())
   }
 
-  def displayNotDeclarant(): Action[AnyContent] = authenticate { implicit request =>
+  def displayNotDeclarant(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
     Ok(notDeclarantPage())
   }
 

--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.officeOfExit.OfficeOfExitInsideUK.form
 import forms.declaration.officeOfExit.{AllowedUKOfficeOfExitAnswers, OfficeOfExit, OfficeOfExitInsideUK}
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class OfficeOfExitController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -43,7 +45,7 @@ class OfficeOfExitController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.officeOfExit match {
       case Some(data) =>
@@ -52,7 +54,7 @@ class OfficeOfExitController @Inject()(
     }
   }
 
-  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/OfficeOfExitOutsideUkController.scala
+++ b/app/controllers/declaration/OfficeOfExitOutsideUkController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.officeOfExit.OfficeOfExitOutsideUK.form
 import forms.declaration.officeOfExit.{OfficeOfExit, OfficeOfExitOutsideUK}
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class OfficeOfExitOutsideUkController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -43,7 +45,7 @@ class OfficeOfExitOutsideUkController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.officeOfExit match {
       case Some(data) => Ok(officeOfExitOutsideUkPage(mode, frm.fill(OfficeOfExitOutsideUK(data))))
@@ -51,7 +53,7 @@ class OfficeOfExitOutsideUkController @Inject()(
     }
   }
 
-  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/OriginationCountryController.scala
+++ b/app/controllers/declaration/OriginationCountryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.countries.Countries
 import forms.declaration.countries.Countries.OriginationCountryPage
+
 import javax.inject.{Inject, Singleton}
 import models.{DeclarationType, Mode}
 import play.api.i18n.I18nSupport
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 @Singleton
 class OriginationCountryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +45,7 @@ class OriginationCountryController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
     val form = (request.cacheModel.locations.originationCountry match {
       case Some(originateCountry) =>
         Countries.form(OriginationCountryPage).fill(originateCountry)
@@ -53,7 +55,7 @@ class OriginationCountryController @Inject()(
     Ok(originationCountryPage(mode, form))
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
     Countries
       .form(OriginationCountryPage)
       .bindFromRequest()

--- a/app/controllers/declaration/PackageInformationRemoveController.scala
+++ b/app/controllers/declaration/PackageInformationRemoveController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.PackageInformation
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PackageInformationRemoveController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,27 +45,29 @@ class PackageInformationRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    Ok(packageTypeRemove(mode, itemId, packageInformation(id, itemId), removeYesNoForm.withSubmissionErrors()))
+  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      Ok(packageTypeRemove(mode, itemId, packageInformation(id, itemId), removeYesNoForm.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val packageInformationToRemove = packageInformation(id, itemId)
-    removeYesNoForm
-      .bindFromRequest()
-      .fold(
-        (formWithErrors: Form[YesNoAnswer]) =>
-          Future.successful(BadRequest(packageTypeRemove(mode, itemId, packageInformationToRemove, formWithErrors))),
-        formData => {
-          formData.answer match {
-            case YesNoAnswers.yes =>
-              updateExportsCache(itemId, packageInformationToRemove)
-                .map(_ => navigator.continueTo(mode, routes.PackageInformationSummaryController.displayPage(_, itemId)))
-            case YesNoAnswers.no =>
-              Future.successful(navigator.continueTo(mode, routes.PackageInformationSummaryController.displayPage(_, itemId)))
+  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
+    implicit request =>
+      val packageInformationToRemove = packageInformation(id, itemId)
+      removeYesNoForm
+        .bindFromRequest()
+        .fold(
+          (formWithErrors: Form[YesNoAnswer]) =>
+            Future.successful(BadRequest(packageTypeRemove(mode, itemId, packageInformationToRemove, formWithErrors))),
+          formData => {
+            formData.answer match {
+              case YesNoAnswers.yes =>
+                updateExportsCache(itemId, packageInformationToRemove)
+                  .map(_ => navigator.continueTo(mode, routes.PackageInformationSummaryController.displayPage(_, itemId)))
+              case YesNoAnswers.no =>
+                Future.successful(navigator.continueTo(mode, routes.PackageInformationSummaryController.displayPage(_, itemId)))
+            }
           }
-        }
-      )
+        )
   }
 
   private def removeYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.packageInformation.remove.empty")

--- a/app/controllers/declaration/PackageInformationSummaryController.scala
+++ b/app/controllers/declaration/PackageInformationSummaryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
@@ -33,6 +34,7 @@ import views.html.declaration.package_information
 
 class PackageInformationSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,14 +44,14 @@ class PackageInformationSummaryController @Inject()(
 
   import PackageInformationSummaryController._
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.packageInformation) match {
       case Some(items) if items.nonEmpty => Ok(packageInformationPage(mode, itemId, anotherYesNoForm.withSubmissionErrors(), items))
       case _                             => navigator.continueTo(mode, routes.PackageInformationAddController.displayPage(_, itemId))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val items = request.cacheModel.itemBy(itemId).flatMap(_.packageInformation).getOrElse(List.empty)
     anotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
+++ b/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.PersonPresentingGoodsDetails
 import forms.declaration.PersonPresentingGoodsDetails.form
@@ -34,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PersonPresentingGoodsDetailsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +43,7 @@ class PersonPresentingGoodsDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.personPresentingGoodsDetails match {
       case Some(data) => Ok(personPresentingGoodsDetailsPage(mode, frm.fill(data)))
@@ -50,7 +51,7 @@ class PersonPresentingGoodsDetailsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(
@@ -62,5 +63,4 @@ class PersonPresentingGoodsDetailsController @Inject()(
 
   private def updateCache(validData: PersonPresentingGoodsDetails)(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => model.copy(parties = model.parties.copy(personPresentingGoodsDetails = Some(validData))))
-
 }

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.{Document, PreviousDocumentsData}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsChangeController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,14 +45,14 @@ class PreviousDocumentsChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     findDocument(id) match {
       case Some(document) => Ok(changePage(mode, id, Document.form().fill(document).withSubmissionErrors()))
       case _              => returnToSummary(mode)
     }
   }
 
-  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     findDocument(id) match {
       case Some(existingDocument) =>
         val boundForm = Document.form().bindFromRequest()

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util._
 import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import forms.declaration.Document._
 import forms.declaration.{Document, PreviousDocumentsData}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -43,11 +45,11 @@ class PreviousDocumentsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     Ok(previousDocumentsPage(mode, form()))
   }
 
-  def savePreviousDocuments(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def savePreviousDocuments(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val boundForm = if (isFirstPreviousDocument) Document.treatLikeOptional(form().bindFromRequest()) else form().bindFromRequest()
 
     val cache = request.cacheModel.previousDocuments.getOrElse(PreviousDocumentsData(Seq.empty))

--- a/app/controllers/declaration/PreviousDocumentsRemoveController.scala
+++ b/app/controllers/declaration/PreviousDocumentsRemoveController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.Document
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsRemoveController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,14 +47,14 @@ class PreviousDocumentsRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     findDocument(id) match {
       case Some(document) => Ok(removePage(mode, id, document, removeYesNoForm))
       case _              => returnToSummary(mode)
     }
   }
 
-  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     findDocument(id) match {
       case Some(document) =>
         removeYesNoForm

--- a/app/controllers/declaration/PreviousDocumentsSummaryController.scala
+++ b/app/controllers/declaration/PreviousDocumentsSummaryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
@@ -31,6 +32,7 @@ import views.html.declaration.previousDocuments.previous_documents_summary
 
 class PreviousDocumentsSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -38,7 +40,7 @@ class PreviousDocumentsSummaryController @Inject()(
   previousDocumentsSummary: previous_documents_summary
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val form = anotherYesNoForm.withSubmissionErrors()
     request.cacheModel.previousDocuments.map(_.documents) match {
       case Some(documents) if documents.nonEmpty => Ok(previousDocumentsSummary(mode, form, documents))
@@ -46,7 +48,7 @@ class PreviousDocumentsSummaryController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val previousDocuments = request.cacheModel.previousDocuments.map(_.documents).getOrElse(Seq.empty)
 
     anotherYesNoForm

--- a/app/controllers/declaration/RepresentativeAgentController.scala
+++ b/app/controllers/declaration/RepresentativeAgentController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers.{no, yes}
 import forms.declaration.RepresentativeAgent
+
 import javax.inject.Inject
 import models.declaration.RepresentativeDetails
 import models.requests.JourneyRequest
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeAgentController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -43,7 +45,7 @@ class RepresentativeAgentController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = RepresentativeAgent.form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.flatMap(_.representingOtherAgent) match {
       case Some(data) => Ok(representativeAgentPage(mode, frm.fill(RepresentativeAgent(data))))
@@ -51,7 +53,7 @@ class RepresentativeAgentController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     RepresentativeAgent
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/RepresentativeEntityController.scala
+++ b/app/controllers/declaration/RepresentativeEntityController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.RepresentativeEntity
 import forms.declaration.RepresentativeEntity.form
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.declaration.RepresentativeDetails
@@ -36,6 +37,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeEntityController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -44,7 +46,7 @@ class RepresentativeEntityController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.flatMap(_.details) match {
       case Some(data) => Ok(representativeEntityPage(mode, frm.fill(RepresentativeEntity(data))))
@@ -52,7 +54,7 @@ class RepresentativeEntityController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/RepresentativeStatusController.scala
+++ b/app/controllers/declaration/RepresentativeStatusController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.DeclarationPage
 import forms.declaration.RepresentativeStatus.form
 import forms.declaration.{RepresentativeEntity, RepresentativeStatus}
+
 import javax.inject.Inject
 import models.DeclarationType._
 import models.declaration.RepresentativeDetails
@@ -37,6 +38,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeStatusController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -45,7 +47,7 @@ class RepresentativeStatusController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.map(_.statusCode) match {
       case Some(data) => Ok(representativeStatusPage(mode, navigationForm, frm.fill(RepresentativeStatus(data))))
@@ -53,7 +55,7 @@ class RepresentativeStatusController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/RoutingCountriesController.scala
+++ b/app/controllers/declaration/RoutingCountriesController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.RoutingQuestionYesNo._
 import forms.declaration.countries.Countries
 import forms.declaration.countries.Countries.{FirstRoutingCountryPage, NextRoutingCountryPage}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RoutingCountriesController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,22 +46,23 @@ class RoutingCountriesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayRoutingQuestion(mode: Mode, fastForward: Boolean): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    if (fastForward && request.cacheModel.containRoutingCountries()) {
-      navigator.continueTo(mode, routes.RoutingCountriesSummaryController.displayPage)
-    } else {
-      val destinationCountryCode = request.cacheModel.locations.destinationCountry.flatMap(_.code)
-      val destinationCountryName = destinationCountryCode.map(findByCode(_)).map(_.asString()).getOrElse("")
+  def displayRoutingQuestion(mode: Mode, fastForward: Boolean): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      if (fastForward && request.cacheModel.containRoutingCountries()) {
+        navigator.continueTo(mode, routes.RoutingCountriesSummaryController.displayPage)
+      } else {
+        val destinationCountryCode = request.cacheModel.locations.destinationCountry.flatMap(_.code)
+        val destinationCountryName = destinationCountryCode.map(findByCode(_)).map(_.asString()).getOrElse("")
 
-      val frm = formFirst().withSubmissionErrors()
-      request.cacheModel.locations.hasRoutingCountries match {
-        case Some(answer) => Ok(routingQuestionPage(mode, frm.fill(answer), destinationCountryName))
-        case None         => Ok(routingQuestionPage(mode, frm, destinationCountryName))
+        val frm = formFirst().withSubmissionErrors()
+        request.cacheModel.locations.hasRoutingCountries match {
+          case Some(answer) => Ok(routingQuestionPage(mode, frm.fill(answer), destinationCountryName))
+          case None         => Ok(routingQuestionPage(mode, frm, destinationCountryName))
+        }
       }
-    }
   }
 
-  def submitRoutingAnswer(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitRoutingAnswer(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val destinationCountry = request.cacheModel.locations.destinationCountry.flatMap(_.code).getOrElse("-")
     val cachedCountries = request.cacheModel.locations.routingCountries
 
@@ -84,7 +87,7 @@ class RoutingCountriesController @Inject()(
     else
       navigator.continueTo(mode, controllers.declaration.routes.LocationController.displayPage)
 
-  def displayRoutingCountry(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayRoutingCountry(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val routingAnswer = request.cacheModel.locations.hasRoutingCountries
     val page = if (request.cacheModel.locations.routingCountries.nonEmpty) NextRoutingCountryPage else FirstRoutingCountryPage
 
@@ -95,7 +98,7 @@ class RoutingCountriesController @Inject()(
     }
   }
 
-  def submitRoutingCountry(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitRoutingCountry(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     val hasCountriesAdded = request.cacheModel.locations.routingCountries.nonEmpty
     val cachedCountries = request.cacheModel.locations.routingCountries
     val page = if (hasCountriesAdded) NextRoutingCountryPage else FirstRoutingCountryPage

--- a/app/controllers/declaration/RoutingCountriesSummaryController.scala
+++ b/app/controllers/declaration/RoutingCountriesSummaryController.scala
@@ -16,11 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.RoutingQuestionYesNo
 import forms.declaration.countries.Countries.{FirstRoutingCountryPage, NextRoutingCountryPage}
 import forms.declaration.countries.{Countries, Country}
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,6 +36,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class RoutingCountriesSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,7 +47,7 @@ class RoutingCountriesSummaryController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val countryCodes = request.cacheModel.locations.routingCountries.flatMap(_.code)
     val countries = findByCodes(countryCodes)
 
@@ -56,7 +58,7 @@ class RoutingCountriesSummaryController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val countryCodes = request.cacheModel.locations.routingCountries
     val countries = findByCodes(countryCodes.flatMap(_.code))
 
@@ -74,26 +76,28 @@ class RoutingCountriesSummaryController @Inject()(
       navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesController.displayRoutingCountry, mode.isErrorFix)
     else navigator.continueTo(mode, controllers.declaration.routes.LocationController.displayPage)
 
-  def displayRemoveCountryPage(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    val isCountryPresentedInCache = request.cacheModel.locations.routingCountries.flatMap(_.code).contains(countryCode)
-    val country = services.Countries.countryCodeMap(countryCode)
+  def displayRemoveCountryPage(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      val isCountryPresentedInCache = request.cacheModel.locations.routingCountries.flatMap(_.code).contains(countryCode)
+      val country = services.Countries.countryCodeMap(countryCode)
 
-    if (isCountryPresentedInCache) Ok(removeRoutingCountryPage(mode, RoutingQuestionYesNo.formRemove(), country))
-    else navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage)
+      if (isCountryPresentedInCache) Ok(removeRoutingCountryPage(mode, RoutingQuestionYesNo.formRemove(), country))
+      else navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage)
   }
 
-  def submitRemoveCountry(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val country = services.Countries.countryCodeMap(countryCode)
+  def submitRemoveCountry(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
+    implicit request =>
+      val country = services.Countries.countryCodeMap(countryCode)
 
-    RoutingQuestionYesNo
-      .formRemove()
-      .bindFromRequest()
-      .fold(
-        formWithErrors => Future.successful(BadRequest(removeRoutingCountryPage(mode, formWithErrors, country))),
-        validAnswer =>
-          if (validAnswer) removeCountry(Country(Some(countryCode))).map(_ => removeRedirect(mode))
-          else Future.successful(removeRedirect(mode))
-      )
+      RoutingQuestionYesNo
+        .formRemove()
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(removeRoutingCountryPage(mode, formWithErrors, country))),
+          validAnswer =>
+            if (validAnswer) removeCountry(Country(Some(countryCode))).map(_ => removeRedirect(mode))
+            else Future.successful(removeRedirect(mode))
+        )
   }
 
   private def removeRedirect(mode: Mode)(implicit request: JourneyRequest[AnyContent]): Result =
@@ -102,36 +106,38 @@ class RoutingCountriesSummaryController @Inject()(
   private def removeCountry(country: Country)(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(_.removeCountryOfRouting(country))
 
-  def displayChangeCountryPage(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    val cachedCountries = request.cacheModel.locations.routingCountries.flatMap(_.code)
-    val isCountryPresentedInCache = cachedCountries.contains(countryCode)
+  def displayChangeCountryPage(mode: Mode, countryCode: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      val cachedCountries = request.cacheModel.locations.routingCountries.flatMap(_.code)
+      val isCountryPresentedInCache = cachedCountries.contains(countryCode)
 
-    val countryIndex = cachedCountries.indexOf(countryCode)
-    val page = if (countryIndex > 0) NextRoutingCountryPage else FirstRoutingCountryPage
+      val countryIndex = cachedCountries.indexOf(countryCode)
+      val page = if (countryIndex > 0) NextRoutingCountryPage else FirstRoutingCountryPage
 
-    if (isCountryPresentedInCache) Ok(changeRoutingCountryPage(mode, Countries.form(page).fill(Country(Some(countryCode))), page, countryCode))
-    else navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage, mode.isErrorFix)
+      if (isCountryPresentedInCache) Ok(changeRoutingCountryPage(mode, Countries.form(page).fill(Country(Some(countryCode))), page, countryCode))
+      else navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage, mode.isErrorFix)
   }
 
-  def submitChangeCountry(mode: Mode, countryToChange: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val cachedCountries = request.cacheModel.locations.routingCountries
-    val cachedCountryCodes = cachedCountries.flatMap(_.code)
-    val countriesForValidation = cachedCountries.filterNot(_.code == Some(countryToChange))
-    val countryIndex = cachedCountryCodes.indexOf(countryToChange)
-    val page = if (countryIndex > 0) NextRoutingCountryPage else FirstRoutingCountryPage
+  def submitChangeCountry(mode: Mode, countryToChange: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
+    implicit request =>
+      val cachedCountries = request.cacheModel.locations.routingCountries
+      val cachedCountryCodes = cachedCountries.flatMap(_.code)
+      val countriesForValidation = cachedCountries.filterNot(_.code == Some(countryToChange))
+      val countryIndex = cachedCountryCodes.indexOf(countryToChange)
+      val page = if (countryIndex > 0) NextRoutingCountryPage else FirstRoutingCountryPage
 
-    Countries
-      .form(page, countriesForValidation)
-      .bindFromRequest()
-      .fold(
-        formWithErrors => Future.successful(BadRequest(changeRoutingCountryPage(mode, formWithErrors, page, countryToChange))),
-        validCountry => {
-          val updatedCountries = cachedCountries.updated(countryIndex, validCountry)
+      Countries
+        .form(page, countriesForValidation)
+        .bindFromRequest()
+        .fold(
+          formWithErrors => Future.successful(BadRequest(changeRoutingCountryPage(mode, formWithErrors, page, countryToChange))),
+          validCountry => {
+            val updatedCountries = cachedCountries.updated(countryIndex, validCountry)
 
-          updateExportsDeclarationSyncDirect(_.updateCountriesOfRouting(updatedCountries)).map { _ =>
-            navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage, mode.isErrorFix)
+            updateExportsDeclarationSyncDirect(_.updateCountriesOfRouting(updatedCountries)).map { _ =>
+              navigator.continueTo(mode, controllers.declaration.routes.RoutingCountriesSummaryController.displayPage, mode.isErrorFix)
+            }
           }
-        }
-      )
+        )
   }
 }

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper.saveAndContinue
 import controllers.util.{FormAction, Remove}
@@ -24,6 +24,7 @@ import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.Seal
 import handlers.ErrorHandler
+
 import javax.inject.Inject
 import models.Mode
 import models.declaration.Container
@@ -39,6 +40,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SealController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   errorHandler: ErrorHandler,
@@ -50,31 +52,34 @@ class SealController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayAddSeal(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    Ok(addPage(mode, Seal.form().withSubmissionErrors(), containerId))
+  def displayAddSeal(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      Ok(addPage(mode, Seal.form().withSubmissionErrors(), containerId))
   }
 
-  def submitAddSeal(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    Seal
-      .form()
-      .bindFromRequest()
-      .fold(
-        (formWithErrors: Form[Seal]) => Future.successful(BadRequest(addPage(mode, formWithErrors, containerId))),
-        validSeal =>
-          request.cacheModel.containerBy(containerId) match {
-            case Some(container) =>
-              saveSeal(mode, Seal.form.fill(validSeal), container)
-            case _ => errorHandler.displayErrorPage()
-        }
-      )
+  def submitAddSeal(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
+    implicit request =>
+      Seal
+        .form()
+        .bindFromRequest()
+        .fold(
+          (formWithErrors: Form[Seal]) => Future.successful(BadRequest(addPage(mode, formWithErrors, containerId))),
+          validSeal =>
+            request.cacheModel.containerBy(containerId) match {
+              case Some(container) =>
+                saveSeal(mode, Seal.form.fill(validSeal), container)
+              case _ => errorHandler.displayErrorPage()
+          }
+        )
   }
 
-  def displaySealSummary(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    Ok(summaryPage(mode, addSealYesNoForm(containerId).withSubmissionErrors(), containerId, seals(containerId)))
+  def displaySealSummary(mode: Mode, containerId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
+    implicit request =>
+      Ok(summaryPage(mode, addSealYesNoForm(containerId).withSubmissionErrors(), containerId, seals(containerId)))
   }
 
   def submitSummaryAction(mode: Mode, containerId: String): Action[AnyContent] =
-    (authenticate andThen journeyType).async { implicit request =>
+    (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
       FormAction.bindFromRequest() match {
         case Remove(values) => confirmRemoveSeal(containerId, sealId(values), mode)
         case _              => addSealAnswer(mode, containerId)
@@ -82,12 +87,12 @@ class SealController @Inject()(
     }
 
   def displaySealRemove(mode: Mode, containerId: String, sealId: String): Action[AnyContent] =
-    (authenticate andThen journeyType) { implicit request =>
+    (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
       Ok(removePage(mode, removeSealYesNoForm, containerId, sealId))
     }
 
   def submitSealRemove(mode: Mode, containerId: String, sealId: String): Action[AnyContent] =
-    (authenticate andThen journeyType).async { implicit request =>
+    (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
       removeSealAnswer(mode, containerId, sealId)
     }
 
@@ -155,5 +160,4 @@ class SealController @Inject()(
 
   private def updateCache(updatedContainer: Container)(implicit req: JourneyRequest[AnyContent]) =
     updateExportsDeclarationSyncDirect(model => model.addOrUpdateContainer(updatedContainer))
-
 }

--- a/app/controllers/declaration/SubmittedDeclarationController.scala
+++ b/app/controllers/declaration/SubmittedDeclarationController.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import connectors.CustomsDeclareExportsConnector
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc._
@@ -28,6 +28,7 @@ import scala.concurrent.ExecutionContext
 
 class SubmittedDeclarationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   mcc: MessagesControllerComponents,
@@ -35,10 +36,9 @@ class SubmittedDeclarationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 
-  def displayPage(): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def displayPage(): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     customsDeclareExportsConnector.findNotifications(request.cacheModel.id).map { notifications =>
       Ok(view(notifications))
     }
   }
-
 }

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.SupervisingCustomsOffice
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class SupervisingCustomsOfficeController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -43,7 +45,7 @@ class SupervisingCustomsOfficeController @Inject()(
 
   import forms.declaration.SupervisingCustomsOffice._
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.supervisingCustomsOffice match {
       case Some(data) => Ok(supervisingCustomsOfficePage(mode, frm.fill(data)))
@@ -51,7 +53,7 @@ class SupervisingCustomsOfficeController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/TaricCodeSummaryController.scala
+++ b/app/controllers/declaration/TaricCodeSummaryController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
+
 import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
@@ -31,6 +32,7 @@ import views.html.declaration.taric_codes
 
 class TaricCodeSummaryController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -38,14 +40,14 @@ class TaricCodeSummaryController @Inject()(
   taricCodesPage: taric_codes
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.taricCodes) match {
       case Some(taricCodes) if taricCodes.nonEmpty => Ok(taricCodesPage(mode, itemId, addYesNoForm.withSubmissionErrors(), taricCodes))
       case _                                       => navigator.continueTo(mode, routes.TaricCodeAddController.displayPage(_, itemId))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val taricCodes = request.cacheModel.itemBy(itemId).flatMap(_.taricCodes).getOrElse(List.empty)
     addYesNoForm
       .bindFromRequest()
@@ -60,5 +62,4 @@ class TaricCodeSummaryController @Inject()(
   }
 
   private def addYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.taricAdditionalCodes.add.answer.empty")
-
 }

--- a/app/controllers/declaration/TotalNumberOfItemsController.scala
+++ b/app/controllers/declaration/TotalNumberOfItemsController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.TotalNumberOfItems
+
 import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TotalNumberOfItemsController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -45,7 +47,7 @@ class TotalNumberOfItemsController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.totalNumberOfItems match {
       case Some(data) => Ok(totalNumberOfItemsPage(mode, frm.fill(data)))
@@ -53,7 +55,7 @@ class TotalNumberOfItemsController @Inject()(
     }
   }
 
-  def saveNoOfItems(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
+  def saveNoOfItems(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -16,12 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import controllers.util.{FormAction, Remove}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{ContainerAdd, ContainerFirst}
+
 import javax.inject.Inject
 import models.declaration.Container
 import models.declaration.Container.maxNumberOfItems
@@ -38,6 +39,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TransportContainerController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -49,7 +51,7 @@ class TransportContainerController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     if (request.cacheModel.hasContainers) {
       Ok(addPage(mode, ContainerAdd.form().withSubmissionErrors()))
     } else {
@@ -57,7 +59,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def submitAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     if (request.cacheModel.hasContainers) {
       val boundForm = ContainerAdd.form().bindFromRequest()
       saveAdditionalContainer(mode, boundForm, maxNumberOfItems, request.cacheModel.containers)
@@ -72,7 +74,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def displayContainerSummary(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayContainerSummary(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     request.cacheModel.containers match {
       case containers if containers.nonEmpty => Ok(summaryPage(mode, addAnotherContainerYesNoForm.withSubmissionErrors(), containers))
       case _ =>
@@ -80,7 +82,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def submitSummaryAction(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitSummaryAction(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     FormAction.bindFromRequest() match {
       case Remove(values) =>
         Future.successful(navigator.continueTo(mode, routes.TransportContainerController.displayContainerRemove(_, containerId(values))))
@@ -89,7 +91,7 @@ class TransportContainerController @Inject()(
   }
 
   def displayContainerRemove(mode: Mode, containerId: String): Action[AnyContent] =
-    (authenticate andThen journeyType) { implicit request =>
+    (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
       request.cacheModel.containerBy(containerId) match {
         case Some(container) => Ok(removePage(mode, removeContainerYesNoForm, container))
         case _               => navigator.continueTo(mode, routes.TransportContainerController.displayContainerSummary)
@@ -97,7 +99,7 @@ class TransportContainerController @Inject()(
     }
 
   def submitContainerRemove(mode: Mode, containerId: String): Action[AnyContent] =
-    (authenticate andThen journeyType).async { implicit request =>
+    (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
       removeContainerAnswer(mode, containerId)
     }
 

--- a/app/controllers/declaration/TransportLeavingTheBorderController.scala
+++ b/app/controllers/declaration/TransportLeavingTheBorderController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.TransportLeavingTheBorder
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
@@ -32,6 +33,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class TransportLeavingTheBorderController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class TransportLeavingTheBorderController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
     val form = TransportLeavingTheBorder.form(request.declarationType).withSubmissionErrors()
     request.cacheModel.transport.borderModeOfTransportCode match {
       case Some(data) => Ok(transportAtBorder(form.fill(data), mode))
@@ -50,7 +52,7 @@ class TransportLeavingTheBorderController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
     TransportLeavingTheBorder
       .form(request.declarationType)
       .bindFromRequest()
@@ -70,5 +72,4 @@ class TransportLeavingTheBorderController @Inject()(
         controllers.declaration.routes.WarehouseIdentificationController.displayPage
       else controllers.declaration.routes.SupervisingCustomsOfficeController.displayPage
     )
-
 }

--- a/app/controllers/declaration/UNDangerousGoodsCodeController.scala
+++ b/app/controllers/declaration/UNDangerousGoodsCodeController.scala
@@ -16,10 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.UNDangerousGoodsCode
 import forms.declaration.UNDangerousGoodsCode.form
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -34,6 +35,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class UNDangerousGoodsCodeController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +44,7 @@ class UNDangerousGoodsCodeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.itemBy(itemId).flatMap(_.dangerousGoodsCode) match {
       case Some(dangerousGoodsCode) => Ok(unDangerousGoodsCodePage(mode, itemId, frm.fill(dangerousGoodsCode)))
@@ -50,7 +52,7 @@ class UNDangerousGoodsCodeController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -16,9 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction}
+import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
 import controllers.navigation.Navigator
 import forms.declaration.WarehouseIdentification
+
 import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -33,6 +34,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class WarehouseIdentificationController @Inject()(
   authenticate: AuthAction,
+  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -42,7 +44,7 @@ class WarehouseIdentificationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.warehouseIdentification match {
       case Some(data) => Ok(page(mode, frm.fill(data)))
@@ -50,7 +52,7 @@ class WarehouseIdentificationController @Inject()(
     }
   }
 
-  def saveIdentificationNumber(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+  def saveIdentificationNumber(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/pdf/EADController.scala
+++ b/app/controllers/pdf/EADController.scala
@@ -17,8 +17,8 @@
 package controllers.pdf
 
 import java.time.LocalDate
+import controllers.actions.{AuthAction, VerifiedEmailAction}
 
-import controllers.actions.AuthAction
 import javax.inject.Inject
 import org.apache.xmlgraphics.util.MimeConstants
 import play.api.i18n.I18nSupport
@@ -28,10 +28,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
 import scala.concurrent.ExecutionContext
 
-class EADController @Inject()(authenticate: AuthAction, mcc: MessagesControllerComponents, eadService: EADService)(implicit ec: ExecutionContext)
-    extends FrontendController(mcc) with I18nSupport {
+class EADController @Inject()(authenticate: AuthAction, verifyEmail: VerifiedEmailAction, mcc: MessagesControllerComponents, eadService: EADService)(
+  implicit ec: ExecutionContext
+) extends FrontendController(mcc) with I18nSupport {
 
-  def generatePdf(mrn: String): Action[AnyContent] = authenticate.async { implicit request =>
+  def generatePdf(mrn: String): Action[AnyContent] = (authenticate andThen verifyEmail).async { implicit request =>
     val fileName = s"EAD-${mrn}-${LocalDate.now}.pdf"
 
     eadService.generatePdf(mrn).map { pdf =>

--- a/app/models/EORI.scala
+++ b/app/models/EORI.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+case class EORI(value: String)

--- a/app/models/VerifiedEmailAddress.scala
+++ b/app/models/VerifiedEmailAddress.scala
@@ -1,0 +1,27 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models
+
+import play.api.libs.json.{Json, OFormat}
+
+import java.time.ZonedDateTime
+
+case class VerifiedEmailAddress(address: String, timestamp: ZonedDateTime)
+
+object VerifiedEmailAddress {
+  implicit val format: OFormat[VerifiedEmailAddress] = Json.format[VerifiedEmailAddress]
+}

--- a/app/models/requests/ItemRequest.scala
+++ b/app/models/requests/ItemRequest.scala
@@ -18,4 +18,4 @@ package models.requests
 import models.declaration.ExportItem
 
 class ItemRequest[A](val item: ExportItem, journeyRequest: JourneyRequest[A])
-    extends JourneyRequest[A](journeyRequest.authenticatedRequest, journeyRequest.cacheModel) {}
+    extends JourneyRequest[A](journeyRequest.verifiedEmailRequest, journeyRequest.cacheModel) {}

--- a/app/models/requests/JourneyRequest.scala
+++ b/app/models/requests/JourneyRequest.scala
@@ -21,12 +21,12 @@ import models.ExportsDeclaration
 import models.responses.FlashKeys
 import play.api.data.FormError
 
-class JourneyRequest[+A](val authenticatedRequest: AuthenticatedRequest[A], val cacheModel: ExportsDeclaration)
-    extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {
+class JourneyRequest[+A](val verifiedEmailRequest: VerifiedEmailRequest[A], val cacheModel: ExportsDeclaration)
+    extends AuthenticatedRequest[A](verifiedEmailRequest, verifiedEmailRequest.user) {
   val declarationType: DeclarationType = cacheModel.`type`
   val sourceDecId: Option[String] = cacheModel.sourceId
   def isType(`type`: DeclarationType*): Boolean = `type`.contains(declarationType)
-  def eori: String = authenticatedRequest.user.eori
+  def eori: String = verifiedEmailRequest.user.eori
   def submissionErrors: Seq[FormError] = {
     val fieldName = flash.get(FlashKeys.fieldName)
     val errorMessage = flash.get(FlashKeys.errorMessage)

--- a/app/models/requests/VerifiedEmailRequest.scala
+++ b/app/models/requests/VerifiedEmailRequest.scala
@@ -1,0 +1,19 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package models.requests
+
+case class VerifiedEmailRequest[+A](request: AuthenticatedRequest[A], email: String) extends AuthenticatedRequest[A](request, request.user) {}

--- a/app/views/unverified_email.scala.html
+++ b/app/views/unverified_email.scala.html
@@ -1,0 +1,50 @@
+@*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *@
+
+@import views.Title
+@import views.html.components.gds._
+
+
+@this(
+  mainTemplate: gdsMainTemplate,
+  pageTitle: pageTitle,
+  paragraphBody: paragraphBody,
+  linkButton: linkButton,
+  link: link
+)
+
+@(redirectionUrl: String)(implicit request: Request[_], messages: Messages)
+
+@mainTemplate(title = Title("emailUnverified.heading")) {
+
+  @pageTitle(messages("emailUnverified.heading"))
+
+  @paragraphBody(messages("emailUnverified.paragraph1"), id = Some("emailUnverified.para1"))
+  <ul class="govuk-list govuk-list--bullet" id="emailUnverified.bullets">
+    <li>@messages("emailUnverified.bullets.item1")</li>
+    <li>@messages("emailUnverified.bullets.item2")</li>
+    <li>@messages("emailUnverified.bullets.item3")</li>
+    <li>@messages("emailUnverified.bullets.item4")</li>
+    <li>@messages("emailUnverified.bullets.item5")</li>
+  </ul>
+
+  <p class="govuk-body govuk-!-margin-top-9">
+    @linkButton(
+      messageKey = "emailUnverified.link",
+      call = Call("GET", redirectionUrl)
+    )
+  </p>
+}

--- a/conf/app.routes
+++ b/conf/app.routes
@@ -6,6 +6,10 @@ GET         /assets/*file                                  controllers.Assets.ve
 
 GET         /unauthorised                                  controllers.UnauthorisedController.onPageLoad
 
+# Unverified Email
+
+GET         /unverified-email                              controllers.UnverifiedEmailController.informUser
+
 # Notifications
 
 GET         /submissions/:id/rejected-notifications        controllers.RejectedNotificationsController.displayPage(id: String)

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -79,6 +79,7 @@ microservice {
       fetch-submissions = "/submissions"
       cancel-declaration = "/cancellations"
       fetch-ead = "/ead"
+      fetch-verified-email = "/eori-email"
     }
 
     contact-frontend {
@@ -159,6 +160,7 @@ urls {
   organisationsLink = "https://www.gov.uk/government/organisations/hm-revenue-customs"
   importExports = "https://www.gov.uk/topic/business-tax/import-export"
   exitSurveyUrl = "http://localhost:9514/feedback/customs-declare-exports-frontend"
+  emailFrontendUrl = "http://localhost:9898/manage-email-cds/service/customs-declare-exports"
 }
 
 accessibility-statement.service-path = "/customs-declare-exports"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -396,6 +396,15 @@ timeoutDialog.message = For your security, we will sign you out in
 timeoutDialog.keepAlive.text= Stay signed in
 timeoutDialog.signout.text= Sign out
 
+emailUnverified.heading=You need to verify your email address for the Customs Declaration Service
+emailUnverified.paragraph1=This will be the only email address we use for:
+emailUnverified.bullets.item1=urgent updates about goods in customs
+emailUnverified.bullets.item2=notifications about import and export declarations
+emailUnverified.bullets.item3=import VAT and duty deferment statements
+emailUnverified.bullets.item4=duty deferment Direct Debit notices
+emailUnverified.bullets.item5=updates about changes to the service
+emailUnverified.link=Verify your email address
+
 choicePage.input.error.empty = Select what you want to do.
 choicePage.input.error.incorrectValue = Select what you want to do.
 

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -19,7 +19,7 @@ package base
 import base.ExportsTestData._
 import controllers.actions.{AuthActionImpl, EoriAllowList}
 import models.SignedInUser
-import models.requests.{AuthenticatedRequest, ExportsSessionKeys}
+import models.requests.{ExportsSessionKeys, VerifiedEmailRequest}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.when
@@ -29,12 +29,13 @@ import play.api.test.FakeRequest
 import uk.gov.hmrc.auth.core._
 import uk.gov.hmrc.auth.core.retrieve.v2.Retrievals._
 import uk.gov.hmrc.auth.core.retrieve.~
+import unit.mock.VerifiedEmailMocks
 import unit.tools.Stubs
 import utils.FakeRequestCSRFSupport._
 
 import scala.concurrent.Future
 
-trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks {
+trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks with RequestBuilder with VerifiedEmailMocks {
 
   val mockAuthConnector: AuthConnector = mock[AuthConnector]
 
@@ -250,8 +251,8 @@ trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks {
       )
     )
 
-  def getAuthenticatedRequest(declarationId: String = "declarationId"): AuthenticatedRequest[AnyContentAsEmpty.type] =
-    new AuthenticatedRequest(FakeRequest("GET", "").withSession((ExportsSessionKeys.declarationId, declarationId)).withCSRFToken, exampleUser)
+  def getAuthenticatedRequest(declarationId: String = "declarationId"): VerifiedEmailRequest[AnyContentAsEmpty.type] =
+    buildVerifiedEmailRequest(FakeRequest("GET", "").withSession((ExportsSessionKeys.declarationId, declarationId)).withCSRFToken, exampleUser)
 
   def getRequest(): Request[AnyContentAsEmpty.type] =
     FakeRequest("GET", "").withSession((ExportsSessionKeys.declarationId, "declarationId")).withCSRFToken

--- a/test/base/RequestBuilder.scala
+++ b/test/base/RequestBuilder.scala
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import models.requests.{AuthenticatedRequest, VerifiedEmailRequest}
+import models.SignedInUser
+import play.api.mvc.Request
+
+trait RequestBuilder {
+  def buildVerifiedEmailRequest[A](sourceRequest: Request[A], user: SignedInUser, email: String = "example@example.com"): VerifiedEmailRequest[A] =
+    VerifiedEmailRequest(new AuthenticatedRequest(sourceRequest, user), email)
+}

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -43,6 +43,7 @@ class AppConfigSpec extends UnitSpec {
         |urls.serviceAvailability="https://www.gov.uk/guidance/customs-declaration-service-service-availability-and-issues"
         |urls.customsMovementsFrontend="http://url-to-movements-frontend/start"
         |urls.exitSurveyUrl="http://localhost:9514/feedback/customs-declare-exports-frontend"
+        |urls.emailFrontendUrl="http://localhost:9898/manage-email-cds/service/customs-declare-exports"
         |
         |microservice.services.auth.host=localhostauth
         |google-analytics.token=N/A
@@ -134,6 +135,10 @@ class AppConfigSpec extends UnitSpec {
 
     "have exitSurvey URL" in {
       validAppConfig.exitSurveyUrl must be("http://localhost:9514/feedback/customs-declare-exports-frontend")
+    }
+
+    "have emailFrontendUrl URL" in {
+      validAppConfig.emailFrontendUrl must be("http://localhost:9898/manage-email-cds/service/customs-declare-exports")
     }
 
     "load the Choice options when list-of-available-journeys is defined" in {

--- a/test/controllers/navigation/NavigatorSpec.scala
+++ b/test/controllers/navigation/NavigatorSpec.scala
@@ -16,19 +16,17 @@
 
 package controllers.navigation
 
-import java.time.{LocalDate, ZoneOffset}
-import java.util.concurrent.TimeUnit
-
+import base.RequestBuilder
 import config.AppConfig
 import controllers.util._
 import forms.declaration.carrier.CarrierDetails
-import models.requests.{AuthenticatedRequest, ExportsSessionKeys, JourneyRequest}
+import models.{ExportsDeclaration, Mode, SignedInUser}
+import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys
-import models.{Mode, SignedInUser}
+import org.mockito.{ArgumentMatchers, Mockito}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.BDDMockito._
 import org.mockito.Mockito.{verify, verifyNoInteractions}
-import org.mockito.{ArgumentMatchers, Mockito}
 import org.scalatest.{BeforeAndAfterEach, Matchers, WordSpec}
 import org.scalatestplus.mockito.MockitoSugar
 import play.api.mvc.{AnyContent, Call, Result}
@@ -38,10 +36,12 @@ import services.audit.{AuditService, AuditTypes}
 import services.cache.ExportsDeclarationBuilder
 import uk.gov.hmrc.http.HeaderCarrier
 
+import java.time.{LocalDate, ZoneOffset}
+import java.util.concurrent.TimeUnit
 import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 
-class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with ExportsDeclarationBuilder with BeforeAndAfterEach {
+class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with ExportsDeclarationBuilder with BeforeAndAfterEach with RequestBuilder {
 
   private val mode = Mode.Normal
   private val call: Mode => Call = _ => Call("GET", "url")
@@ -60,24 +60,24 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
     super.afterEach()
   }
 
+  private def decoratedRequest(sourceRequest: FakeRequest[AnyContent])(implicit declaration: ExportsDeclaration) =
+    new JourneyRequest[AnyContent](buildVerifiedEmailRequest(sourceRequest, mock[SignedInUser]), declaration)
+
   "Continue To" should {
     val updatedDate = LocalDate.of(2020, 1, 1)
     val expiryDate = LocalDate.of(2020, 1, 1).plusDays(10)
 
-    val declaration = aDeclaration(withUpdateDate(updatedDate))
-    def authenticatedRequest(action: Option[FormAction]) = new AuthenticatedRequest[AnyContent](
+    implicit val declaration = aDeclaration(withUpdateDate(updatedDate))
+
+    def request(action: Option[FormAction]) =
       FakeRequest("GET", "uri")
         .withFormUrlEncodedBody(action.getOrElse("other-field").toString -> "")
-        .withSession(ExportsSessionKeys.declarationId -> "declarationId"),
-      mock[SignedInUser]
-    )
-    def request(action: Option[FormAction]): JourneyRequest[AnyContent] =
-      new JourneyRequest[AnyContent](authenticatedRequest(action), declaration)
+        .withSession(ExportsSessionKeys.declarationId -> "declarationId")
 
     "Go to Save as Draft" in {
       given(config.draftTimeToLive).willReturn(FiniteDuration(10, TimeUnit.DAYS))
 
-      val result = navigator.continueTo(mode, call(_))(request(Some(SaveAndReturn)), hc)
+      val result = navigator.continueTo(mode, call(_))(decoratedRequest(request(Some(SaveAndReturn))), hc)
 
       status(result) shouldBe SEE_OTHER
       redirectLocation(result) shouldBe Some(controllers.declaration.routes.ConfirmationController.displayDraftConfirmation().url)
@@ -89,7 +89,7 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
 
     "Go to URL provided" when {
       "Save And Continue" in {
-        val result = navigator.continueTo(mode, call(_))(request(Some(SaveAndContinue)), hc)
+        val result = navigator.continueTo(mode, call(_))(decoratedRequest(request(Some(SaveAndContinue))), hc)
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) shouldBe Some("url")
@@ -97,7 +97,7 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
       }
 
       "Add" in {
-        val result = navigator.continueTo(mode, call(_))(request(Some(Add)), hc)
+        val result = navigator.continueTo(mode, call(_))(decoratedRequest(request(Some(Add))), hc)
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) shouldBe Some("url")
@@ -105,7 +105,7 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
       }
 
       "Remove" in {
-        val result = navigator.continueTo(mode, call(_))(request(Some(Remove(Seq.empty))), hc)
+        val result = navigator.continueTo(mode, call(_))(decoratedRequest(request(Some(Remove(Seq.empty)))), hc)
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) shouldBe Some("url")
@@ -113,7 +113,7 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
       }
 
       "Unknown Action" in {
-        val result = navigator.continueTo(mode, call(_))(request(Some(Unknown)), hc)
+        val result = navigator.continueTo(mode, call(_))(decoratedRequest(request(Some(Unknown))), hc)
 
         status(result) shouldBe SEE_OTHER
         redirectLocation(result) shouldBe Some("url")
@@ -124,40 +124,31 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
 
   "Navigator" should {
 
-    val authenticatedRequest = new AuthenticatedRequest[AnyContent](
-      FakeRequest("GET", "uri")
-        .withSession(ExportsSessionKeys.declarationId -> "declarationId"),
-      mock[SignedInUser]
-    )
+    val request = FakeRequest("GET", "uri")
+      .withSession(ExportsSessionKeys.declarationId -> "declarationId")
 
     "redirect to RejectedNotificationsController.displayPage" when {
 
       val sourceId = "1234"
-      val declaration = aDeclaration(withSourceId(sourceId))
+      implicit val declaration = aDeclaration(withSourceId(sourceId))
 
       "continueTo method is invoked with mode ErrorFix and sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = navigator.continueTo(Mode.ErrorFix, call)(request, hc)
+        val result = navigator.continueTo(Mode.ErrorFix, call)(decoratedRequest(request), hc)
 
         redirectLocation(result) shouldBe Some(controllers.routes.RejectedNotificationsController.displayPage(sourceId).url)
       }
 
       "backLink method is invoked with mode ErrorFix and sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix)(request)
+        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix)(decoratedRequest(request))
 
         result shouldBe controllers.routes.RejectedNotificationsController.displayPage(sourceId)
       }
 
       "backLink method for items is invoked with mode ErrorFix and sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix, ItemId("123456"))(request)
+        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix, ItemId("123456"))(decoratedRequest(request))
 
         result shouldBe controllers.routes.RejectedNotificationsController.displayPage(sourceId)
       }
@@ -165,31 +156,25 @@ class NavigatorSpec extends WordSpec with Matchers with MockitoSugar with Export
 
     "redirect to SubmissionsController.displayListOfSubmissions" when {
 
-      val declaration = aDeclaration(withoutSourceId())
+      implicit val declaration = aDeclaration(withoutSourceId())
 
       "continueTo method is invoked with mode ErrorFix but without sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = navigator.continueTo(Mode.ErrorFix, call)(request, hc)
+        val result = navigator.continueTo(Mode.ErrorFix, call)(decoratedRequest(request), hc)
 
         redirectLocation(result) shouldBe Some(controllers.routes.SubmissionsController.displayListOfSubmissions().url)
       }
 
       "backLink method is invoked with mode ErrorFix but without sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix)(request)
+        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix)(decoratedRequest(request))
 
         result shouldBe controllers.routes.SubmissionsController.displayListOfSubmissions()
       }
 
       "backLink method for items is invoked with mode ErrorFix but without sourceId in request" in {
 
-        val request = new JourneyRequest[AnyContent](authenticatedRequest, declaration)
-
-        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix, ItemId("123456"))(request)
+        val result = Navigator.backLink(CarrierDetails, Mode.ErrorFix, ItemId("123456"))(decoratedRequest(request))
 
         result shouldBe controllers.routes.SubmissionsController.displayListOfSubmissions()
       }

--- a/test/services/cache/ExportsTestData.scala
+++ b/test/services/cache/ExportsTestData.scala
@@ -17,17 +17,18 @@
 package services.cache
 
 import base.ExportsTestData.newUser
+import base.RequestBuilder
 import forms.declaration._
 import forms.declaration.officeOfExit.AllowedUKOfficeOfExitAnswers
+import models.{DeclarationType, ExportsDeclaration}
 import models.DeclarationType.DeclarationType
 import models.declaration.Container
-import models.requests.{AuthenticatedRequest, JourneyRequest}
-import models.{DeclarationType, ExportsDeclaration}
+import models.requests.JourneyRequest
 import play.api.mvc.AnyContent
 import play.api.test.FakeRequest
 import utils.FakeRequestCSRFSupport._
 
-trait ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder {
+trait ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder with RequestBuilder {
 
   private def declaration(`type`: DeclarationType): ExportsDeclaration = aDeclaration(
     withType(`type`),
@@ -45,8 +46,8 @@ trait ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder 
   )
 
   protected def journeyRequest(`type`: DeclarationType = DeclarationType.STANDARD): JourneyRequest[AnyContent] =
-    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration(`type`))
+    new JourneyRequest(buildVerifiedEmailRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration(`type`))
 
   protected def journeyRequest(declaration: ExportsDeclaration): JourneyRequest[AnyContent] =
-    new JourneyRequest(new AuthenticatedRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
+    new JourneyRequest(buildVerifiedEmailRequest(FakeRequest("", "").withCSRFToken, newUser("12345", "12345")), declaration)
 }

--- a/test/unit/controllers/CancelDeclarationControllerSpec.scala
+++ b/test/unit/controllers/CancelDeclarationControllerSpec.scala
@@ -20,8 +20,8 @@ import base.Injector
 import com.codahale.metrics.Timer
 import com.kenshoo.play.metrics.Metrics
 import controllers.CancelDeclarationController
-import forms.cancellation.CancellationChangeReason.NoLongerRequired
 import forms.{CancelDeclaration, Lrn}
+import forms.cancellation.CancellationChangeReason.NoLongerRequired
 import metrics.{ExportsMetrics, MetricIdentifiers}
 import org.mockito.ArgumentMatchers
 import org.mockito.ArgumentMatchers.any
@@ -43,6 +43,7 @@ class CancelDeclarationControllerSpec extends ControllerWithoutFormSpec with Err
 
     val controller = new CancelDeclarationController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockCustomsDeclareExportsConnector,
       mockErrorHandler,
       mockExportsMetrics,

--- a/test/unit/controllers/ChoiceControllerSpec.scala
+++ b/test/unit/controllers/ChoiceControllerSpec.scala
@@ -38,7 +38,7 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues {
 
   val choicePage = mock[choice_page]
   val controller =
-    new ChoiceController(mockAuthAction, stubMessagesControllerComponents(), choicePage)
+    new ChoiceController(mockAuthAction, mockVerifiedEmailAction, stubMessagesControllerComponents(), choicePage)
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/RejectedNotificationsControllerSpec.scala
+++ b/test/unit/controllers/RejectedNotificationsControllerSpec.scala
@@ -35,6 +35,7 @@ class RejectedNotificationsControllerSpec extends ControllerWithoutFormSpec with
 
   private val controller = new RejectedNotificationsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockCustomsDeclareExportsConnector,
     stubMessagesControllerComponents(),
     mockRejectedReasons,

--- a/test/unit/controllers/RemoveSavedDeclarationsControllerSpec.scala
+++ b/test/unit/controllers/RemoveSavedDeclarationsControllerSpec.scala
@@ -33,6 +33,7 @@ class RemoveSavedDeclarationsControllerSpec extends ControllerWithoutFormSpec {
 
     val controller = new RemoveSavedDeclarationsController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockCustomsDeclareExportsConnector,
       stubMessagesControllerComponents(),
       removeDeclarationPage,

--- a/test/unit/controllers/SavedDeclarationsControllerSpec.scala
+++ b/test/unit/controllers/SavedDeclarationsControllerSpec.scala
@@ -33,6 +33,7 @@ class SavedDeclarationsControllerSpec extends ControllerWithoutFormSpec {
 
   private val controller = new SavedDeclarationsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockCustomsDeclareExportsConnector,
     stubMessagesControllerComponents(),
     savedDeclarationsPage,

--- a/test/unit/controllers/SubmissionsControllerSpec.scala
+++ b/test/unit/controllers/SubmissionsControllerSpec.scala
@@ -18,11 +18,11 @@ package unit.controllers
 
 import java.time.{Instant, LocalDate, ZoneOffset, ZonedDateTime}
 import java.util.UUID
-
 import akka.util.Timeout
 import config.PaginationConfig
 import connectors.exchange.ExportsDeclarationExchange
 import controllers.SubmissionsController
+import controllers.actions.VerifiedEmailAction
 import models._
 import models.declaration.notifications.Notification
 import models.declaration.submissions.RequestType.SubmissionRequest
@@ -59,6 +59,7 @@ class SubmissionsControllerSpec extends ControllerWithoutFormSpec with BeforeAnd
 
   val controller = new SubmissionsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockCustomsDeclareExportsConnector,
     stubMessagesControllerComponents(),
     submissionsPage,

--- a/test/unit/controllers/UnverifiedEmailControllerSpec.scala
+++ b/test/unit/controllers/UnverifiedEmailControllerSpec.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers
+
+import config.AppConfig
+import controllers.UnverifiedEmailController
+import play.api.test.Helpers._
+import unit.base.ControllerWithoutFormSpec
+import views.html.unverified_email
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, when}
+import play.twirl.api.HtmlFormat
+
+class UnverifiedEmailControllerSpec extends ControllerWithoutFormSpec {
+
+  val page = mock[unverified_email]
+
+  def controller() =
+    new UnverifiedEmailController(mockAuthAction, stubMessagesControllerComponents(), page, mock[AppConfig])
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach
+
+    reset(page)
+
+    authorizedUser()
+    when(page.apply(any())(any(), any())).thenReturn(HtmlFormat.empty)
+  }
+
+  "UnverifiedEmailController" should {
+    "display the unverified email detection page" in {
+      val result = controller().informUser(getRequest())
+
+      status(result) mustBe OK
+    }
+  }
+}

--- a/test/unit/controllers/actions/AuthActionSpec.scala
+++ b/test/unit/controllers/actions/AuthActionSpec.scala
@@ -29,7 +29,7 @@ class AuthActionSpec extends ControllerWithoutFormSpec with Injector {
   val choicePage = instanceOf[choice_page]
 
   val controller =
-    new ChoiceController(mockAuthAction, stubMessagesControllerComponents(), choicePage)
+    new ChoiceController(mockAuthAction, mockVerifiedEmailAction, stubMessagesControllerComponents(), choicePage)
 
   "Auth Action" should {
 

--- a/test/unit/controllers/actions/VerifiedEmailActionSpec.scala
+++ b/test/unit/controllers/actions/VerifiedEmailActionSpec.scala
@@ -1,0 +1,99 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.controllers.actions
+
+import base.{ExportsTestData, Injector}
+import connectors.CustomsDeclareExportsConnector
+import controllers.actions.VerifiedEmailActionImpl
+import models.{EORI, VerifiedEmailAddress}
+import models.requests.{AuthenticatedRequest, VerifiedEmailRequest}
+import org.mockito.ArgumentMatchers.{eq => meq, _}
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.concurrent.ScalaFutures
+import play.api.{Configuration, Environment}
+import play.api.mvc.{MessagesControllerComponents, Result}
+import play.api.test.FakeRequest
+import unit.base.ControllerWithoutFormSpec
+
+import java.time.ZonedDateTime
+import scala.concurrent.Future
+
+class VerifiedEmailActionSpec extends ControllerWithoutFormSpec with Injector with ScalaFutures {
+
+  lazy val conf = instanceOf[Configuration]
+  lazy val env = instanceOf[Environment]
+  lazy val mcc = instanceOf[MessagesControllerComponents]
+  lazy val backendConnector = mock[CustomsDeclareExportsConnector]
+
+  lazy val action = new ActionTestWrapper(backendConnector, mcc)
+
+  lazy val sampleEmailAddress = "example@example.com"
+  lazy val sampleEori = EORI("12345")
+  lazy val user = ExportsTestData.newUser(sampleEori.value, "Id")
+
+  lazy val verifiedEmail = VerifiedEmailAddress(sampleEmailAddress, ZonedDateTime.now())
+  lazy val authenticatedRequest = new AuthenticatedRequest[Any](FakeRequest("GET", "requestPath"), user)
+
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(backendConnector)
+  }
+
+  "VerifiedEmailAction" should {
+    "return a VerifiedEmailRequest" when {
+      "user has a verified email address" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any(), any())).thenReturn(Future.successful(Some(verifiedEmail)))
+
+        val request = new AuthenticatedRequest(authenticatedRequest, user)
+
+        whenReady(action.testRefine(request)) { result =>
+          result mustBe Right(VerifiedEmailRequest(request, sampleEmailAddress))
+        }
+      }
+    }
+
+    "return a redirection Result" when {
+      "user has no verified email address" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any(), any())).thenReturn(Future.successful(None))
+
+        val request = new AuthenticatedRequest(authenticatedRequest, user)
+
+        whenReady(action.testRefine(request)) { result =>
+          result must be('left)
+        }
+      }
+    }
+
+    "propagate exception" when {
+      "connector fails" in {
+        when(backendConnector.getVerifiedEmailAddress(meq(sampleEori))(any(), any()))
+          .thenReturn(Future.failed(new Exception("Some unhappy response")))
+
+        val request = new AuthenticatedRequest(authenticatedRequest, user)
+        val result = action.testRefine(request)
+
+        assert(result.failed.futureValue.isInstanceOf[Exception])
+      }
+    }
+  }
+
+  class ActionTestWrapper(backendConnector: CustomsDeclareExportsConnector, mcc: MessagesControllerComponents)
+      extends VerifiedEmailActionImpl(backendConnector, mcc) {
+    def testRefine[A](request: AuthenticatedRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] =
+      refine(request)
+  }
+}

--- a/test/unit/controllers/declaration/AdditionalActorsAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalActorsAddControllerSpec.scala
@@ -39,6 +39,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
   val controller = new AdditionalActorsAddController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
@@ -40,6 +40,7 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
   val controller =
     new AdditionalActorsRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/AdditionalActorsSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalActorsSummaryControllerSpec.scala
@@ -39,6 +39,7 @@ class AdditionalActorsSummaryControllerSpec extends ControllerSpec with OptionVa
 
   val controller = new AdditionalActorsSummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
@@ -39,6 +39,7 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec {
 
   val controller = new AdditionalDeclarationTypeController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
@@ -39,6 +39,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
 
   val controller = new AdditionalFiscalReferencesAddController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
@@ -39,6 +39,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
   val controller =
     new AdditionalFiscalReferencesRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/AdditionalInformationAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationAddControllerSpec.scala
@@ -40,6 +40,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
   val controller = new AdditionalInformationAddController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
@@ -41,6 +41,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
   val controller = new AdditionalInformationChangeController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationControllerSpec.scala
@@ -38,6 +38,7 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
 
   val controller = new AdditionalInformationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/AdditionalInformationRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationRemoveControllerSpec.scala
@@ -41,6 +41,7 @@ class AdditionalInformationRemoveControllerSpec extends ControllerSpec with Opti
   val controller =
     new AdditionalInformationRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
+++ b/test/unit/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
@@ -36,6 +36,7 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
   val controller = new AdditionalInformationRequiredController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/BorderTransportControllerSpec.scala
@@ -38,6 +38,7 @@ class BorderTransportControllerSpec extends ControllerSpec {
 
   val controller = new BorderTransportController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -39,6 +39,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
 
   val controller = new CarrierDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/CarrierEoriNumberControllerSpec.scala
+++ b/test/unit/controllers/declaration/CarrierEoriNumberControllerSpec.scala
@@ -41,6 +41,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new CarrierEoriNumberController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/CommodityDetailsControllerSpec.scala
@@ -38,6 +38,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new CommodityDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/CommodityMeasureControllerSpec.scala
+++ b/test/unit/controllers/declaration/CommodityMeasureControllerSpec.scala
@@ -37,6 +37,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
   val controller = new CommodityMeasureController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ConfirmationControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConfirmationControllerSpec.scala
@@ -32,7 +32,13 @@ class ConfirmationControllerSpec extends ControllerWithoutFormSpec with Injector
     val draftConfirmationPage = instanceOf[draft_confirmation_page]
 
     val controller =
-      new ConfirmationController(mockAuthAction, stubMessagesControllerComponents(), submissionConfirmationPage, draftConfirmationPage)
+      new ConfirmationController(
+        mockAuthAction,
+        mockVerifiedEmailAction,
+        stubMessagesControllerComponents(),
+        submissionConfirmationPage,
+        draftConfirmationPage
+      )
 
     authorizedUser()
   }

--- a/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -38,6 +38,7 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
 
   val controller = new ConsigneeDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -38,6 +38,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec {
 
   val controller = new ConsignmentReferencesController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ConsignorDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsignorDetailsControllerSpec.scala
@@ -39,6 +39,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
   val controller = new ConsignorDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
+++ b/test/unit/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
@@ -41,6 +41,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new ConsignorEoriNumberController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/CusCodeControllerSpec.scala
+++ b/test/unit/controllers/declaration/CusCodeControllerSpec.scala
@@ -37,7 +37,15 @@ class CusCodeControllerSpec extends ControllerSpec {
   val mockPage = mock[cus_code]
 
   val controller =
-    new CusCodeController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)(ec)
+    new CusCodeController(
+      mockAuthAction,
+      mockVerifiedEmailAction,
+      mockJourneyAction,
+      mockExportsCacheService,
+      navigator,
+      stubMessagesControllerComponents(),
+      mockPage
+    )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -39,6 +39,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec {
 
   val controller = new DeclarantDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DeclarantExporterControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarantExporterControllerSpec.scala
@@ -37,6 +37,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new DeclarantExporterController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DeclarationChoiceControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationChoiceControllerSpec.scala
@@ -46,7 +46,9 @@ class DeclarationChoiceControllerSpec extends ControllerWithoutFormSpec with Opt
   val choicePage = mock[declaration_choice]
 
   val controller =
-    new DeclarationChoiceController(mockAuthAction, mockExportsCacheService, stubMessagesControllerComponents(), choicePage)(ec)
+    new DeclarationChoiceController(mockAuthAction, mockVerifiedEmailAction, mockExportsCacheService, stubMessagesControllerComponents(), choicePage)(
+      ec
+    )
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/DeclarationHolderAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderAddControllerSpec.scala
@@ -36,15 +36,15 @@ class DeclarationHolderAddControllerSpec extends ControllerSpec with OptionValue
 
   val mockAddPage = mock[declaration_holder_add]
 
-  val controller =
-    new DeclarationHolderAddController(
-      mockAuthAction,
-      mockJourneyAction,
-      mockExportsCacheService,
-      navigator,
-      stubMessagesControllerComponents(),
-      mockAddPage
-    )(ec)
+  val controller = new DeclarationHolderAddController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    mockAddPage
+  )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
@@ -36,15 +36,15 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
 
   val mockAddPage = mock[declaration_holder_change]
 
-  val controller =
-    new DeclarationHolderChangeController(
-      mockAuthAction,
-      mockJourneyAction,
-      mockExportsCacheService,
-      navigator,
-      stubMessagesControllerComponents(),
-      mockAddPage
-    )(ec)
+  val controller = new DeclarationHolderChangeController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    mockAddPage
+  )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/DeclarationHolderControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderControllerSpec.scala
@@ -39,6 +39,7 @@ class DeclarationHolderControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new DeclarationHolderController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DeclarationHolderRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderRemoveControllerSpec.scala
@@ -36,15 +36,15 @@ class DeclarationHolderRemoveControllerSpec extends ControllerSpec with OptionVa
 
   val mockRemovePage = mock[declaration_holder_remove]
 
-  val controller =
-    new DeclarationHolderRemoveController(
-      mockAuthAction,
-      mockJourneyAction,
-      mockExportsCacheService,
-      navigator,
-      stubMessagesControllerComponents(),
-      mockRemovePage
-    )(ec)
+  val controller = new DeclarationHolderRemoveController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    mockRemovePage
+  )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/DeclarationHolderRequiredControllerSpec.scala
+++ b/test/unit/controllers/declaration/DeclarationHolderRequiredControllerSpec.scala
@@ -38,6 +38,7 @@ class DeclarationHolderRequiredControllerSpec extends ControllerSpec with Option
 
   val controller = new DeclarationHolderRequiredController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
+++ b/test/unit/controllers/declaration/DepartureTransportControllerSpec.scala
@@ -42,6 +42,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
   val controller = new DepartureTransportController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DestinationCountryControllerSpec.scala
+++ b/test/unit/controllers/declaration/DestinationCountryControllerSpec.scala
@@ -39,6 +39,7 @@ class DestinationCountryControllerSpec extends ControllerSpec {
 
   val controller = new DestinationCountryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
+++ b/test/unit/controllers/declaration/DispatchLocationControllerSpec.scala
@@ -38,6 +38,7 @@ class DispatchLocationControllerSpec extends ControllerSpec {
 
   val controller = new DispatchLocationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DocumentsProducedAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/DocumentsProducedAddControllerSpec.scala
@@ -38,6 +38,7 @@ class DocumentsProducedAddControllerSpec extends ControllerSpec with ErrorHandle
 
   val controller = new DocumentsProducedAddController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DocumentsProducedChangeControllerSpec.scala
+++ b/test/unit/controllers/declaration/DocumentsProducedChangeControllerSpec.scala
@@ -39,6 +39,7 @@ class DocumentsProducedChangeControllerSpec extends ControllerSpec with ErrorHan
 
   val controller = new DocumentsProducedChangeController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DocumentsProducedControllerSpec.scala
+++ b/test/unit/controllers/declaration/DocumentsProducedControllerSpec.scala
@@ -37,6 +37,7 @@ class DocumentsProducedControllerSpec extends ControllerSpec with ErrorHandlerMo
 
   val controller = new DocumentsProducedController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/DocumentsProducedRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/DocumentsProducedRemoveControllerSpec.scala
@@ -40,6 +40,7 @@ class DocumentsProducedRemoveControllerSpec extends ControllerSpec with OptionVa
   val controller =
     new DocumentsProducedRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/EntryIntoDeclarantsRecordsControllerSpec.scala
+++ b/test/unit/controllers/declaration/EntryIntoDeclarantsRecordsControllerSpec.scala
@@ -40,6 +40,7 @@ class EntryIntoDeclarantsRecordsControllerSpec extends ControllerSpec with Scala
 
   private val controller = new EntryIntoDeclarantsRecordsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ExporterDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/ExporterDetailsControllerSpec.scala
@@ -40,6 +40,7 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new ExporterDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/ExporterEoriNumberControllerSpec.scala
+++ b/test/unit/controllers/declaration/ExporterEoriNumberControllerSpec.scala
@@ -41,6 +41,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
 
   val controller = new ExporterEoriNumberController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
+++ b/test/unit/controllers/declaration/FiscalInformationControllerSpec.scala
@@ -38,6 +38,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new FiscalInformationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/InlandTransportDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/InlandTransportDetailsControllerSpec.scala
@@ -39,6 +39,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with BeforeAnd
 
   private val controller = new InlandTransportDetailsController(
     authenticate = mockAuthAction,
+    verifyEmail = mockVerifiedEmailAction,
     journeyType = mockJourneyAction,
     navigator = navigator,
     exportsCacheService = mockExportsCacheService,

--- a/test/unit/controllers/declaration/IsExsControllerSpec.scala
+++ b/test/unit/controllers/declaration/IsExsControllerSpec.scala
@@ -38,8 +38,15 @@ class IsExsControllerSpec extends ControllerSpec with ScalaFutures {
 
   private val isExsPage = mock[is_exs]
 
-  private val controller =
-    new IsExsController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), isExsPage)(ec)
+  private val controller = new IsExsController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    isExsPage
+  )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/ItemsSummaryControllerSpec.scala
@@ -50,6 +50,7 @@ class ItemsSummaryControllerSpec extends ControllerWithoutFormSpec with OptionVa
 
   private val controller = new ItemsSummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/LocationControllerSpec.scala
+++ b/test/unit/controllers/declaration/LocationControllerSpec.scala
@@ -37,6 +37,7 @@ class LocationControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new LocationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     stubMessagesControllerComponents(),
     mockGoodsLocationPage,

--- a/test/unit/controllers/declaration/NactCodeAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/NactCodeAddControllerSpec.scala
@@ -39,6 +39,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new NactCodeAddController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/NactCodeRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/NactCodeRemoveControllerSpec.scala
@@ -38,6 +38,7 @@ class NactCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new NactCodeRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/NactCodeSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/NactCodeSummaryControllerSpec.scala
@@ -35,8 +35,15 @@ class NactCodeSummaryControllerSpec extends ControllerSpec with OptionValues {
 
   val mockPage = mock[nact_codes]
 
-  val controller =
-    new NactCodeSummaryController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)
+  val controller = new NactCodeSummaryController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    mockExportsCacheService,
+    navigator,
+    stubMessagesControllerComponents(),
+    mockPage
+  )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/NatureOfTransactionControllerSpec.scala
+++ b/test/unit/controllers/declaration/NatureOfTransactionControllerSpec.scala
@@ -38,6 +38,7 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new NatureOfTransactionController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
+++ b/test/unit/controllers/declaration/NotEligibleControllerSpec.scala
@@ -32,7 +32,7 @@ class NotEligibleControllerSpec extends ControllerWithoutFormSpec {
     val notDeclarantPage: not_declarant = mock[not_declarant]
 
     val controller =
-      new NotEligibleController(mockAuthAction, stubMessagesControllerComponents(), notEligiblePage, notDeclarantPage)
+      new NotEligibleController(mockAuthAction, mockVerifiedEmailAction, stubMessagesControllerComponents(), notEligiblePage, notDeclarantPage)
 
     authorizedUser()
     withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))

--- a/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
+++ b/test/unit/controllers/declaration/OfficeOfExitControllerSpec.scala
@@ -37,6 +37,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new OfficeOfExitController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/OfficeOfExitOutsideUkControllerSpec.scala
+++ b/test/unit/controllers/declaration/OfficeOfExitOutsideUkControllerSpec.scala
@@ -37,6 +37,7 @@ class OfficeOfExitOutsideUkControllerSpec extends ControllerSpec with OptionValu
 
   val controller = new OfficeOfExitOutsideUkController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/OriginationCountryControllerSpec.scala
+++ b/test/unit/controllers/declaration/OriginationCountryControllerSpec.scala
@@ -39,6 +39,7 @@ class OriginationCountryControllerSpec extends ControllerSpec {
 
   val controller = new OriginationCountryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/PackageInformationAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/PackageInformationAddControllerSpec.scala
@@ -38,6 +38,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
   val controller =
     new PackageInformationAddController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/PackageInformationRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/PackageInformationRemoveControllerSpec.scala
@@ -38,6 +38,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with OptionV
   val controller =
     new PackageInformationRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/PackageInformationSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/PackageInformationSummaryControllerSpec.scala
@@ -39,6 +39,7 @@ class PackageInformationSummaryControllerSpec extends ControllerSpec with Option
 
   val controller = new PackageInformationSummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
+++ b/test/unit/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
@@ -41,6 +41,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
 
   private val controller = new PersonPresentingGoodsDetailsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/PreviousDocumentsControllerSpec.scala
+++ b/test/unit/controllers/declaration/PreviousDocumentsControllerSpec.scala
@@ -36,6 +36,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
   val controller = new PreviousDocumentsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
@@ -36,6 +36,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
   private val controller = new PreviousDocumentsRemoveController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/PreviousDocumentsSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/PreviousDocumentsSummaryControllerSpec.scala
@@ -38,6 +38,7 @@ class PreviousDocumentsSummaryControllerSpec extends ControllerSpec {
 
   private val controller = new PreviousDocumentsSummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
+++ b/test/unit/controllers/declaration/ProcedureCodesControllerSpec.scala
@@ -41,6 +41,7 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
   val controller = new ProcedureCodesController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/RepresentativeAgentControllerSpec.scala
+++ b/test/unit/controllers/declaration/RepresentativeAgentControllerSpec.scala
@@ -37,6 +37,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new RepresentativeAgentController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/RepresentativeEntityControllerSpec.scala
+++ b/test/unit/controllers/declaration/RepresentativeEntityControllerSpec.scala
@@ -38,6 +38,7 @@ class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new RepresentativeEntityController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/RepresentativeStatusControllerSpec.scala
+++ b/test/unit/controllers/declaration/RepresentativeStatusControllerSpec.scala
@@ -39,6 +39,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new RepresentativeStatusController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/RoutingCountriesControllerSpec.scala
+++ b/test/unit/controllers/declaration/RoutingCountriesControllerSpec.scala
@@ -37,6 +37,7 @@ class RoutingCountriesControllerSpec extends ControllerSpec {
 
   val controller = new RoutingCountriesController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/RoutingCountriesSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/RoutingCountriesSummaryControllerSpec.scala
@@ -38,6 +38,7 @@ class RoutingCountriesSummaryControllerSpec extends ControllerSpec {
 
   val controller = new RoutingCountriesSummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/SealControllerSpec.scala
+++ b/test/unit/controllers/declaration/SealControllerSpec.scala
@@ -44,6 +44,7 @@ class SealControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
   val controller = new SealController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockErrorHandler,

--- a/test/unit/controllers/declaration/StatisticalValueControllerSpec.scala
+++ b/test/unit/controllers/declaration/StatisticalValueControllerSpec.scala
@@ -40,6 +40,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
 
   val controller = new StatisticalValueController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockErrorHandler,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/SubmittedDeclarationControllerSpec.scala
+++ b/test/unit/controllers/declaration/SubmittedDeclarationControllerSpec.scala
@@ -39,6 +39,7 @@ class SubmittedDeclarationControllerSpec extends ControllerWithoutFormSpec with 
 
   private val controller = new SubmittedDeclarationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockCustomsDeclareExportsConnector,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/SummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/SummaryControllerSpec.scala
@@ -46,6 +46,7 @@ class SummaryControllerSpec extends ControllerWithoutFormSpec with ErrorHandlerM
 
   private val controller = new SummaryController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockErrorHandler,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/unit/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -37,6 +37,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
   private val controller = new SupervisingCustomsOfficeController(
     authenticate = mockAuthAction,
+    verifyEmail = mockVerifiedEmailAction,
     journeyType = mockJourneyAction,
     navigator = navigator,
     exportsCacheService = mockExportsCacheService,

--- a/test/unit/controllers/declaration/TaricCodeAddControllerSpec.scala
+++ b/test/unit/controllers/declaration/TaricCodeAddControllerSpec.scala
@@ -39,6 +39,7 @@ class TaricCodeAddControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeAddController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/TaricCodeRemoveControllerSpec.scala
+++ b/test/unit/controllers/declaration/TaricCodeRemoveControllerSpec.scala
@@ -38,6 +38,7 @@ class TaricCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeRemoveController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/TaricCodeSummaryControllerSpec.scala
+++ b/test/unit/controllers/declaration/TaricCodeSummaryControllerSpec.scala
@@ -38,6 +38,7 @@ class TaricCodeSummaryControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeSummaryController(
       mockAuthAction,
+      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/unit/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
+++ b/test/unit/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
@@ -61,6 +61,7 @@ class TotalNumberOfItemsControllerSpec extends ControllerSpec with OptionValues 
 
   val controller = new TotalNumberOfItemsController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/unit/controllers/declaration/TotalPackageQuantityControllerSpec.scala
+++ b/test/unit/controllers/declaration/TotalPackageQuantityControllerSpec.scala
@@ -37,6 +37,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
 
   val controller = new TotalPackageQuantityController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     stubMessagesControllerComponents(),
     navigator,

--- a/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportContainerControllerSpec.scala
@@ -43,6 +43,7 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
 
   val controller = new TransportContainerController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
@@ -37,6 +37,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec {
 
   val controller = new TransportLeavingTheBorderController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/unit/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -35,15 +35,15 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
   val transportPaymentPage = mock[transport_payment]
 
-  val controller =
-    new TransportPaymentController(
-      mockAuthAction,
-      mockJourneyAction,
-      navigator,
-      mockExportsCacheService,
-      stubMessagesControllerComponents(),
-      transportPaymentPage
-    )(ec)
+  val controller = new TransportPaymentController(
+    mockAuthAction,
+    mockVerifiedEmailAction,
+    mockJourneyAction,
+    navigator,
+    mockExportsCacheService,
+    stubMessagesControllerComponents(),
+    transportPaymentPage
+  )(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/unit/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
+++ b/test/unit/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
@@ -39,6 +39,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new UNDangerousGoodsCodeController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/unit/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -38,6 +38,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
   val controller = new WarehouseIdentificationController(
     mockAuthAction,
+    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/unit/controllers/pdf/EADControllerSpec.scala
+++ b/test/unit/controllers/pdf/EADControllerSpec.scala
@@ -44,7 +44,7 @@ class EADControllerSpec extends ControllerWithoutFormSpec with Injector {
   val connector = mock[CustomsDeclareExportsConnector]
   val eADService = new EADService(barcodeService, pdfTemplate, playFop, connector)
 
-  val controller = new EADController(mockAuthAction, mcc, eADService)
+  val controller = new EADController(mockAuthAction, mockVerifiedEmailAction, mcc, eADService)
 
   override def beforeEach(): Unit = {
     when(connector.fetchMrnStatus(any())(any(), any())).thenReturn(Future.successful(Some(MrnStatusSpec.completeMrnStatus)))

--- a/test/unit/mock/ItemActionMocks.scala
+++ b/test/unit/mock/ItemActionMocks.scala
@@ -26,5 +26,5 @@ import scala.concurrent.ExecutionContext
 trait ItemActionMocks extends JourneyActionMocks with MockAuthAction {
   self: MockitoSugar with Suite with BeforeAndAfterEach =>
 
-  val mockItemAction = new ItemActionBuilder(mockAuthAction, mockJourneyAction)(ExecutionContext.global)
+  val mockItemAction = new ItemActionBuilder(mockAuthAction, mockVerifiedEmailAction, mockJourneyAction)(ExecutionContext.global)
 }

--- a/test/unit/mock/VerifiedEmailMocks.scala
+++ b/test/unit/mock/VerifiedEmailMocks.scala
@@ -1,0 +1,33 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package unit.mock
+
+import controllers.actions.VerifiedEmailAction
+import models.requests.{AuthenticatedRequest, VerifiedEmailRequest}
+import play.api.mvc.Result
+
+import scala.concurrent.{ExecutionContext, Future}
+
+trait VerifiedEmailMocks {
+  val mockVerifiedEmailAction =
+    new VerifiedEmailAction() {
+      implicit val executionContext: ExecutionContext = ExecutionContext.global
+
+      override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] =
+        Future.successful(Right(VerifiedEmailRequest(request, "example@example.com")))
+    }
+}

--- a/test/views/UnverifiedEmailSpec.scala
+++ b/test/views/UnverifiedEmailSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views
+
+import base.Injector
+import helpers.views.declaration.CommonMessages
+import unit.tools.Stubs
+import views.declaration.spec.UnitViewSpec
+import views.html.unverified_email
+
+import scala.collection.JavaConverters._
+
+class UnverifiedEmailSpec extends UnitViewSpec with CommonMessages with Stubs with Injector {
+
+  lazy val redirectUrl = "/some/url"
+
+  val page = instanceOf[unverified_email]
+
+  val view = () => page(redirectUrl)(request, messages)
+
+  val messageKeyPrefix = "emailUnverified"
+
+  "Unverified Email Page" must {
+
+    "display page header" in {
+      view().getElementsByTag("h1").first() must containMessage(s"$messageKeyPrefix.heading")
+    }
+
+    "have a 'Verify your email address' button with correct link" in {
+      val link = view().getElementsByClass("govuk-button").first()
+
+      link must haveHref(redirectUrl)
+      link must containMessage(s"${messageKeyPrefix}.link")
+    }
+
+    "have paragraph1 with text" in {
+      view().getElementById("emailUnverified.para1") must containMessage(s"${messageKeyPrefix}.paragraph1")
+    }
+
+    "have bullet list with expected items" in {
+      val ul = view().getElementById("emailUnverified.bullets")
+
+      val expectedBulletTextKeys = (1 to 4).map { idx =>
+        s"${messageKeyPrefix}.bullets.item${idx}"
+      }
+
+      val itemsWithExpectedKeys = ul.children().asScala.zip(expectedBulletTextKeys)
+
+      itemsWithExpectedKeys.foreach { itemWithExpected =>
+        val (item, expectedKey) = itemWithExpected
+        item must containMessage(expectedKey)
+      }
+    }
+  }
+}


### PR DESCRIPTION
Add new action refiner that checks the verification
status of the user's email address. If the email
address in unverified the user is redirected to a
page informing them of the fact and offering them
a link to the customs-email-frontend service to
verify their address.