### PR TITLE
CEDS-3058 Change inbox endpoint to /messages

### DIFF
--- a/conf/app.routes
+++ b/conf/app.routes
@@ -11,11 +11,11 @@ GET         /unauthorised                                  controllers.Unauthori
 GET         /unverified-email                              controllers.UnverifiedEmailController.informUser
 
 # Secure Messaging
-GET         /conversations                                 controllers.SecureMessagingController.displayInbox
+GET         /messages                                      controllers.SecureMessagingController.displayInbox
 GET         /conversation/:client/:conversationId          controllers.SecureMessagingController.displayConversation(client, conversationId)
 + nocsrf
-POST        /conversation/:client/:conversationId           controllers.SecureMessagingController.submitReply(client, conversationId)
-GET         /conversation/:client/:conversationId/result    controllers.SecureMessagingController.displayReplyResult(client, conversationId)
+POST        /conversation/:client/:conversationId          controllers.SecureMessagingController.submitReply(client, conversationId)
+GET         /conversation/:client/:conversationId/result   controllers.SecureMessagingController.displayReplyResult(client, conversationId)
 
 # Notifications
 


### PR DESCRIPTION
This is a fix to cover for hardcoded url value
in secure-message-frontend partial always pointing
to /messages url.