### PR TITLE
CEDS-3132 Set order of document types on 'previous_documents' page

### DIFF
--- a/app/services/DocumentType.scala
+++ b/app/services/DocumentType.scala
@@ -29,9 +29,10 @@ object DocumentType {
 
   private val deserialiser: (String, String) => DocumentType = (a: String, b: String) => DocumentType(a, b)
 
+  // CEDS-3132: the resulting tariff list should be rendered in the same order as shown at:
+  // https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/915216/Previous_document_codes_for_Data_Element_2-1_of_the_Customs_Declaration_Service_-_v2.csv/preview
   val allDocuments: List[DocumentType] = JsonFile
     .readFromJsonFile("/code-lists/document-type-autocomplete-list.json", deserialiser)
-    .sortBy(_.description.toLowerCase)
 
   val documentCodesMap: Map[String, DocumentType] =
     allDocuments.map(documentType => (documentType.code, documentType)).toMap

--- a/test/services/DocumentTypeSpec.scala
+++ b/test/services/DocumentTypeSpec.scala
@@ -17,26 +17,17 @@
 package services
 
 import org.scalatest.{MustMatchers, WordSpec}
+import org.scalatest.Inspectors.forAll
 import services.DocumentType.allDocuments
 
 class DocumentTypeSpec extends WordSpec with MustMatchers {
 
   "Document Type" should {
 
-    "return document type in correct order" in {
-
-      val threeTypes =
-        allDocuments.filter(
-          d =>
-            d.description == "Master Unique Consignment Reference (MUCR) (Including any inventory reference where applicable)" || d.description == "Information Sheet INF3" || d.description == "Other"
-        )
-      val expectedResult =
-        List(
-          DocumentType("Information Sheet INF3", "IF3"),
-          DocumentType("Master Unique Consignment Reference (MUCR) (Including any inventory reference where applicable)", "MCR"),
-          DocumentType("Other", "ZZZ")
-        )
-      threeTypes must be(expectedResult)
+    "return document type in the expected order (no-order, as loaded)" in {
+      val ixs = List(0, 1, 2, 3, 4, 25, 26, 33, 34, allDocuments.size - 1)
+      val codes = List("235", "270", "271", "325", "337", "955", "CLE", "SDE", "CSE", "CPD")
+      forAll(ixs zip codes)(t => allDocuments(t._1).code mustBe t._2)
     }
 
     "return correct text for asText method" in {


### PR DESCRIPTION
Set order of document types on 'previous_documents' page as shown at the gov.uk link given in ticket