### PR TITLE
[CEDS-2879] Make address validation more permissive

### DIFF
--- a/app/forms/common/Address.scala
+++ b/app/forms/common/Address.scala
@@ -36,22 +36,19 @@ case class Address(
 object Address {
   implicit val format = Json.format[Address]
 
-  private val validateAddressField: Int => String => Boolean =
-    (length: Int) => (input: String) => noLongerThan(length)(input) and isAlphanumeric(input.replaceAll(" ", ""))
-
   val mapping = Forms.mapping(
     "fullName" -> text()
       .verifying("declaration.address.fullName.empty", nonEmpty)
-      .verifying("declaration.address.fullName.error", isEmpty or (isValidName and noLongerThan(70))),
+      .verifying("declaration.address.fullName.error", isEmpty or noLongerThan(70)),
     "addressLine" -> text()
       .verifying("declaration.address.addressLine.empty", nonEmpty)
-      .verifying("declaration.address.addressLine.error", validateAddressField(70)),
+      .verifying("declaration.address.addressLine.error", noLongerThan(70)),
     "townOrCity" -> text()
       .verifying("declaration.address.townOrCity.empty", nonEmpty)
-      .verifying("declaration.address.townOrCity.error", validateAddressField(35)),
+      .verifying("declaration.address.townOrCity.error", noLongerThan(35)),
     "postCode" -> text()
       .verifying("declaration.address.postCode.empty", nonEmpty)
-      .verifying("declaration.address.postCode.error", validateAddressField(9)),
+      .verifying("declaration.address.postCode.error", noLongerThan(9)),
     "country" -> text()
       .verifying("declaration.address.country.empty", nonEmpty)
       .verifying(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -498,11 +498,11 @@ declaration.representative.representationType.indirect = Indirect representative
 declaration.representative.representationType.indirect.hint = The representative is sharing legal responsibility with the exporter.
 
 declaration.address.fullName = Full name
-declaration.address.fullName.error = Enter a name, up to 35 characters
-declaration.address.fullName.empty = Enter a name, up to 35 characters
+declaration.address.fullName.error = Enter a name, up to 70 characters.
+declaration.address.fullName.empty = Enter a name, up to 70 characters.
 declaration.address.addressLine = Address line 1
-declaration.address.addressLine.error = Enter an address line 1, up to 35 characters
-declaration.address.addressLine.empty = Enter an address line 1, up to 35 characters
+declaration.address.addressLine.error = Enter an address line 1, up to 70 characters.
+declaration.address.addressLine.empty = Enter an address line 1, up to 70 characters.
 declaration.address.townOrCity = Town or city
 declaration.address.townOrCity.error = Enter a town or city, up to 35 characters
 declaration.address.townOrCity.empty = Enter a town or city, up to 35 characters

--- a/test/forms/common/AddressSpec.scala
+++ b/test/forms/common/AddressSpec.scala
@@ -45,15 +45,6 @@ class AddressSpec extends WordSpec with MustMatchers {
         fullNameError must be(defined)
         fullNameError.get.message must equal("declaration.address.fullName.error")
       }
-
-      "provided with input containing special characters" in {
-        val input = buildAddressInputMap(fullName = "FullName!@#")
-        val form = Address.form().bind(input)
-
-        val fullNameError = form.errors.find(_.key == "fullName")
-        fullNameError must be(defined)
-        fullNameError.get.message must equal("declaration.address.fullName.error")
-      }
     }
 
     "contain errors for addressLine" when {
@@ -68,15 +59,6 @@ class AddressSpec extends WordSpec with MustMatchers {
 
       "provided with input longer than 70 characters" in {
         val input = buildAddressInputMap(addressLine = createRandomAlphanumericString(71))
-        val form = Address.form().bind(input)
-
-        val addressLineError = form.errors.find(_.key == "addressLine")
-        addressLineError must be(defined)
-        addressLineError.get.message must equal("declaration.address.addressLine.error")
-      }
-
-      "provided with input containing special characters" in {
-        val input = buildAddressInputMap(addressLine = "Address!@#")
         val form = Address.form().bind(input)
 
         val addressLineError = form.errors.find(_.key == "addressLine")
@@ -103,15 +85,6 @@ class AddressSpec extends WordSpec with MustMatchers {
         townOrCityError must be(defined)
         townOrCityError.get.message must equal("declaration.address.townOrCity.error")
       }
-
-      "provided with input containing special characters" in {
-        val input = buildAddressInputMap(townOrCity = "City%$#")
-        val form = Address.form().bind(input)
-
-        val townOrCityError = form.errors.find(_.key == "townOrCity")
-        townOrCityError must be(defined)
-        townOrCityError.get.message must equal("declaration.address.townOrCity.error")
-      }
     }
 
     "contain errors for postCode" when {
@@ -126,15 +99,6 @@ class AddressSpec extends WordSpec with MustMatchers {
 
       "provided with input in wrong format" in {
         val input = buildAddressInputMap(postCode = "AB 12 CD 345")
-        val form = Address.form().bind(input)
-
-        val postCodeError = form.errors.find(_.key == "postCode")
-        postCodeError must be(defined)
-        postCodeError.get.message must equal("declaration.address.postCode.error")
-      }
-
-      "provided with input containing special characters" in {
-        val input = buildAddressInputMap(postCode = "AB*^ $%7")
         val form = Address.form().bind(input)
 
         val postCodeError = form.errors.find(_.key == "postCode")
@@ -203,16 +167,21 @@ object AddressSpec {
 
   import play.api.libs.json._
 
-  val correctAddress =
-    Address(fullName = "Full Name", addressLine = "Address Line", townOrCity = "Town or City", postCode = "AB12 34CD", country = "Poland")
+  val seventyOneChars = "01234567890123456789012345678901234567890123456789012345678901234567890"
+  val thirtySixChars = "0123456789012345678901234567890123456"
+  val tenChars = "01234567890"
 
-  val incorrectAddress = Address(
-    fullName = "nX9KuS2J6Ee1ATbgbcZFaFOCHI1t8RJnNfbU0dbPQAK4w0q6PdzuZIyxcXziSbUBzizlmi1",
-    addressLine = "nX9KuS2J6Ee1ATbgbcZFaFOCHI1t8RJnNfbU0dbPQAK4w0q6PdzuZIyxcXziSbUBzizlmi1",
-    townOrCity = "gDsSwbyP6cPkpgRZSHoH3JtEj8grDfjsVCmq",
-    postCode = "TN0EHF96qN",
-    country = "abc"
-  )
+  val correctAddress =
+    Address(
+      fullName = "Full Name abcABC123¬!\"£$%^&*()_+=-`|\\<,>?:;@'~#{}[]Ħ",
+      addressLine = "Address Line abcABC123¬!\"£$%^&*()_+=-`|\\<,>?:;@'~#{}[]Ħ",
+      townOrCity = "Town¬!\"£$%^&*()_+=-`|\\<,>?:;@'~#Ħ",
+      postCode = "AB12 34CĦ",
+      country = "Poland"
+    )
+
+  val incorrectAddress =
+    Address(fullName = seventyOneChars, addressLine = seventyOneChars, townOrCity = thirtySixChars, postCode = tenChars, country = "abc")
 
   val addressWithEmptyFullname =
     Address(fullName = "", addressLine = "Address Line", townOrCity = "Town or City", postCode = "AB12 34CD", country = "Poland")

--- a/test/forms/declaration/EntityDetailsSpec.scala
+++ b/test/forms/declaration/EntityDetailsSpec.scala
@@ -22,6 +22,7 @@ import play.api.libs.json.{JsObject, JsString, JsValue}
 
 class EntityDetailsSpec extends WordSpec with MustMatchers {
   import EntityDetailsSpec._
+  import AddressSpec._
 
   "Bound form with NamedEntityDetails mapping" should {
 
@@ -82,7 +83,7 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
     "contain errors for Address only" when {
       "EORI is empty & Address has error in a single field" in {
         val address =
-          Address(fullName = "!@#$%^&*", addressLine = "Address Line", townOrCity = "City", postCode = "AB12 CD3", country = "United Kingdom")
+          Address(fullName = seventyOneChars, addressLine = "Address Line", townOrCity = "City", postCode = "AB12 CD3", country = "United Kingdom")
         val input = buildEntityInputMap(address = address)
 
         val form = EntityDetails.form().bind(input)
@@ -96,10 +97,10 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
 
       "EORI is empty & Address has errors in all fields" in {
         val address = Address(
-          fullName = "!@#$%^&*",
-          addressLine = "",
-          townOrCity = "City!@$",
-          postCode = "AB12 CD34 1235 1346",
+          fullName = seventyOneChars,
+          addressLine = seventyOneChars,
+          townOrCity = thirtySixChars,
+          postCode = tenChars,
           country = "Any Country you can imagine"
         )
         val input = buildEntityInputMap(address = address)
@@ -110,7 +111,7 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
         val addressErrors = form.errors.filter(_.key.contains("address."))
         addressErrors.size must equal(5)
         addressErrors.map(_.message) must contain("declaration.address.fullName.error")
-        addressErrors.map(_.message) must contain("declaration.address.addressLine.empty")
+        addressErrors.map(_.message) must contain("declaration.address.addressLine.error")
         addressErrors.map(_.message) must contain("declaration.address.townOrCity.error")
         addressErrors.map(_.message) must contain("declaration.address.postCode.error")
         addressErrors.map(_.message) must contain("declaration.address.country.error")
@@ -119,10 +120,10 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
       "EORI is correct but Address has errors" in {
         val eori = "9GB1234567ABCDEF"
         val address = Address(
-          fullName = "!@#$%^&*",
-          addressLine = "",
-          townOrCity = "City!@$",
-          postCode = "AB12 CD34 1235 1346",
+          fullName = seventyOneChars,
+          addressLine = seventyOneChars,
+          townOrCity = thirtySixChars,
+          postCode = tenChars,
           country = "Any Country you can imagine"
         )
         val input = buildEntityInputMap(eori, address)
@@ -133,7 +134,7 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
         val addressErrors = form.errors.filter(_.key.contains("address."))
         addressErrors.size must equal(5)
         addressErrors.map(_.message) must contain("declaration.address.fullName.error")
-        addressErrors.map(_.message) must contain("declaration.address.addressLine.empty")
+        addressErrors.map(_.message) must contain("declaration.address.addressLine.error")
         addressErrors.map(_.message) must contain("declaration.address.townOrCity.error")
         addressErrors.map(_.message) must contain("declaration.address.postCode.error")
         addressErrors.map(_.message) must contain("declaration.address.country.error")
@@ -144,10 +145,10 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
       "both EORI & Address elements are wrong" in {
         val eori = "9GB!@#$%^&*"
         val address = Address(
-          fullName = "!@#$%^&*",
-          addressLine = "",
-          townOrCity = "City!@$",
-          postCode = "AB12 CD34 1235 1346",
+          fullName = seventyOneChars,
+          addressLine = seventyOneChars,
+          townOrCity = thirtySixChars,
+          postCode = tenChars,
           country = "Any Country you can imagine"
         )
         val input = buildEntityInputMap(eori, address)
@@ -163,7 +164,7 @@ class EntityDetailsSpec extends WordSpec with MustMatchers {
         val addressErrors = form.errors.filter(_.key.contains("address."))
         addressErrors.size must equal(5)
         addressErrors.map(_.message) must contain("declaration.address.fullName.error")
-        addressErrors.map(_.message) must contain("declaration.address.addressLine.empty")
+        addressErrors.map(_.message) must contain("declaration.address.addressLine.error")
         addressErrors.map(_.message) must contain("declaration.address.townOrCity.error")
         addressErrors.map(_.message) must contain("declaration.address.postCode.error")
         addressErrors.map(_.message) must contain("declaration.address.country.error")

--- a/test/unit/forms/declaration/ExporterDetailsSpec.scala
+++ b/test/unit/forms/declaration/ExporterDetailsSpec.scala
@@ -30,22 +30,29 @@ class ExporterDetailsSpec extends WordSpec with MustMatchers with LightFormMatch
 
   onEveryDeclarationJourney() { request =>
     s"Exporter Details form for ${request.declarationType}" should {
+
       val outcomeFromIncorrectForm = ExporterDetails.form(request.declarationType).bind(incorrectExporterDetailsJSON)
+
       "validate eori and address" in {
         outcomeFromIncorrectForm.error("details.eori") must haveMessage("declaration.eori.error.format")
       }
+
       "validate address fullname" in {
         outcomeFromIncorrectForm.error("details.address.fullName") must haveMessage("declaration.address.fullName.error")
       }
+
       "validate address addresline" in {
         outcomeFromIncorrectForm.error("details.address.addressLine") must haveMessage("declaration.address.addressLine.error")
       }
+
       "validate town or city" in {
         outcomeFromIncorrectForm.error("details.address.townOrCity") must haveMessage("declaration.address.townOrCity.error")
       }
+
       "validate post code" in {
         outcomeFromIncorrectForm.error("details.address.postCode") must haveMessage("declaration.address.postCode.error")
       }
+
       "validate country" in {
         outcomeFromIncorrectForm.error("details.address.country") must haveMessage("declaration.address.country.error")
       }


### PR DESCRIPTION
Before the address form validation restricted values
to be alphanumeric and latin characters only.

This is in contrast to the DMS Schema rules that allow
any characters and only limits on the field lengths
allowed.

These changes relax the implemented validation rules
to become inline with the DMS Schema rules.