### PR TITLE
[CEDS-2965] Removing signin link from signout page

### DIFF
--- a/app/views/user_signed_out.scala.html
+++ b/app/views/user_signed_out.scala.html
@@ -39,12 +39,6 @@
 
   @pageTitle(messages("userSignedOut.title"))
 
-  @paragraphBody(messages("userSignedOut.information"))
-
-    <p class="govuk-body">
-    @link(text= messages("userSignedOut.rootPageLink", request.host), call = controllers.routes.RootController.displayPage())
-  </p>
-
   @exitSurvey()
 
   @govukLink

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1572,8 +1572,6 @@ field.declaration.locations.warehouseIdentification.supervisingCustomsOffice = C
 field.declaration.consignmentReferences.ucr = Unique Consignment Reference (UCR)
 
 userSignedOut.title = We have saved your answers and signed you out
-userSignedOut.information = To continue the declaration later, save this link:
-userSignedOut.rootPageLink = {0}/customs-declare-exports/
 
 pdf.template.title = Export accompanying document (EAD)
 pdf.template.mrn = MRN


### PR DESCRIPTION
Will be brought back once the Government Gateway link
has been created.