### PR TITLE
[CEDS-2821] Receiving MRN via URL param to skip entry page

### DIFF
--- a/app/config/SfusConfig.scala
+++ b/app/config/SfusConfig.scala
@@ -24,7 +24,9 @@ import play.api.Configuration
 class SfusConfig @Inject()(featureSwitchConfig: FeatureSwitchConfig, config: Configuration) {
 
   val sfusLink: String =
-    config.getOptional[String]("urls.sfus").getOrElse(throw new IllegalStateException("Missing configuration for CDS File Upload frontend start"))
+    config
+      .getOptional[String]("urls.sfus")
+      .getOrElse(throw new IllegalStateException("Missing configuration for CDS File Upload frontend mrn page url"))
 
   val isSfusEnabled: Boolean = featureSwitchConfig.isFeatureOn(Feature.sfus)
 }

--- a/app/views/declaration_information.scala.html
+++ b/app/views/declaration_information.scala.html
@@ -43,10 +43,9 @@
     }
 
     @if(status == SubmissionStatus.ADDITIONAL_DOCUMENTS_REQUIRED && sfusConfig.isSfusEnabled) {
-        @link(text = messages("submissions.sfus"), call = Call("GET", sfusConfig.sfusLink), target="_blank")
+        @link(text = messages("submissions.sfus"), call = Call("GET", s"${sfusConfig.sfusLink}/${submission.mrn.getOrElse("")}"), target="_blank")
     }
 }
-
 
 @renderDeclarationLinks = {
     <div class="govuk-list">

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -153,7 +153,7 @@ urls {
   tradeTariffVol3ForCds2 = "https://www.gov.uk/government/collections/uk-trade-tariff-volume-3-for-cds--2"
   classificationHelp = "https://www.gov.uk/guidance/ask-hmrc-for-advice-on-classifying-your-goods"
   ecicsTool = "https://ec.europa.eu/taxation_customs/dds2/ecics/chemicalsubstance_consultation.jsp"
-  sfus = "http://localhost:6793/cds-file-upload-service/start"
+  sfus = "http://localhost:6793/cds-file-upload-service/mrn-entry"
   eoriService = "https://www.gov.uk/eori"
   cdsRegister = "https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service"
   cdsCheckStatus = "https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk"


### PR DESCRIPTION
As part of the usability improvements we are allowing the link
to SFUS from the Exports UI to include the MRN of the declaration
to pre-populate that field and remove the need for the user
to re-type it.