### PR TITLE
[CEDS-3109]_Choice_page_for_Exports_UI

### DIFF
--- a/app/forms/Choice.scala
+++ b/app/forms/Choice.scala
@@ -30,7 +30,7 @@ object Choice {
   val choiceId = "Choice"
 
   import AllowedChoiceValues._
-  private val correctChoices = Set(CreateDec, ContinueDec, CancelDec, Submissions)
+  private val correctChoices = Set(CreateDec, ContinueDec, CancelDec, Submissions, Inbox)
 
   val choiceMapping: Mapping[Choice] = Forms.single(
     "value" -> optional(
@@ -47,6 +47,7 @@ object Choice {
     val ContinueDec = "CON"
     val CancelDec = "CAN"
     val Submissions = "SUB"
+    val Inbox = "MSG"
   }
 
   implicit val queryStringBindable: QueryStringBindable[Choice] = new QueryStringBindable[Choice] {

--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -76,6 +76,12 @@
                     value = Some(CancelDec),
                     content = Text(messages(s"declaration.choice.$CancelDec")),
                     checked = form("value").value.contains(CancelDec)
+                ),
+                RadioItem(
+                    id = Some(Inbox),
+                    value = Some(Inbox),
+                    content = Text(messages(s"declaration.choice.$Inbox")),
+                    checked = form("value").value.contains(Inbox)
                 )
             ).filter(radioOption => availableJourneys.contains(radioOption.value.get)),
             errorMessage = form("value").error.map(err => ErrorMessage(content = Text(messages(err.message, err.args:_*))))
@@ -84,12 +90,18 @@
         @saveAndContinue("site.continue")
 
         @if(secureMessagingInboxConfig.isSfusSecureMessagingEnabled) {
-            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2">
-            <h3>@messages("declaration.choice.linkDescription")</h3>
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
+            <h3>@messages("declaration.choice.link.sfus.description")</h3>
 
             <p>@link(id = Some("sfusUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = Call("GET", s"${sfusConfig.sfusUploadLink}"), target = "_blank")</p>
             <p>@link(id = Some("sfusInboxLink"), text = messages("declaration.choice.link.sfusInbox.txt"), call = Call("GET", s"${secureMessagingInboxConfig.sfusInboxLink}"), target = "_blank")</p>
-            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2">
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
+        }
+        @if(secureMessagingInboxConfig.isExportsSecureMessagingEnabled) {
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
+            <h3>@messages("declaration.choice.link.exports.description")</h3>
+            <p>@link(id = Some("sfusUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = Call("GET", s"${sfusConfig.sfusUploadLink}"), target = "_blank")</p>
+            <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
         }
     }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -110,7 +110,7 @@ microservice {
   }
 }
 
-list-of-available-journeys = "CRT,CAN,SUB,CON"
+list-of-available-journeys = "CRT,CAN,SUB,CON,MSG"
 list-of-available-declarations = "STANDARD,SUPPLEMENTARY,SIMPLIFIED,OCCASIONAL,radio_divider,CLEARANCE"
 
 countryCodesCsvFilename = "code-lists/mdg-country-codes.csv"

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -104,13 +104,15 @@ cancellation.reason.otherReason = Other reason
 cancellation.reason.noLongerRequired = No longer required
 
 declaration.choice.description = What do you want to do?
-declaration.choice.linkDescription = If you receive a notification to upload documents or respond to a query, you can use the CDS document uploads and secure messages service.
+declaration.choice.link.sfus.description = If you receive a notification to upload documents or respond to a query, you can use the CDS document uploads and secure messages service.
+declaration.choice.link.exports.description = If you receive a notification to upload documents you can use the CDS uploads service.
 declaration.choice.link.sfusInbox.txt = View messages (opens in new tab)
 declaration.choice.link.sfusUpload.txt = Upload documents (opens in new tab)
 declaration.choice.CRT = Create a declaration
 declaration.choice.CAN = Cancel a declaration
 declaration.choice.CON = Continue a declaration you saved
 declaration.choice.SUB = View and manage your submitted declarations
+declaration.choice.MSG = View messages
 
 declaration.section.1 = Section 1 of 6
 declaration.section.2 = Section 2 of 6

--- a/test/base/ExportsTestData.scala
+++ b/test/base/ExportsTestData.scala
@@ -194,5 +194,5 @@ object ExportsTestData extends ExportsDeclarationBuilder {
 
   val choiceForm = Json.toJson(Choice("EAL"))
 
-  val allJourneys = Seq(CreateDec, ContinueDec, CancelDec, Submissions)
+  val allJourneys = Seq(CreateDec, ContinueDec, CancelDec, Submissions, Inbox)
 }

--- a/test/unit/controllers/actions/AuthActionSpec.scala
+++ b/test/unit/controllers/actions/AuthActionSpec.scala
@@ -17,7 +17,7 @@
 package unit.controllers.actions
 
 import base.Injector
-import config.AppConfig
+import config.{AppConfig, SecureMessagingInboxConfig}
 import controllers.ChoiceController
 import controllers.actions.NoExternalId
 import play.api.test.Helpers._
@@ -29,9 +29,17 @@ class AuthActionSpec extends ControllerWithoutFormSpec with Injector {
 
   val choicePage = instanceOf[choice_page]
   val appConfig = mock[AppConfig]
+  val secureMessagingInboxConfig = mock[SecureMessagingInboxConfig]
 
   val controller =
-    new ChoiceController(mockAuthAction, mockVerifiedEmailAction, stubMessagesControllerComponents(), choicePage, appConfig)
+    new ChoiceController(
+      mockAuthAction,
+      mockVerifiedEmailAction,
+      stubMessagesControllerComponents(),
+      secureMessagingInboxConfig,
+      choicePage,
+      appConfig
+    )
 
   "Auth Action" should {
 

--- a/test/views/ChoiceViewSpec.scala
+++ b/test/views/ChoiceViewSpec.scala
@@ -19,8 +19,9 @@ package views
 import base.ExportsTestData._
 import base.OverridableInjector
 import config.{SecureMessagingInboxConfig, SfusConfig}
+import features.SecureMessagingFeatureStatus
+import features.SecureMessagingFeatureStatus.SecureMessagingFeatureStatus
 import forms.Choice
-import forms.Choice.AllowedChoiceValues.CreateDec
 import org.jsoup.nodes.Document
 import org.mockito.Mockito.{reset, when}
 import org.scalatest.BeforeAndAfterEach
@@ -44,7 +45,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
     new OverridableInjector(bind[SfusConfig].toInstance(sfusConfig), bind[SecureMessagingInboxConfig].toInstance(secureMessagingInboxConfig))
   private val choicePage = injector.instanceOf[choice_page]
 
-  private def createView(form: Form[Choice] = form): Document = choicePage(form, allJourneys)(request, messages)
+  private def createView(form: Form[Choice] = form, journeys: Seq[String] = allJourneys): Document = choicePage(form, journeys)(request, messages)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -59,22 +60,37 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
   private val dummyUploadLink = "dummyUploadLink"
   private val dummyInboxLink = "dummyInboxLink"
 
-  private def withSfusInboxEnabled(messaging: Boolean = true): Unit = {
+  private val SFUS = SecureMessagingFeatureStatus.sfus
+  private val EXPORTS = SecureMessagingFeatureStatus.exports
+  private val DISABLED = SecureMessagingFeatureStatus.disabled
+
+  private def withSecureMessagingFeatureStatus(flag: SecureMessagingFeatureStatus): Unit = {
+    flag match {
+      case SFUS =>
+        when(secureMessagingInboxConfig.isSfusSecureMessagingEnabled).thenReturn(true)
+        when(secureMessagingInboxConfig.isExportsSecureMessagingEnabled).thenReturn(false)
+      case EXPORTS =>
+        when(secureMessagingInboxConfig.isSfusSecureMessagingEnabled).thenReturn(false)
+        when(secureMessagingInboxConfig.isExportsSecureMessagingEnabled).thenReturn(true)
+      case _ =>
+        when(secureMessagingInboxConfig.isSfusSecureMessagingEnabled).thenReturn(false)
+        when(secureMessagingInboxConfig.isExportsSecureMessagingEnabled).thenReturn(false)
+    }
+
     when(sfusConfig.sfusUploadLink).thenReturn(dummyUploadLink)
-    when(secureMessagingInboxConfig.isSfusSecureMessagingEnabled).thenReturn(messaging)
     when(secureMessagingInboxConfig.sfusInboxLink).thenReturn(dummyInboxLink)
   }
 
   "Choice View on empty page" should {
 
     "display same page title as header" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val viewWithMessage = createView()
       viewWithMessage.title() must include(viewWithMessage.getElementsByTag("h1").text())
     }
 
     "display radio buttons with description (not selected)" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().fill(Choice("")))
       ensureAllLabelTextIsCorrect(view)
 
@@ -82,26 +98,18 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       ensureRadioIsUnChecked(view, "CAN")
       ensureRadioIsUnChecked(view, "SUB")
       ensureRadioIsUnChecked(view, "CON")
-    }
-
-    "display only Create radio button with description" in {
-      withSfusInboxEnabled()
-      val form = Choice.form().fill(Choice("CRT"))
-      val view = choicePage(form, Seq(CreateDec))(request, messages)
-
-      ensureCreateLabelIsCorrect(view)
-      ensureRadioIsChecked(view, "CRT")
+      ensureRadioIsUnChecked(view, "MSG")
     }
 
     "not display 'Back' button" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val backButton = createView().getElementById("back-link")
 
       backButton mustBe null
     }
 
     "display 'Continue' button on page" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView()
 
       val saveButton = view.getElementsByClass("govuk-button")
@@ -111,17 +119,32 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
 
   "Choice View" when {
 
-    "secure messaging flag is enabled" should {
+    "available journey types are restricted" should {
+      "display only the appropriate radio buttons" in {
+        allJourneys.foreach { excludedJourneyKey =>
+          val filteredJourneyKeys = allJourneys.filterNot(_.equals(excludedJourneyKey))
+          val view = createView(journeys = filteredJourneyKeys)
+
+          filteredJourneyKeys.foreach { journeyKey =>
+            view.getElementById(journeyKey) mustNot be(null)
+          }
+
+          view.getElementById(excludedJourneyKey) mustBe null
+        }
+      }
+    }
+
+    "secureMessagingInbox flag is set to 'sfus'" should {
       "display SFUS link description text" in {
-        withSfusInboxEnabled()
+        withSecureMessagingFeatureStatus(SFUS)
         val h3s = createView().getElementsByTag("h3")
 
         h3s.size mustBe 1
-        h3s.first().text() mustBe messages("declaration.choice.linkDescription")
+        h3s.first().text() mustBe messages("declaration.choice.link.sfus.description")
       }
 
       "display SFUS upload documents link" in {
-        withSfusInboxEnabled()
+        withSecureMessagingFeatureStatus(SFUS)
         val link = createView().getElementById("sfusUploadLink")
 
         link.text() mustBe messages("declaration.choice.link.sfusUpload.txt")
@@ -129,7 +152,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       }
 
       "display SFUS message inbox link" in {
-        withSfusInboxEnabled()
+        withSecureMessagingFeatureStatus(SFUS)
         val link = createView().getElementById("sfusInboxLink")
 
         link.text() mustBe messages("declaration.choice.link.sfusInbox.txt")
@@ -137,20 +160,38 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       }
     }
 
-    "secure messaging flag is disabled" should {
-      "not display SFUS link description text" in {
-        withSfusInboxEnabled(false)
+    "secureMessagingInbox flag is set to 'exports'" should {
+      "display Exports link description text" in {
+        withSecureMessagingFeatureStatus(EXPORTS)
+        val h3s = createView().getElementsByTag("h3")
+
+        h3s.size mustBe 1
+        h3s.first().text() mustBe messages("declaration.choice.link.exports.description")
+      }
+
+      "display SFUS upload documents link" in {
+        withSecureMessagingFeatureStatus(EXPORTS)
+        val link = createView().getElementById("sfusUploadLink")
+
+        link.text() mustBe messages("declaration.choice.link.sfusUpload.txt")
+        link.attr("href") mustBe dummyUploadLink
+      }
+    }
+
+    "secureMessagingInbox flag is set to 'disabled'" should {
+      "not display SFUS or Exports link description text" in {
+        withSecureMessagingFeatureStatus(DISABLED)
         val h3s = createView().getElementsByTag("h3")
         h3s.size mustBe 0
       }
 
       "not display SFUS upload documents link" in {
-        withSfusInboxEnabled(false)
+        withSecureMessagingFeatureStatus(DISABLED)
         createView().getElementById("sfusUploadLink") mustBe null
       }
 
       "not display SFUS inbox link" in {
-        withSfusInboxEnabled(false)
+        withSecureMessagingFeatureStatus(DISABLED)
         createView().getElementById("sfusInboxLink") mustBe null
       }
     }
@@ -159,7 +200,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
   "Choice View for invalid input" should {
 
     "display error when no choice is made" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().bind(Map[String, String]()))
 
       view must haveGovukGlobalErrorSummary
@@ -169,7 +210,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
     }
 
     "display error when choice is incorrect" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().bind(Map("value" -> "incorrect")))
 
       view must haveGovukGlobalErrorSummary
@@ -182,7 +223,7 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
   "Choice View when filled" should {
 
     "display selected radio button - Create (CRT)" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().fill(Choice("CRT")))
       ensureAllLabelTextIsCorrect(view)
 
@@ -190,10 +231,11 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       ensureRadioIsUnChecked(view, "CAN")
       ensureRadioIsUnChecked(view, "SUB")
       ensureRadioIsUnChecked(view, "CON")
+      ensureRadioIsUnChecked(view, "MSG")
     }
 
     "display selected radio button - Cancel a declaration (CAN)" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().fill(Choice("CAN")))
       ensureAllLabelTextIsCorrect(view)
 
@@ -201,10 +243,11 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       ensureRadioIsChecked(view, "CAN")
       ensureRadioIsUnChecked(view, "SUB")
       ensureRadioIsUnChecked(view, "CON")
+      ensureRadioIsUnChecked(view, "MSG")
     }
 
     "display selected radio button - View recent declarations (SUB)" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().fill(Choice("SUB")))
 
       ensureAllLabelTextIsCorrect(view)
@@ -213,10 +256,11 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       ensureRadioIsUnChecked(view, "CAN")
       ensureRadioIsChecked(view, "SUB")
       ensureRadioIsUnChecked(view, "CON")
+      ensureRadioIsUnChecked(view, "MSG")
     }
 
     "display selected radio button - Continue saved declaration (Con)" in {
-      withSfusInboxEnabled()
+      withSecureMessagingFeatureStatus(EXPORTS)
       val view = createView(Choice.form().fill(Choice("CON")))
 
       ensureAllLabelTextIsCorrect(view)
@@ -225,20 +269,30 @@ class ChoiceViewSpec extends UnitViewSpec with CommonMessages with Stubs with Be
       ensureRadioIsUnChecked(view, "CAN")
       ensureRadioIsUnChecked(view, "SUB")
       ensureRadioIsChecked(view, "CON")
+      ensureRadioIsUnChecked(view, "MSG")
+    }
+
+    "display selected radio button - View Messages (Msg)" in {
+      withSecureMessagingFeatureStatus(EXPORTS)
+      val view = createView(Choice.form().fill(Choice("MSG")))
+
+      ensureAllLabelTextIsCorrect(view)
+
+      ensureRadioIsUnChecked(view, "CRT")
+      ensureRadioIsUnChecked(view, "CAN")
+      ensureRadioIsUnChecked(view, "SUB")
+      ensureRadioIsUnChecked(view, "CON")
+      ensureRadioIsChecked(view, "MSG")
     }
   }
 
   private def ensureAllLabelTextIsCorrect(view: Document): Unit = {
-    view.getElementsByTag("label").size mustBe 4
+    view.getElementsByTag("label").size mustBe 5
     view.getElementsByAttributeValue("for", "CRT") must containMessageForElements("declaration.choice.CRT")
     view.getElementsByAttributeValue("for", "SUB") must containMessageForElements("declaration.choice.SUB")
     view.getElementsByAttributeValue("for", "CAN") must containMessageForElements("declaration.choice.CAN")
     view.getElementsByAttributeValue("for", "CON") must containMessageForElements("declaration.choice.CON")
-  }
-
-  private def ensureCreateLabelIsCorrect(view: Document): Unit = {
-    view.getElementsByTag("label").size mustBe 1
-    view.getElementsByAttributeValue("for", "CRT") must containMessageForElements("declaration.choice.CRT")
+    view.getElementsByAttributeValue("for", "MSG") must containMessageForElements("declaration.choice.MSG")
   }
 
   private def ensureRadioIsChecked(view: Document, elementId: String): Unit = {


### PR DESCRIPTION
Add a new radio button option that when selected takes
the user to the Exports secure message inbox page, only
visible when the 'secureMessagingInbox' feature flag is
set to 'exports'.

Also adds a link to the SFUS file upload service on the
choice page when 'secureMessagingInbox' feature flag is
set to 'exports'.