### PR TITLE
CEDS-3164 Remove email verification from journey endpoints

### DIFF
--- a/app/controllers/CancelDeclarationController.scala
+++ b/app/controllers/CancelDeclarationController.scala
@@ -41,7 +41,6 @@ class CancelDeclarationController @Inject()(
   authenticate: AuthAction,
   verifyEmail: VerifiedEmailAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
-  errorHandler: ErrorHandler,
   exportsMetrics: ExportsMetrics,
   mcc: MessagesControllerComponents,
   auditService: AuditService,

--- a/app/controllers/RemoveSavedDeclarationsController.scala
+++ b/app/controllers/RemoveSavedDeclarationsController.scala
@@ -16,17 +16,15 @@
 
 package controllers
 
-import config.AppConfig
 import connectors.CustomsDeclareExportsConnector
 import controllers.actions.{AuthAction, VerifiedEmailAction}
 import forms.RemoveDraftDeclaration.form
-
-import javax.inject.Inject
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.remove_declaration
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RemoveSavedDeclarationsController @Inject()(
@@ -34,8 +32,7 @@ class RemoveSavedDeclarationsController @Inject()(
   verifyEmail: VerifiedEmailAction,
   customsDeclareExportsConnector: CustomsDeclareExportsConnector,
   mcc: MessagesControllerComponents,
-  removeDeclarationPage: remove_declaration,
-  appConfig: AppConfig
+  removeDeclarationPage: remove_declaration
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport {
 

--- a/app/controllers/SubmissionsController.scala
+++ b/app/controllers/SubmissionsController.scala
@@ -100,8 +100,8 @@ class SubmissionsController @Inject()(
       }.getOrElse(Future.successful(None))
 
       actualDeclaration.flatMap {
-        case Some(dec) if dec.sourceId == Some(id) => Future.successful(redirect)
-        case _                                     => createNewDraftDec(id, redirect)
+        case Some(dec) if dec.sourceId.contains(id) => Future.successful(redirect)
+        case _                                      => createNewDraftDec(id, redirect)
       }
     }
 

--- a/app/controllers/actions/ItemAction.scala
+++ b/app/controllers/actions/ItemAction.scala
@@ -16,10 +16,10 @@
 
 package controllers.actions
 
-import javax.inject.Inject
 import models.requests.{ItemRequest, JourneyRequest}
 import play.api.mvc.{ActionRefiner, Result}
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 case class ItemAction(itemId: String)(implicit val executionContext: ExecutionContext) extends ActionRefiner[JourneyRequest, ItemRequest] {
@@ -37,9 +37,7 @@ case class ItemAction(itemId: String)(implicit val executionContext: ExecutionCo
     }
 }
 
-class ItemActionBuilder @Inject()(authorized: AuthAction, verifyEmail: VerifiedEmailAction, journeyAction: JourneyAction)(
-  implicit val executionContext: ExecutionContext
-) {
+class ItemActionBuilder @Inject()(authorized: AuthAction, journeyAction: JourneyAction)(implicit val executionContext: ExecutionContext) {
 
-  def apply(itemId: String) = authorized andThen verifyEmail andThen journeyAction andThen ItemAction(itemId)
+  def apply(itemId: String) = authorized andThen journeyAction andThen ItemAction(itemId)
 }

--- a/app/controllers/actions/JourneyAction.scala
+++ b/app/controllers/actions/JourneyAction.scala
@@ -18,7 +18,7 @@ package controllers.actions
 
 import com.google.inject.Inject
 import models.DeclarationType.DeclarationType
-import models.requests.{JourneyRequest, VerifiedEmailRequest}
+import models.requests.{AuthenticatedRequest, JourneyRequest}
 import play.api.Logger
 import play.api.mvc.{ActionRefiner, Result, Results}
 import services.cache.ExportsCacheService
@@ -28,13 +28,13 @@ import uk.gov.hmrc.play.HeaderCarrierConverter
 import scala.concurrent.{ExecutionContext, Future}
 
 class JourneyAction @Inject()(cacheService: ExportsCacheService)(implicit val exc: ExecutionContext)
-    extends ActionRefiner[VerifiedEmailRequest, JourneyRequest] {
+    extends ActionRefiner[AuthenticatedRequest, JourneyRequest] {
 
   private val logger = Logger(this.getClass)
 
   override protected def executionContext: ExecutionContext = exc
 
-  private def refiner[A](request: VerifiedEmailRequest[A], types: Seq[DeclarationType]): Future[Either[Result, JourneyRequest[A]]] = {
+  private def refiner[A](request: AuthenticatedRequest[A], types: Seq[DeclarationType]): Future[Either[Result, JourneyRequest[A]]] = {
     implicit val hc: HeaderCarrier = HeaderCarrierConverter.fromHeadersAndSession(request.headers, Some(request.session))
     request.declarationId match {
       case Some(id) =>
@@ -49,14 +49,14 @@ class JourneyAction @Inject()(cacheService: ExportsCacheService)(implicit val ex
         Future.successful(Left(Results.Redirect(controllers.routes.RootController.displayPage())))
     }
   }
-  override def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, JourneyRequest[A]]] =
+  override def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, JourneyRequest[A]]] =
     refiner(request, Seq.empty[DeclarationType])
 
-  def apply(type1: DeclarationType, others: DeclarationType*): ActionRefiner[VerifiedEmailRequest, JourneyRequest] = apply(others.toSeq.+:(type1))
+  def apply(type1: DeclarationType, others: DeclarationType*): ActionRefiner[AuthenticatedRequest, JourneyRequest] = apply(others.toSeq.+:(type1))
 
-  def apply(types: Seq[DeclarationType]): ActionRefiner[VerifiedEmailRequest, JourneyRequest] =
-    new ActionRefiner[VerifiedEmailRequest, JourneyRequest] {
-      override protected def refine[A](request: VerifiedEmailRequest[A]): Future[Either[Result, JourneyRequest[A]]] = refiner(request, types)
+  def apply(types: Seq[DeclarationType]): ActionRefiner[AuthenticatedRequest, JourneyRequest] =
+    new ActionRefiner[AuthenticatedRequest, JourneyRequest] {
+      override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, JourneyRequest[A]]] = refiner(request, types)
       override protected def executionContext: ExecutionContext = exc
     }
 }

--- a/app/controllers/actions/VerifiedEmailAction.scala
+++ b/app/controllers/actions/VerifiedEmailAction.scala
@@ -37,7 +37,7 @@ class VerifiedEmailActionImpl @Inject()(backendConnector: CustomsDeclareExportsC
     extends VerifiedEmailAction {
 
   implicit val executionContext: ExecutionContext = mcc.executionContext
-  private lazy val onError = Redirect(routes.UnverifiedEmailController.informUser)
+  private lazy val onError = Redirect(routes.UnverifiedEmailController.informUser())
 
   override protected def refine[A](request: AuthenticatedRequest[A]): Future[Either[Result, VerifiedEmailRequest[A]]] = {
 

--- a/app/controllers/declaration/AdditionalActorsAddController.scala
+++ b/app/controllers/declaration/AdditionalActorsAddController.scala
@@ -16,15 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalActorsAddController.AdditionalActorsFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.NoneOfTheAbove
 import forms.declaration.DeclarationAdditionalActors
 import forms.declaration.DeclarationAdditionalActors.form
-
-import javax.inject.Inject
 import models.declaration.DeclarationAdditionalActorsData
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -35,11 +33,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.additionalActors.additional_actors_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalActorsAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -51,7 +49,7 @@ class AdditionalActorsAddController @Inject()(
   val validTypes =
     Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.declarationAdditionalActorsData match {
       case Some(_) => Ok(declarationAdditionalActorsPage(mode, frm.fill(DeclarationAdditionalActors(None, Some(NoneOfTheAbove.value)))))
@@ -59,7 +57,7 @@ class AdditionalActorsAddController @Inject()(
     }
   }
 
-  def saveForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form().bindFromRequest()
     val cachedActors = request.cacheModel.parties.declarationAdditionalActorsData.map(_.actors).getOrElse(Seq.empty)
     boundForm.fold(

--- a/app/controllers/declaration/AdditionalActorsRemoveController.scala
+++ b/app/controllers/declaration/AdditionalActorsRemoveController.scala
@@ -16,13 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarationAdditionalActors
-
-import javax.inject.Inject
 import models.declaration.DeclarationAdditionalActorsData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -34,11 +32,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.additionalActors.additional_actors_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalActorsRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,14 +45,14 @@ class AdditionalActorsRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     findActor(id) match {
       case Some(actor) => Ok(removePage(mode, id, actor, removeYesNoForm.withSubmissionErrors()))
       case _           => navigator.continueTo(mode, routes.AdditionalActorsSummaryController.displayPage)
     }
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     findActor(id) match {
       case Some(actor) =>
         removeYesNoForm

--- a/app/controllers/declaration/AdditionalActorsSummaryController.scala
+++ b/app/controllers/declaration/AdditionalActorsSummaryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.{DeclarationType, Mode}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
@@ -30,9 +28,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.additionalActors.additional_actors_summary
 
+import javax.inject.Inject
+
 class AdditionalActorsSummaryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +42,7 @@ class AdditionalActorsSummaryController @Inject()(
   val validTypes =
     Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     request.cacheModel.parties.declarationAdditionalActorsData match {
       case Some(data) if data.actors.nonEmpty =>
         Ok(additionalActorsPage(mode, anotherYesNoForm.withSubmissionErrors(), data.actors))
@@ -51,7 +50,7 @@ class AdditionalActorsSummaryController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val actors = request.cacheModel.parties.declarationAdditionalActorsData.map(_.actors).getOrElse(Seq.empty)
     anotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.AdditionalDeclarationType
 import forms.declaration.additionaldeclarationtype._
@@ -33,7 +33,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalDeclarationTypeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -42,7 +41,7 @@ class AdditionalDeclarationTypeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val form = extractFormType(request).form().withSubmissionErrors()
     request.cacheModel.additionalDeclarationType match {
       case Some(data) => Ok(declarationTypePage(mode, form.fill(data)))
@@ -50,7 +49,7 @@ class AdditionalDeclarationTypeController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val decType = extractFormType(request).form().bindFromRequest()
 
     decType

--- a/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
@@ -16,15 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalFiscalReferencesAddController.AdditionalFiscalReferencesFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.AdditionalFiscalReference.form
 import forms.declaration.AdditionalFiscalReferencesData._
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -34,11 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.fiscalInformation.additional_fiscal_references_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalFiscalReferencesAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,12 +45,12 @@ class AdditionalFiscalReferencesAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     Ok(additionalFiscalReferencesPage(mode, itemId, frm))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form().bindFromRequest()
 
     boundForm.fold(

--- a/app/controllers/declaration/AdditionalInformationAddController.scala
+++ b/app/controllers/declaration/AdditionalInformationAddController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
-
-import javax.inject.Inject
 import models.declaration.AdditionalInformationData
 import models.declaration.AdditionalInformationData.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -35,11 +33,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.additionalInformation.additional_information_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -48,11 +46,11 @@ class AdditionalInformationAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     Ok(additionalInformationPage(mode, itemId, form().withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form().bindFromRequest()
 
     boundForm.fold(

--- a/app/controllers/declaration/AdditionalInformationChangeController.scala
+++ b/app/controllers/declaration/AdditionalInformationChangeController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
-
-import javax.inject.Inject
 import models.declaration.AdditionalInformationData
 import models.declaration.AdditionalInformationData.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -36,11 +34,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.additionalInformation.additional_information_change
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationChangeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -49,25 +47,23 @@ class AdditionalInformationChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
-    implicit request =>
-      findAdditionalInformation(itemId, id) match {
-        case Some(document) => Ok(changePage(mode, itemId, id, form().fill(document).withSubmissionErrors()))
-        case _              => returnToSummary(mode, itemId)
-      }
+  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    findAdditionalInformation(itemId, id) match {
+      case Some(document) => Ok(changePage(mode, itemId, id, form().fill(document).withSubmissionErrors()))
+      case _              => returnToSummary(mode, itemId)
+    }
   }
 
-  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      findAdditionalInformation(itemId, id) match {
-        case Some(existingInformation) =>
-          val boundForm = form().bindFromRequest()
-          boundForm.fold(
-            formWithErrors => Future.successful(BadRequest(changePage(mode, itemId, id, formWithErrors))),
-            updatedInformation => changeInformation(mode, itemId, id, existingInformation, updatedInformation, boundForm)
-          )
-        case _ => Future.successful(returnToSummary(mode, itemId))
-      }
+  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    findAdditionalInformation(itemId, id) match {
+      case Some(existingInformation) =>
+        val boundForm = form().bindFromRequest()
+        boundForm.fold(
+          formWithErrors => Future.successful(BadRequest(changePage(mode, itemId, id, formWithErrors))),
+          updatedInformation => changeInformation(mode, itemId, id, existingInformation, updatedInformation, boundForm)
+        )
+      case _ => Future.successful(returnToSummary(mode, itemId))
+    }
   }
 
   private def returnToSummary(mode: Mode, itemId: String)(implicit request: JourneyRequest[AnyContent]) =

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.Mode
 import models.requests.JourneyRequest
 import play.api.data.Form
@@ -31,9 +29,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.additionalInformation.additional_information
 
+import javax.inject.Inject
+
 class AdditionalInformationController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +40,7 @@ class AdditionalInformationController @Inject()(
   additionalInformationPage: additional_information
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = anotherYesNoForm.withSubmissionErrors()
     cachedAdditionalInformationData(itemId) match {
       case Some(data) if data.items.nonEmpty =>
@@ -53,7 +52,7 @@ class AdditionalInformationController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     anotherYesNoForm
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/AdditionalInformationRemoveController.scala
+++ b/app/controllers/declaration/AdditionalInformationRemoveController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper.remove
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.AdditionalInformation
-
-import javax.inject.Inject
 import models.declaration.AdditionalInformationData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -35,11 +33,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.additionalInformation.additional_information_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -48,34 +46,32 @@ class AdditionalInformationRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
-    implicit request =>
-      findAdditionalInformation(itemId, id) match {
-        case Some(information) => Ok(removePage(mode, itemId, id, information, removeYesNoForm.withSubmissionErrors()))
-        case _                 => returnToSummary(mode, itemId)
-      }
+  def displayPage(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    findAdditionalInformation(itemId, id) match {
+      case Some(information) => Ok(removePage(mode, itemId, id, information, removeYesNoForm.withSubmissionErrors()))
+      case _                 => returnToSummary(mode, itemId)
+    }
   }
 
-  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      findAdditionalInformation(itemId, id) match {
-        case Some(information) =>
-          removeYesNoForm
-            .bindFromRequest()
-            .fold(
-              (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(removePage(mode, itemId, id, information, formWithErrors))),
-              formData => {
-                formData.answer match {
-                  case YesNoAnswers.yes =>
-                    removeAdditionalInformation(itemId, information)
-                      .map(declaration => afterRemove(mode, itemId, declaration))
-                  case YesNoAnswers.no =>
-                    Future.successful(returnToSummary(mode, itemId))
-                }
+  def submitForm(mode: Mode, itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    findAdditionalInformation(itemId, id) match {
+      case Some(information) =>
+        removeYesNoForm
+          .bindFromRequest()
+          .fold(
+            (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(removePage(mode, itemId, id, information, formWithErrors))),
+            formData => {
+              formData.answer match {
+                case YesNoAnswers.yes =>
+                  removeAdditionalInformation(itemId, information)
+                    .map(declaration => afterRemove(mode, itemId, declaration))
+                case YesNoAnswers.no =>
+                  Future.successful(returnToSummary(mode, itemId))
               }
-            )
-        case _ => Future.successful(returnToSummary(mode, itemId))
-      }
+            }
+          )
+      case _ => Future.successful(returnToSummary(mode, itemId))
+    }
   }
 
   private def removeYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.additionalInformation.remove.empty")

--- a/app/controllers/declaration/AdditionalInformationRequiredController.scala
+++ b/app/controllers/declaration/AdditionalInformationRequiredController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.declaration.AdditionalInformationData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.additionalInformation.additional_information_required
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class AdditionalInformationRequiredController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,14 +43,14 @@ class AdditionalInformationRequiredController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     cachedItems(itemId) match {
       case items if items.isEmpty => Ok(additionalInfoReq(mode, itemId, previousAnswer(itemId).withSubmissionErrors()))
       case _                      => navigator.continueTo(mode, controllers.declaration.routes.AdditionalInformationController.displayPage(_, itemId))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/BorderTransportController.scala
+++ b/app/controllers/declaration/BorderTransportController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.BorderTransport
 import forms.declaration.BorderTransport._
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.border_transport
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class BorderTransportController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -46,7 +44,7 @@ class BorderTransportController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val transport = request.cacheModel.transport
     val borderTransportData = (
       transport.meansOfTransportCrossingTheBorderType,
@@ -63,7 +61,7 @@ class BorderTransportController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CarrierDetailsController.scala
+++ b/app/controllers/declaration/CarrierDetailsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.carrier.CarrierDetails
-
-import javax.inject.Inject
 import models.DeclarationType._
 import models.Mode
 import models.requests.JourneyRequest
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.carrier_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CarrierDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,7 +45,7 @@ class CarrierDetailsController @Inject()(
   private val validTypes = Seq(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE)
 
   def displayPage(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+    (authenticate andThen journeyType(validTypes)) { implicit request =>
       request.cacheModel.parties.carrierDetails match {
         case Some(data) => Ok(carrierDetailsPage(mode, form().fill(data)))
         case _          => Ok(carrierDetailsPage(mode, form()))
@@ -57,7 +55,7 @@ class CarrierDetailsController @Inject()(
   private def form()(implicit request: JourneyRequest[_]) = CarrierDetails.form(request.declarationType).withSubmissionErrors()
 
   def saveAddress(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+    (authenticate andThen journeyType(validTypes)).async { implicit request =>
       form()
         .bindFromRequest()
         .fold(

--- a/app/controllers/declaration/CarrierEoriNumberController.scala
+++ b/app/controllers/declaration/CarrierEoriNumberController.scala
@@ -16,15 +16,13 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.carrier.{CarrierDetails, CarrierEoriNumber}
-
-import javax.inject.Inject
-import models.{ExportsDeclaration, Mode}
-import models.requests.JourneyRequest
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD}
+import models.requests.JourneyRequest
+import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.carrier_eori_number
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CarrierEoriNumberController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -47,7 +45,7 @@ class CarrierEoriNumberController @Inject()(
 
   val validJourneys = Seq(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     request.cacheModel.parties.carrierDetails match {
       case Some(data) => Ok(carrierEoriDetailsPage(mode, form().fill(CarrierEoriNumber(data))))
       case _          => Ok(carrierEoriDetailsPage(mode, form()))
@@ -56,7 +54,7 @@ class CarrierEoriNumberController @Inject()(
 
   private def form()(implicit request: JourneyRequest[_]) = CarrierEoriNumber.form().withSubmissionErrors()
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.CommodityDetails
 import forms.declaration.CommodityDetails.form
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.commodity_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CommodityDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +42,7 @@ class CommodityDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form(request.declarationType).withSubmissionErrors()
     request.cacheModel.itemBy(itemId).flatMap(_.commodityDetails) match {
       case Some(commodityDetails) => Ok(commodityDetailsPage(mode, itemId, frm.fill(commodityDetails)))
@@ -52,7 +50,7 @@ class CommodityDetailsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form(request.declarationType)
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CommodityMeasureController.scala
+++ b/app/controllers/declaration/CommodityMeasureController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.CommodityMeasure
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.commodityMeasure.commodity_measure
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CommodityMeasureController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,14 +43,14 @@ class CommodityMeasureController @Inject()(
 
   private def form()(implicit request: JourneyRequest[_]) = CommodityMeasure.form(request.declarationType).withSubmissionErrors()
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.commodityMeasure) match {
       case Some(data) => Ok(commodityMeasurePage(mode, itemId, form().fill(data)))
       case _          => Ok(commodityMeasurePage(mode, itemId, form()))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ConfirmationController.scala
+++ b/app/controllers/declaration/ConfirmationController.scala
@@ -16,27 +16,26 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, VerifiedEmailAction}
-
-import javax.inject.Inject
+import controllers.actions.AuthAction
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.{draft_confirmation_page, submission_confirmation_page}
 
+import javax.inject.Inject
+
 class ConfirmationController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   mcc: MessagesControllerComponents,
   submissionConfirmationPage: submission_confirmation_page,
   draftConfirmationPage: draft_confirmation_page
 ) extends FrontendController(mcc) with I18nSupport {
 
-  def displaySubmissionConfirmation(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
+  def displaySubmissionConfirmation(): Action[AnyContent] = authenticate { implicit request =>
     Ok(submissionConfirmationPage())
   }
 
-  def displayDraftConfirmation(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
+  def displayDraftConfirmation(): Action[AnyContent] = authenticate { implicit request =>
     Ok(draftConfirmationPage())
   }
 }

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.ConsigneeDetails
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,6 +28,7 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.consignee_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 /**
@@ -37,7 +36,6 @@ import scala.concurrent.{ExecutionContext, Future}
   */
 class ConsigneeDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,7 +44,7 @@ class ConsigneeDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = ConsigneeDetails.form().withSubmissionErrors()
     request.cacheModel.parties.consigneeDetails match {
       case Some(data) => Ok(consigneeDetailsPage(mode, frm.fill(data)))
@@ -54,7 +52,7 @@ class ConsigneeDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     ConsigneeDetails
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.ConsignmentReferences
 import forms.declaration.ConsignmentReferences.form
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.consignment_references
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignmentReferencesController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +42,7 @@ class ConsignmentReferencesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.consignmentReferences match {
       case Some(data) => Ok(consignmentReferencesPage(mode, frm.fill(data)))
@@ -52,7 +50,7 @@ class ConsignmentReferencesController @Inject()(
     }
   }
 
-  def submitConsignmentReferences(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitConsignmentReferences(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ConsignorDetailsController.scala
+++ b/app/controllers/declaration/ConsignorDetailsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.consignor.ConsignorDetails
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.consignor_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignorDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,7 +43,7 @@ class ConsignorDetailsController @Inject()(
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     val frm = ConsignorDetails.form().withSubmissionErrors()
     request.cacheModel.parties.consignorDetails match {
       case Some(data) => Ok(consignorDetailsPage(mode, frm.fill(data)))
@@ -53,7 +51,7 @@ class ConsignorDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
     ConsignorDetails
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/ConsignorEoriNumberController.scala
+++ b/app/controllers/declaration/ConsignorEoriNumberController.scala
@@ -16,13 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.consignor.ConsignorEoriNumber.form
 import forms.declaration.consignor.{ConsignorDetails, ConsignorEoriNumber}
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.consignor_eori_number
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ConsignorEoriNumberController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -47,7 +45,7 @@ class ConsignorEoriNumberController @Inject()(
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.consignorDetails match {
       case Some(data) => Ok(consignorEoriDetailsPage(mode, frm.fill(ConsignorEoriNumber(data))))
@@ -55,7 +53,7 @@ class ConsignorEoriNumberController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/CusCodeController.scala
+++ b/app/controllers/declaration/CusCodeController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.CusCode
 import forms.declaration.CusCode.form
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.cus_code
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class CusCodeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,16 +44,15 @@ class CusCodeController @Inject()(
 
   val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) {
-    implicit request =>
-      val frm = form().withSubmissionErrors()
-      request.cacheModel.itemBy(itemId).flatMap(_.cusCode) match {
-        case Some(cusCode) => Ok(cusCodePage(mode, itemId, frm.fill(cusCode)))
-        case _             => Ok(cusCodePage(mode, itemId, frm))
-      }
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+    val frm = form().withSubmissionErrors()
+    request.cacheModel.itemBy(itemId).flatMap(_.cusCode) match {
+      case Some(cusCode) => Ok(cusCodePage(mode, itemId, frm.fill(cusCode)))
+      case _             => Ok(cusCodePage(mode, itemId, frm))
+    }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.Eori
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -35,7 +35,6 @@ import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarantDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +43,7 @@ class DeclarantDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.declarantDetails match {
       case Some(_) => Ok(declarantDetailsPage(mode, frm.fill(DeclarantEoriConfirmation(YesNoAnswers.yes))))
@@ -52,7 +51,7 @@ class DeclarantDetailsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/DeclarantExporterController.scala
+++ b/app/controllers/declaration/DeclarantExporterController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.DeclarantIsExporter
 import forms.declaration.DeclarantIsExporter.form
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.i18n.I18nSupport
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarant_exporter
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarantExporterController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +41,7 @@ class DeclarantExporterController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.declarantIsExporter match {
       case Some(data) => Ok(declarantExporterPage(mode, frm.fill(data)))
@@ -51,7 +49,7 @@ class DeclarantExporterController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/DeclarationChoiceController.scala
+++ b/app/controllers/declaration/DeclarationChoiceController.scala
@@ -16,13 +16,10 @@
 
 package controllers.declaration
 
-import java.time.Instant
 import connectors.exchange.ExportsDeclarationExchange
 import controllers.actions.{AuthAction, VerifiedEmailAction}
 import forms.declaration.DeclarationChoice
 import forms.declaration.DeclarationChoice._
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.ExportsSessionKeys
 import models.{DeclarationStatus, Mode}
@@ -35,6 +32,8 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declaration_choice
 
+import java.time.Instant
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationChoiceController @Inject()(

--- a/app/controllers/declaration/DeclarationHolderAddController.scala
+++ b/app/controllers/declaration/DeclarationHolderAddController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util._
 import controllers.util.DeclarationHolderHelper._
+import controllers.util._
 import forms.declaration.DeclarationHolder
 import forms.declaration.DeclarationHolder.form
-
-import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -34,11 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationHolderAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,11 +45,11 @@ class DeclarationHolderAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     Ok(declarationHolderPage(mode, form.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
     boundForm.fold(formWithErrors => {
       Future.successful(BadRequest(declarationHolderPage(mode, formWithErrors)))

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper._
 import controllers.util.MultipleItemsHelper
 import forms.declaration.DeclarationHolder
 import forms.declaration.DeclarationHolder.form
-
-import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -34,11 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_change
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationHolderChangeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,12 +45,12 @@ class DeclarationHolderChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val holder = DeclarationHolder.fromId(id)
     Ok(declarationHolderChangePage(mode, id, form.fill(holder).withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = form.bindFromRequest()
     boundForm.fold(
       formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, id, formWithErrors))),

--- a/app/controllers/declaration/DeclarationHolderController.scala
+++ b/app/controllers/declaration/DeclarationHolderController.scala
@@ -16,13 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.DeclarationType.{SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
 import models.requests.JourneyRequest
@@ -33,9 +31,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_summary
 
+import javax.inject.Inject
+
 class DeclarationHolderController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,13 +42,13 @@ class DeclarationHolderController @Inject()(
   declarationHolderPage: declaration_holder_summary
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val holders = cachedHolders
     if (holders.isEmpty) navigator.continueTo(mode, nextPageWhenNoHolders)
     else Ok(declarationHolderPage(mode, addAnotherYesNoForm.withSubmissionErrors(), holders))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val holders = cachedHolders
     addAnotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/DeclarationHolderRemoveController.scala
+++ b/app/controllers/declaration/DeclarationHolderRemoveController.scala
@@ -16,13 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
+import controllers.util.DeclarationHolderHelper
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarationHolder
-
-import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -33,12 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
-import controllers.util.DeclarationHolderHelper
 
 class DeclarationHolderRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,12 +45,12 @@ class DeclarationHolderRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val holder = DeclarationHolder.fromId(id)
     Ok(holderRemovePage(mode, holder, removeYesNoForm.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val holderToRemove = DeclarationHolder.fromId(id)
     removeYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/DeclarationHolderRequiredController.scala
+++ b/app/controllers/declaration/DeclarationHolderRequiredController.scala
@@ -16,14 +16,11 @@
 
 package controllers.declaration
 
-import scala.concurrent.{ExecutionContext, Future}
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, STANDARD, SUPPLEMENTARY}
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
@@ -35,9 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_required
 
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
 class DeclarationHolderRequiredController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -48,13 +47,13 @@ class DeclarationHolderRequiredController @Inject()(
 
   private val validJourneys = Seq(STANDARD, SUPPLEMENTARY, OCCASIONAL, CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     val holders = cachedHolders
     if (holders.isEmpty) Ok(declarationHolderRequired(mode, formWithPreviousAnswer.withSubmissionErrors()))
     else navigator.continueTo(mode, routes.DeclarationHolderController.displayPage(_))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
     form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/DepartureTransportController.scala
+++ b/app/controllers/declaration/DepartureTransportController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.DepartureTransport
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.departure_transport
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DepartureTransportController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -48,7 +46,7 @@ class DepartureTransportController @Inject()(
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.CLEARANCE)
 
   def displayPage(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+    (authenticate andThen journeyType(validTypes)) { implicit request =>
       val frm = form().withSubmissionErrors()
       val transport = request.cacheModel.transport
       val formData = DepartureTransport(transport.meansOfTransportOnDepartureType, transport.meansOfTransportOnDepartureIDNumber)
@@ -57,7 +55,7 @@ class DepartureTransportController @Inject()(
     }
 
   def submitForm(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+    (authenticate andThen journeyType(validTypes)).async { implicit request =>
       form()
         .bindFromRequest()
         .fold(

--- a/app/controllers/declaration/DestinationCountryController.scala
+++ b/app/controllers/declaration/DestinationCountryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.countries.Countries
 import forms.declaration.countries.Countries.DestinationCountryPage
-
-import javax.inject.{Inject, Singleton}
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
 import play.api.i18n.I18nSupport
@@ -30,12 +28,12 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.destinationCountries.destination_country
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class DestinationCountryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +42,7 @@ class DestinationCountryController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val form = (request.cacheModel.locations.destinationCountry match {
       case Some(destinationCountry) =>
         Countries.form(DestinationCountryPage).fill(destinationCountry)
@@ -54,7 +52,7 @@ class DestinationCountryController @Inject()(
     Ok(destinationCountryPage(mode, form))
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     Countries
       .form(DestinationCountryPage)
       .bindFromRequest()

--- a/app/controllers/declaration/DocumentsProducedAddController.scala
+++ b/app/controllers/declaration/DocumentsProducedAddController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.DocumentsProducedAddController.DocumentsProducedFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.additionaldocuments.DocumentsProduced
 import forms.declaration.additionaldocuments.DocumentsProduced.{form, globalErrors}
-
-import javax.inject.Inject
 import models.declaration.DocumentsProducedData
 import models.declaration.DocumentsProducedData.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -35,11 +33,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.documentsProduced.documents_produced_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DocumentsProducedAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -48,11 +46,11 @@ class DocumentsProducedAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     Ok(documentProducedPage(mode, itemId, form().withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = globalErrors(form().bindFromRequest())
 
     boundForm.fold(

--- a/app/controllers/declaration/DocumentsProducedChangeController.scala
+++ b/app/controllers/declaration/DocumentsProducedChangeController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.DocumentsProducedAddController.DocumentsProducedFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
 import forms.declaration.additionaldocuments.DocumentsProduced
 import forms.declaration.additionaldocuments.DocumentsProduced.{form, globalErrors}
-
-import javax.inject.Inject
 import models.declaration.DocumentsProducedData
 import models.declaration.DocumentsProducedData.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -36,11 +34,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.documentsProduced.documents_produced_change
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class DocumentsProducedChangeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -49,32 +47,30 @@ class DocumentsProducedChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, documentId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
-    implicit request =>
-      findDocument(itemId, documentId) match {
-        case Some(document) => Ok(documentProducedPage(mode, itemId, documentId, form().fill(document).withSubmissionErrors()))
-        case _              => returnToSummary(mode, itemId)
-      }
+  def displayPage(mode: Mode, itemId: String, documentId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    findDocument(itemId, documentId) match {
+      case Some(document) => Ok(documentProducedPage(mode, itemId, documentId, form().fill(document).withSubmissionErrors()))
+      case _              => returnToSummary(mode, itemId)
+    }
   }
 
-  def submitForm(mode: Mode, itemId: String, documentId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      findDocument(itemId, documentId) match {
-        case Some(existingDocument) =>
-          val boundForm = globalErrors(form().bindFromRequest())
-          boundForm.fold(
-            formWithErrors => {
-              Future.successful(BadRequest(documentProducedPage(mode, itemId, documentId, formWithErrors)))
-            },
-            updatedDocument => {
-              if (updatedDocument.isDefined)
-                changeDocument(mode, itemId, documentId, existingDocument, updatedDocument, boundForm)
-              else
-                Future.successful(returnToSummary(mode, itemId))
-            }
-          )
-        case _ => Future.successful(returnToSummary(mode, itemId))
-      }
+  def submitForm(mode: Mode, itemId: String, documentId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    findDocument(itemId, documentId) match {
+      case Some(existingDocument) =>
+        val boundForm = globalErrors(form().bindFromRequest())
+        boundForm.fold(
+          formWithErrors => {
+            Future.successful(BadRequest(documentProducedPage(mode, itemId, documentId, formWithErrors)))
+          },
+          updatedDocument => {
+            if (updatedDocument.isDefined)
+              changeDocument(mode, itemId, documentId, existingDocument, updatedDocument, boundForm)
+            else
+              Future.successful(returnToSummary(mode, itemId))
+          }
+        )
+      case _ => Future.successful(returnToSummary(mode, itemId))
+    }
   }
 
   private def returnToSummary(mode: Mode, itemId: String)(implicit request: JourneyRequest[AnyContent]) =

--- a/app/controllers/declaration/DocumentsProducedController.scala
+++ b/app/controllers/declaration/DocumentsProducedController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.Mode
 import models.requests.JourneyRequest
 import play.api.data.Form
@@ -31,9 +29,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.documentsProduced.documents_produced
 
+import javax.inject.Inject
+
 class DocumentsProducedController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -41,7 +40,7 @@ class DocumentsProducedController @Inject()(
   documentProducedPage: documents_produced
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = anotherYesNoForm.withSubmissionErrors()
     cachedDocuments(itemId) match {
       case documents if documents.nonEmpty => Ok(documentProducedPage(mode, itemId, frm, documents))
@@ -49,7 +48,7 @@ class DocumentsProducedController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     anotherYesNoForm
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
+++ b/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
@@ -16,12 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.EntryIntoDeclarantsRecords.form
-import javax.inject.Inject
 import models.DeclarationType.CLEARANCE
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -31,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.entry_into_declarants_records
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class EntryIntoDeclarantsRecordsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +43,7 @@ class EntryIntoDeclarantsRecordsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.isEntryIntoDeclarantsRecords match {
       case Some(data) => Ok(entryIntoDeclarantsRecordsPage(mode, frm.fill(data)))
@@ -52,7 +51,7 @@ class EntryIntoDeclarantsRecordsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ExporterDetailsController.scala
+++ b/app/controllers/declaration/ExporterDetailsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.exporter.ExporterDetails
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.exporter_address
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ExporterDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +41,7 @@ class ExporterDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.exporterDetails match {
       case Some(data) => Ok(exporterDetailsPage(mode, frm.fill(data)))
@@ -51,7 +49,7 @@ class ExporterDetailsController @Inject()(
     }
   }
 
-  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveAddress(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/ExporterEoriNumberController.scala
+++ b/app/controllers/declaration/ExporterEoriNumberController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.exporter.{ExporterDetails, ExporterEoriNumber}
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.exporter_eori_number
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ExporterEoriNumberController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -44,7 +42,7 @@ class ExporterEoriNumberController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = ExporterEoriNumber.form().withSubmissionErrors()
     request.cacheModel.parties.exporterDetails match {
       case Some(data) => Ok(exporterEoriDetailsPage(mode, frm.fill(ExporterEoriNumber(data))))
@@ -52,7 +50,7 @@ class ExporterEoriNumberController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     ExporterEoriNumber
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/FiscalInformationController.scala
+++ b/app/controllers/declaration/FiscalInformationController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.FiscalInformation
 import forms.declaration.FiscalInformation._
-
-import javax.inject.Inject
 import models.declaration.ProcedureCodesData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.fiscalInformation.fiscal_information
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class FiscalInformationController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,47 +43,45 @@ class FiscalInformationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, fastForward: Boolean): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
-    implicit request =>
-      def cacheContainsFiscalReferenceData = request.cacheModel.itemBy(itemId).exists(_.additionalFiscalReferencesData.exists(_.references.nonEmpty))
-      def cacheItemIneligibleForOSR =
-        request.cacheModel
-          .itemBy(itemId)
-          .flatMap(_.procedureCodes)
-          .flatMap(_.procedureCode)
-          .exists(code => !ProcedureCodesData.osrProcedureCodes.contains(code))
+  def displayPage(mode: Mode, itemId: String, fastForward: Boolean): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    def cacheContainsFiscalReferenceData = request.cacheModel.itemBy(itemId).exists(_.additionalFiscalReferencesData.exists(_.references.nonEmpty))
+    def cacheItemIneligibleForOSR =
+      request.cacheModel
+        .itemBy(itemId)
+        .flatMap(_.procedureCodes)
+        .flatMap(_.procedureCode)
+        .exists(code => !ProcedureCodesData.osrProcedureCodes.contains(code))
 
-      def displayFiscalInformationPage() = {
-        val frm = form().withSubmissionErrors()
-        request.cacheModel.itemBy(itemId).flatMap(_.fiscalInformation) match {
-          case Some(fiscalInformation) => Ok(fiscalInformationPage(mode, itemId, frm.fill(fiscalInformation)))
-          case _                       => Ok(fiscalInformationPage(mode, itemId, frm))
-        }
+    def displayFiscalInformationPage() = {
+      val frm = form().withSubmissionErrors()
+      request.cacheModel.itemBy(itemId).flatMap(_.fiscalInformation) match {
+        case Some(fiscalInformation) => Ok(fiscalInformationPage(mode, itemId, frm.fill(fiscalInformation)))
+        case _                       => Ok(fiscalInformationPage(mode, itemId, frm))
       }
+    }
 
-      if (mode == Mode.Change) {
-        displayFiscalInformationPage()
-      } else if (fastForward && cacheContainsFiscalReferenceData) {
-        navigator.continueTo(mode, routes.AdditionalFiscalReferencesController.displayPage(_, itemId))
-      } else if (fastForward && cacheItemIneligibleForOSR) {
-        navigator.continueTo(mode, routes.ProcedureCodesController.displayPage(_, itemId))
+    if (mode == Mode.Change) {
+      displayFiscalInformationPage()
+    } else if (fastForward && cacheContainsFiscalReferenceData) {
+      navigator.continueTo(mode, routes.AdditionalFiscalReferencesController.displayPage(_, itemId))
+    } else if (fastForward && cacheItemIneligibleForOSR) {
+      navigator.continueTo(mode, routes.ProcedureCodesController.displayPage(_, itemId))
+    } else {
+      if (cacheContainsFiscalReferenceData) {
+        navigator.continueTo(mode, controllers.declaration.routes.AdditionalFiscalReferencesController.displayPage(_, itemId))
       } else {
-        if (cacheContainsFiscalReferenceData) {
-          navigator.continueTo(mode, controllers.declaration.routes.AdditionalFiscalReferencesController.displayPage(_, itemId))
-        } else {
-          displayFiscalInformationPage()
-        }
+        displayFiscalInformationPage()
       }
+    }
   }
 
-  def saveFiscalInformation(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      form()
-        .bindFromRequest()
-        .fold(
-          (formWithErrors: Form[FiscalInformation]) => Future.successful(BadRequest(fiscalInformationPage(mode, itemId, formWithErrors))),
-          formData => updateCache(itemId, formData).map(_ => redirectToNextPage(mode, itemId, formData))
-        )
+  def saveFiscalInformation(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    form()
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[FiscalInformation]) => Future.successful(BadRequest(fiscalInformationPage(mode, itemId, formWithErrors))),
+        formData => updateCache(itemId, formData).map(_ => redirectToNextPage(mode, itemId, formData))
+      )
   }
 
   private def updateCache(itemId: String, updatedFiscalInformation: FiscalInformation)(

--- a/app/controllers/declaration/InlandTransportDetailsController.scala
+++ b/app/controllers/declaration/InlandTransportDetailsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.InlandModeOfTransportCode
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.inland_transport_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class InlandTransportDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -47,7 +45,7 @@ class InlandTransportDetailsController @Inject()(
 
   private val validJourneys = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.inlandModeOfTransportCode match {
       case Some(data) => Ok(inlandTransportDetailsPage(mode, frm.fill(data)))
@@ -55,7 +53,7 @@ class InlandTransportDetailsController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     InlandModeOfTransportCode
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/IsExsController.scala
+++ b/app/controllers/declaration/IsExsController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{IsExs, UNDangerousGoodsCode}
-
-import javax.inject.Inject
 import models.DeclarationType.{CLEARANCE, DeclarationType}
 import models.declaration.{ExportItem, Parties}
 import models.requests.JourneyRequest
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.is_exs
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class IsExsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,7 +45,7 @@ class IsExsController @Inject()(
 
   private val allowedJourney: DeclarationType = CLEARANCE
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(allowedJourney)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(allowedJourney)) { implicit request =>
     val frm = IsExs.form.withSubmissionErrors()
     request.cacheModel.parties.isExs match {
       case Some(data) => Ok(isExsPage(mode, frm.fill(data)))
@@ -55,7 +53,7 @@ class IsExsController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(allowedJourney)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(allowedJourney)).async { implicit request =>
     IsExs.form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/LocationController.scala
+++ b/app/controllers/declaration/LocationController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.GoodsLocationForm
-
-import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
 import play.api.i18n.I18nSupport
@@ -29,11 +27,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.goods_location
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class LocationController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   mcc: MessagesControllerComponents,
   goodsLocationPage: goods_location,
@@ -43,7 +41,7 @@ class LocationController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
   import forms.declaration.GoodsLocationForm._
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.goodsLocation match {
       case Some(data) => Ok(goodsLocationPage(mode, frm.fill(data.toForm)))
@@ -51,7 +49,7 @@ class LocationController @Inject()(
     }
   }
 
-  def saveLocation(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveLocation(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/NactCodeRemoveController.scala
+++ b/app/controllers/declaration/NactCodeRemoveController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.nact_code_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class NactCodeRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,13 +44,12 @@ class NactCodeRemoveController @Inject()(
 
   val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) {
-    implicit request =>
-      Ok(nactCodeRemove(mode, itemId, code, removeYesNoForm.withSubmissionErrors()))
+  def displayPage(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+    Ok(nactCodeRemove(mode, itemId, code, removeYesNoForm.withSubmissionErrors()))
   }
 
   def submitForm(mode: Mode, itemId: String, code: String): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+    (authenticate andThen journeyType(validTypes)).async { implicit request =>
       removeYesNoForm
         .bindFromRequest()
         .fold(

--- a/app/controllers/declaration/NactCodeSummaryController.scala
+++ b/app/controllers/declaration/NactCodeSummaryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
 import play.api.data.Form
@@ -31,9 +29,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.nact_codes
 
+import javax.inject.Inject
+
 class NactCodeSummaryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,27 +44,25 @@ class NactCodeSummaryController @Inject()(
 
   val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL)
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) {
-    implicit request =>
-      request.cacheModel.itemBy(itemId).flatMap(_.nactCodes) match {
-        case Some(nactCodes) if nactCodes.nonEmpty => Ok(nactCodesPage(mode, itemId, anotherYesNoForm.withSubmissionErrors(), nactCodes))
-        case _                                     => navigator.continueTo(mode, routes.NactCodeAddController.displayPage(_, itemId))
-      }
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+    request.cacheModel.itemBy(itemId).flatMap(_.nactCodes) match {
+      case Some(nactCodes) if nactCodes.nonEmpty => Ok(nactCodesPage(mode, itemId, anotherYesNoForm.withSubmissionErrors(), nactCodes))
+      case _                                     => navigator.continueTo(mode, routes.NactCodeAddController.displayPage(_, itemId))
+    }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) {
-    implicit request =>
-      val nactCodes = request.cacheModel.itemBy(itemId).flatMap(_.nactCodes).getOrElse(List.empty)
-      anotherYesNoForm
-        .bindFromRequest()
-        .fold(
-          (formWithErrors: Form[YesNoAnswer]) => BadRequest(nactCodesPage(mode, itemId, formWithErrors, nactCodes)),
-          validYesNo =>
-            validYesNo.answer match {
-              case YesNoAnswers.yes => navigator.continueTo(mode, controllers.declaration.routes.NactCodeAddController.displayPage(_, itemId))
-              case YesNoAnswers.no  => navigator.continueTo(mode, nextPage(itemId))
-          }
-        )
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+    val nactCodes = request.cacheModel.itemBy(itemId).flatMap(_.nactCodes).getOrElse(List.empty)
+    anotherYesNoForm
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[YesNoAnswer]) => BadRequest(nactCodesPage(mode, itemId, formWithErrors, nactCodes)),
+        validYesNo =>
+          validYesNo.answer match {
+            case YesNoAnswers.yes => navigator.continueTo(mode, controllers.declaration.routes.NactCodeAddController.displayPage(_, itemId))
+            case YesNoAnswers.no  => navigator.continueTo(mode, nextPage(itemId))
+        }
+      )
   }
 
   private def anotherYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.nationalAdditionalCode.add.answer.empty")

--- a/app/controllers/declaration/NatureOfTransactionController.scala
+++ b/app/controllers/declaration/NatureOfTransactionController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.NatureOfTransaction
 import forms.declaration.NatureOfTransaction._
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.nature_of_transaction
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class NatureOfTransactionController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -44,7 +42,7 @@ class NatureOfTransactionController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.natureOfTransaction match {
       case Some(data) => Ok(natureOfTransactionPage(mode, frm.fill(data)))
@@ -52,7 +50,7 @@ class NatureOfTransactionController @Inject()(
     }
   }
 
-  def saveTransactionType(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveTransactionType(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form().bindFromRequest
       .fold(
         (formWithErrors: Form[NatureOfTransaction]) => Future.successful(BadRequest(natureOfTransactionPage(mode, formWithErrors))),

--- a/app/controllers/declaration/NotEligibleController.scala
+++ b/app/controllers/declaration/NotEligibleController.scala
@@ -16,27 +16,26 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, VerifiedEmailAction}
-
-import javax.inject.Inject
+import controllers.actions.AuthAction
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.{not_declarant, not_eligible}
 
+import javax.inject.Inject
+
 class NotEligibleController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   mcc: MessagesControllerComponents,
   notEligiblePage: not_eligible,
   notDeclarantPage: not_declarant
 ) extends FrontendController(mcc) with I18nSupport {
 
-  def displayNotEligible(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
+  def displayNotEligible(): Action[AnyContent] = authenticate { implicit request =>
     Ok(notEligiblePage())
   }
 
-  def displayNotDeclarant(): Action[AnyContent] = (authenticate andThen verifyEmail) { implicit request =>
+  def displayNotDeclarant(): Action[AnyContent] = authenticate { implicit request =>
     Ok(notDeclarantPage())
   }
 

--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import forms.declaration.officeOfExit.OfficeOfExit.form
 import forms.declaration.officeOfExit.OfficeOfExit
-
-import javax.inject.Inject
+import forms.declaration.officeOfExit.OfficeOfExit.form
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.office_of_exit
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class OfficeOfExitController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -45,7 +43,7 @@ class OfficeOfExitController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.officeOfExit match {
       case Some(data) =>
@@ -54,7 +52,7 @@ class OfficeOfExitController @Inject()(
     }
   }
 
-  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveOffice(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/OriginationCountryController.scala
+++ b/app/controllers/declaration/OriginationCountryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.countries.Countries
 import forms.declaration.countries.Countries.OriginationCountryPage
-
-import javax.inject.{Inject, Singleton}
 import models.{DeclarationType, Mode}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
@@ -29,12 +27,12 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.destinationCountries.origination_country
 
+import javax.inject.{Inject, Singleton}
 import scala.concurrent.{ExecutionContext, Future}
 
 @Singleton
 class OriginationCountryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,7 +43,7 @@ class OriginationCountryController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val form = (request.cacheModel.locations.originationCountry match {
       case Some(originateCountry) =>
         Countries.form(OriginationCountryPage).fill(originateCountry)
@@ -55,7 +53,7 @@ class OriginationCountryController @Inject()(
     Ok(originationCountryPage(mode, form))
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
     Countries
       .form(OriginationCountryPage)
       .bindFromRequest()

--- a/app/controllers/declaration/PackageInformationAddController.scala
+++ b/app/controllers/declaration/PackageInformationAddController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.PackageInformationAddController.PackageInformationFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.PackageInformation
 import forms.declaration.PackageInformation.form
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -33,11 +31,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.package_information_add
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class PackageInformationAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,15 +44,14 @@ class PackageInformationAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val items = request.cacheModel.itemBy(itemId).flatMap(_.packageInformation).getOrElse(List.empty)
     Ok(packageInformationPage(mode, itemId, form().withSubmissionErrors(), items))
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit authRequest =>
-      val boundForm = form().bindFromRequest()
-      saveInformation(mode, itemId, boundForm, authRequest.cacheModel.itemBy(itemId).flatMap(_.packageInformation).getOrElse(Seq.empty))
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit authRequest =>
+    val boundForm = form().bindFromRequest()
+    saveInformation(mode, itemId, boundForm, authRequest.cacheModel.itemBy(itemId).flatMap(_.packageInformation).getOrElse(Seq.empty))
   }
 
   private def saveInformation(mode: Mode, itemId: String, boundForm: Form[PackageInformation], cachedData: Seq[PackageInformation])(

--- a/app/controllers/declaration/PackageInformationSummaryController.scala
+++ b/app/controllers/declaration/PackageInformationSummaryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
 import models.requests.JourneyRequest
@@ -32,9 +30,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.package_information
 
+import javax.inject.Inject
+
 class PackageInformationSummaryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,14 +43,14 @@ class PackageInformationSummaryController @Inject()(
 
   import PackageInformationSummaryController._
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.packageInformation) match {
       case Some(items) if items.nonEmpty => Ok(packageInformationPage(mode, itemId, anotherYesNoForm.withSubmissionErrors(), items))
       case _                             => navigator.continueTo(mode, routes.PackageInformationAddController.displayPage(_, itemId))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val items = request.cacheModel.itemBy(itemId).flatMap(_.packageInformation).getOrElse(List.empty)
     anotherYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
+++ b/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
@@ -16,11 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.PersonPresentingGoodsDetails
 import forms.declaration.PersonPresentingGoodsDetails.form
-import javax.inject.Inject
 import models.DeclarationType.CLEARANCE
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -30,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.person_presenting_goods_details
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class PersonPresentingGoodsDetailsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -43,7 +42,7 @@ class PersonPresentingGoodsDetailsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.personPresentingGoodsDetails match {
       case Some(data) => Ok(personPresentingGoodsDetailsPage(mode, frm.fill(data)))
@@ -51,7 +50,7 @@ class PersonPresentingGoodsDetailsController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(CLEARANCE)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -16,13 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.{Document, PreviousDocumentsData}
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.i18n.I18nSupport
@@ -32,11 +30,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.previousDocuments.previous_documents_change
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsChangeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -45,14 +43,14 @@ class PreviousDocumentsChangeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     findDocument(id) match {
       case Some(document) => Ok(changePage(mode, id, Document.form().fill(document).withSubmissionErrors()))
       case _              => returnToSummary(mode)
     }
   }
 
-  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     findDocument(id) match {
       case Some(existingDocument) =>
         val boundForm = Document.form().bindFromRequest()

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
 import controllers.util._
-import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import forms.declaration.Document._
 import forms.declaration.{Document, PreviousDocumentsData}
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.i18n.I18nSupport
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.previousDocuments.previous_documents
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -45,11 +43,11 @@ class PreviousDocumentsController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     Ok(previousDocumentsPage(mode, form()))
   }
 
-  def savePreviousDocuments(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def savePreviousDocuments(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val boundForm = if (isFirstPreviousDocument) Document.treatLikeOptional(form().bindFromRequest()) else form().bindFromRequest()
 
     val cache = request.cacheModel.previousDocuments.getOrElse(PreviousDocumentsData(Seq.empty))

--- a/app/controllers/declaration/PreviousDocumentsRemoveController.scala
+++ b/app/controllers/declaration/PreviousDocumentsRemoveController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.Document
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -34,11 +32,11 @@ import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
 import views.html.declaration.previousDocuments.previous_documents_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class PreviousDocumentsRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -47,14 +45,14 @@ class PreviousDocumentsRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable {
 
-  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     findDocument(id) match {
       case Some(document) => Ok(removePage(mode, id, document, removeYesNoForm))
       case _              => returnToSummary(mode)
     }
   }
 
-  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     findDocument(id) match {
       case Some(document) =>
         removeYesNoForm

--- a/app/controllers/declaration/PreviousDocumentsSummaryController.scala
+++ b/app/controllers/declaration/PreviousDocumentsSummaryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
 import play.api.i18n.I18nSupport
@@ -30,9 +28,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.previousDocuments.previous_documents_summary
 
+import javax.inject.Inject
+
 class PreviousDocumentsSummaryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -40,7 +39,7 @@ class PreviousDocumentsSummaryController @Inject()(
   previousDocumentsSummary: previous_documents_summary
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val form = anotherYesNoForm.withSubmissionErrors()
     request.cacheModel.previousDocuments.map(_.documents) match {
       case Some(documents) if documents.nonEmpty => Ok(previousDocumentsSummary(mode, form, documents))
@@ -48,7 +47,7 @@ class PreviousDocumentsSummaryController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val previousDocuments = request.cacheModel.previousDocuments.map(_.documents).getOrElse(Seq.empty)
 
     anotherYesNoForm

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper.remove
 import controllers.util._
 import forms.declaration.ProcedureCodes
 import forms.declaration.ProcedureCodes.form
-
-import javax.inject.Inject
 import models.declaration.ProcedureCodesData
 import models.declaration.ProcedureCodesData._
 import models.requests.JourneyRequest
@@ -36,11 +34,11 @@ import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.procedure_codes
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class ProcedureCodesController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -49,7 +47,7 @@ class ProcedureCodesController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.itemBy(itemId) match {
       case Some(exportItem) =>
@@ -61,20 +59,19 @@ class ProcedureCodesController @Inject()(
     }
   }
 
-  def submitProcedureCodes(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      val boundForm = form().bindFromRequest()
-      val actionTypeOpt = FormAction.bindFromRequest()
+  def submitProcedureCodes(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    val boundForm = form().bindFromRequest()
+    val actionTypeOpt = FormAction.bindFromRequest()
 
-      val cache = request.cacheModel.itemBy(itemId).flatMap(_.procedureCodes).getOrElse(ProcedureCodesData(None, Seq()))
-      actionTypeOpt match {
-        case Add if !boundForm.hasErrors => addAnotherCodeHandler(mode, itemId, boundForm.get, cache)
-        case SaveAndContinue | SaveAndReturn if !boundForm.hasErrors =>
-          saveAndContinueHandler(mode, itemId, boundForm.get, cache)
-        case Remove(values) => removeCodeHandler(mode, itemId, retrieveProcedureCode(values), boundForm, cache)
-        case _ =>
-          Future.successful(BadRequest(procedureCodesPage(mode, itemId, boundForm, cache.additionalProcedureCodes)))
-      }
+    val cache = request.cacheModel.itemBy(itemId).flatMap(_.procedureCodes).getOrElse(ProcedureCodesData(None, Seq()))
+    actionTypeOpt match {
+      case Add if !boundForm.hasErrors => addAnotherCodeHandler(mode, itemId, boundForm.get, cache)
+      case SaveAndContinue | SaveAndReturn if !boundForm.hasErrors =>
+        saveAndContinueHandler(mode, itemId, boundForm.get, cache)
+      case Remove(values) => removeCodeHandler(mode, itemId, retrieveProcedureCode(values), boundForm, cache)
+      case _ =>
+        Future.successful(BadRequest(procedureCodesPage(mode, itemId, boundForm, cache.additionalProcedureCodes)))
+    }
   }
 
   private def addAnotherCodeHandler(mode: Mode, itemId: String, userInput: ProcedureCodes, cachedData: ProcedureCodesData)(

--- a/app/controllers/declaration/RepresentativeAgentController.scala
+++ b/app/controllers/declaration/RepresentativeAgentController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer.YesNoAnswers.{no, yes}
 import forms.declaration.RepresentativeAgent
-
-import javax.inject.Inject
 import models.declaration.RepresentativeDetails
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -32,11 +30,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.representative_details_agent
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeAgentController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -45,7 +43,7 @@ class RepresentativeAgentController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = RepresentativeAgent.form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.flatMap(_.representingOtherAgent) match {
       case Some(data) => Ok(representativeAgentPage(mode, frm.fill(RepresentativeAgent(data))))
@@ -53,7 +51,7 @@ class RepresentativeAgentController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     RepresentativeAgent
       .form()
       .bindFromRequest()

--- a/app/controllers/declaration/RepresentativeEntityController.scala
+++ b/app/controllers/declaration/RepresentativeEntityController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.RepresentativeEntity
 import forms.declaration.RepresentativeEntity.form
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.declaration.RepresentativeDetails
 import models.requests.JourneyRequest
@@ -33,11 +31,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.representative_details_entity
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeEntityController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -46,7 +44,7 @@ class RepresentativeEntityController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.flatMap(_.details) match {
       case Some(data) => Ok(representativeEntityPage(mode, frm.fill(RepresentativeEntity(data))))
@@ -54,7 +52,7 @@ class RepresentativeEntityController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/RepresentativeStatusController.scala
+++ b/app/controllers/declaration/RepresentativeStatusController.scala
@@ -16,13 +16,11 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.DeclarationPage
 import forms.declaration.RepresentativeStatus.form
 import forms.declaration.{RepresentativeEntity, RepresentativeStatus}
-
-import javax.inject.Inject
 import models.DeclarationType._
 import models.declaration.RepresentativeDetails
 import models.requests.JourneyRequest
@@ -34,11 +32,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.representative_details_status
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class RepresentativeStatusController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -47,7 +45,7 @@ class RepresentativeStatusController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.parties.representativeDetails.map(_.statusCode) match {
       case Some(data) => Ok(representativeStatusPage(mode, navigationForm, frm.fill(RepresentativeStatus(data))))
@@ -55,7 +53,7 @@ class RepresentativeStatusController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/StatisticalValueController.scala
+++ b/app/controllers/declaration/StatisticalValueController.scala
@@ -16,13 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.StatisticalValue
 import forms.declaration.StatisticalValue.form
-import handlers.ErrorHandler
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -32,13 +29,12 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.statistical_value
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class StatisticalValueController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
-  errorHandler: ErrorHandler,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -48,27 +44,25 @@ class StatisticalValueController @Inject()(
 
   val validTypes = Seq(DeclarationType.SUPPLEMENTARY, DeclarationType.STANDARD)
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) {
-    implicit request =>
-      val frm = StatisticalValue.form().withSubmissionErrors()
-      request.cacheModel.itemBy(itemId).flatMap(_.statisticalValue) match {
-        case Some(itemType) => Ok(itemTypePage(mode, itemId, frm.fill(itemType)))
-        case _              => Ok(itemTypePage(mode, itemId, frm))
-      }
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
+    val frm = StatisticalValue.form().withSubmissionErrors()
+    request.cacheModel.itemBy(itemId).flatMap(_.statisticalValue) match {
+      case Some(itemType) => Ok(itemTypePage(mode, itemId, frm.fill(itemType)))
+      case _              => Ok(itemTypePage(mode, itemId, frm))
+    }
   }
 
-  def submitItemType(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      form
-        .bindFromRequest()
-        .fold(
-          (formWithErrors: Form[StatisticalValue]) => Future.successful(BadRequest(itemTypePage(mode, itemId, formWithErrors))),
-          validForm =>
-            updateExportsCache(itemId, validForm).map { _ =>
-              navigator
-                .continueTo(mode, controllers.declaration.routes.PackageInformationSummaryController.displayPage(_, itemId))
-          }
-        )
+  def submitItemType(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    form
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[StatisticalValue]) => Future.successful(BadRequest(itemTypePage(mode, itemId, formWithErrors))),
+        validForm =>
+          updateExportsCache(itemId, validForm).map { _ =>
+            navigator
+              .continueTo(mode, controllers.declaration.routes.PackageInformationSummaryController.displayPage(_, itemId))
+        }
+      )
   }
 
   private def updateExportsCache(itemId: String, updatedItem: StatisticalValue)(

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.SupervisingCustomsOffice
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.supervising_customs_office
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class SupervisingCustomsOfficeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -45,7 +43,7 @@ class SupervisingCustomsOfficeController @Inject()(
 
   import forms.declaration.SupervisingCustomsOffice._
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.supervisingCustomsOffice match {
       case Some(data) => Ok(supervisingCustomsOfficePage(mode, frm.fill(data)))
@@ -53,7 +51,7 @@ class SupervisingCustomsOfficeController @Inject()(
     }
   }
 
-  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submit(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/TaricCodeAddController.scala
+++ b/app/controllers/declaration/TaricCodeAddController.scala
@@ -16,14 +16,11 @@
 
 package controllers.declaration
 
-import scala.concurrent.{ExecutionContext, Future}
-
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper
 import forms.declaration.TaricCode.taricCodeLimit
 import forms.declaration.{TaricCode, TaricCodeFirst}
-import javax.inject.Inject
 import models.declaration.ExportItem
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -34,9 +31,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.{taric_code_add, taric_code_add_first}
 
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
+
 class TaricCodeAddController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -46,7 +45,7 @@ class TaricCodeAddController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val exportItem = request.cacheModel.itemBy(itemId)
     exportItem.flatMap(_.taricCodes) match {
       case Some(taricCodes) if taricCodes.nonEmpty => Ok(taricCodeAdd(mode, itemId, TaricCode.form().withSubmissionErrors()))
@@ -61,7 +60,7 @@ class TaricCodeAddController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     val exportItem = request.cacheModel.itemBy(itemId)
     exportItem.flatMap(_.taricCodes) match {
       case Some(taricCodes) if taricCodes.nonEmpty =>

--- a/app/controllers/declaration/TaricCodeRemoveController.scala
+++ b/app/controllers/declaration/TaricCodeRemoveController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.taric_code_remove
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TaricCodeRemoveController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,27 +42,25 @@ class TaricCodeRemoveController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) {
-    implicit request =>
-      Ok(taricCodeRemove(mode, itemId, code, removeYesNoForm.withSubmissionErrors()))
+  def displayPage(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
+    Ok(taricCodeRemove(mode, itemId, code, removeYesNoForm.withSubmissionErrors()))
   }
 
-  def submitForm(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async {
-    implicit request =>
-      removeYesNoForm
-        .bindFromRequest()
-        .fold(
-          (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(taricCodeRemove(mode, itemId, code, formWithErrors))),
-          formData => {
-            formData.answer match {
-              case YesNoAnswers.yes =>
-                updateExportsCache(itemId, code)
-                  .map(_ => navigator.continueTo(mode, routes.TaricCodeSummaryController.displayPage(_, itemId)))
-              case YesNoAnswers.no =>
-                Future.successful(navigator.continueTo(mode, routes.TaricCodeSummaryController.displayPage(_, itemId)))
-            }
+  def submitForm(mode: Mode, itemId: String, code: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
+    removeYesNoForm
+      .bindFromRequest()
+      .fold(
+        (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(taricCodeRemove(mode, itemId, code, formWithErrors))),
+        formData => {
+          formData.answer match {
+            case YesNoAnswers.yes =>
+              updateExportsCache(itemId, code)
+                .map(_ => navigator.continueTo(mode, routes.TaricCodeSummaryController.displayPage(_, itemId)))
+            case YesNoAnswers.no =>
+              Future.successful(navigator.continueTo(mode, routes.TaricCodeSummaryController.displayPage(_, itemId)))
           }
-        )
+        }
+      )
   }
 
   private def removeYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.taricAdditionalCodes.remove.answer.empty")

--- a/app/controllers/declaration/TaricCodeSummaryController.scala
+++ b/app/controllers/declaration/TaricCodeSummaryController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-
-import javax.inject.Inject
 import models.Mode
 import play.api.data.Form
 import play.api.i18n.I18nSupport
@@ -30,9 +28,10 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.taric_codes
 
+import javax.inject.Inject
+
 class TaricCodeSummaryController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -40,14 +39,14 @@ class TaricCodeSummaryController @Inject()(
   taricCodesPage: taric_codes
 ) extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.itemBy(itemId).flatMap(_.taricCodes) match {
       case Some(taricCodes) if taricCodes.nonEmpty => Ok(taricCodesPage(mode, itemId, addYesNoForm.withSubmissionErrors(), taricCodes))
       case _                                       => navigator.continueTo(mode, routes.TaricCodeAddController.displayPage(_, itemId))
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val taricCodes = request.cacheModel.itemBy(itemId).flatMap(_.taricCodes).getOrElse(List.empty)
     addYesNoForm
       .bindFromRequest()

--- a/app/controllers/declaration/TotalNumberOfItemsController.scala
+++ b/app/controllers/declaration/TotalNumberOfItemsController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.TotalNumberOfItems
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.total_number_of_items
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TotalNumberOfItemsController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   mcc: MessagesControllerComponents,
@@ -47,7 +45,7 @@ class TotalNumberOfItemsController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.totalNumberOfItems match {
       case Some(data) => Ok(totalNumberOfItemsPage(mode, frm.fill(data)))
@@ -55,7 +53,7 @@ class TotalNumberOfItemsController @Inject()(
     }
   }
 
-  def saveNoOfItems(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+  def saveNoOfItems(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/TotalPackageQuantityController.scala
+++ b/app/controllers/declaration/TotalPackageQuantityController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.TotalPackageQuantity
-
-import javax.inject.Inject
 import models.DeclarationType.DeclarationType
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.total_package_quantity
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TotalPackageQuantityController @Inject()(
   authorize: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journey: JourneyAction,
   mcc: MessagesControllerComponents,
   navigator: Navigator,
@@ -45,21 +43,20 @@ class TotalPackageQuantityController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authorize andThen verifyEmail andThen journey(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authorize andThen journey(validTypes)) { implicit request =>
     val form = TotalPackageQuantity.form(request.declarationType).withSubmissionErrors()
     val data = request.cacheModel.totalPackageQuantity.fold(form)(form.fill)
     Ok(totalPackageQuantity(mode, data))
   }
 
-  def saveTotalPackageQuantity(mode: Mode): Action[AnyContent] = (authorize andThen verifyEmail andThen journey(validTypes)).async {
-    implicit request =>
-      TotalPackageQuantity
-        .form(request.declarationType)
-        .bindFromRequest()
-        .fold(
-          error => Future.successful(BadRequest(totalPackageQuantity(mode, error))),
-          form => updateCache(form).map(_ => navigator.continueTo(mode, nextPage(request.declarationType)))
-        )
+  def saveTotalPackageQuantity(mode: Mode): Action[AnyContent] = (authorize andThen journey(validTypes)).async { implicit request =>
+    TotalPackageQuantity
+      .form(request.declarationType)
+      .bindFromRequest()
+      .fold(
+        error => Future.successful(BadRequest(totalPackageQuantity(mode, error))),
+        form => updateCache(form).map(_ => navigator.continueTo(mode, nextPage(request.declarationType)))
+      )
   }
 
   private def nextPage(declarationType: DeclarationType): Mode => Call =

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -16,14 +16,12 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import controllers.util.{FormAction, Remove}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{ContainerAdd, ContainerFirst}
-
-import javax.inject.Inject
 import models.declaration.Container
 import models.declaration.Container.maxNumberOfItems
 import models.requests.JourneyRequest
@@ -35,11 +33,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration._
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TransportContainerController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -51,7 +49,7 @@ class TransportContainerController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     if (request.cacheModel.hasContainers) {
       Ok(addPage(mode, ContainerAdd.form().withSubmissionErrors()))
     } else {
@@ -59,7 +57,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def submitAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitAddContainer(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     if (request.cacheModel.hasContainers) {
       val boundForm = ContainerAdd.form().bindFromRequest()
       saveAdditionalContainer(mode, boundForm, maxNumberOfItems, request.cacheModel.containers)
@@ -74,7 +72,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def displayContainerSummary(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayContainerSummary(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     request.cacheModel.containers match {
       case containers if containers.nonEmpty => Ok(summaryPage(mode, addAnotherContainerYesNoForm.withSubmissionErrors(), containers))
       case _ =>
@@ -82,7 +80,7 @@ class TransportContainerController @Inject()(
     }
   }
 
-  def submitSummaryAction(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitSummaryAction(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     FormAction.bindFromRequest() match {
       case Remove(values) =>
         Future.successful(navigator.continueTo(mode, routes.TransportContainerController.displayContainerRemove(_, containerId(values))))
@@ -91,7 +89,7 @@ class TransportContainerController @Inject()(
   }
 
   def displayContainerRemove(mode: Mode, containerId: String): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+    (authenticate andThen journeyType) { implicit request =>
       request.cacheModel.containerBy(containerId) match {
         case Some(container) => Ok(removePage(mode, removeContainerYesNoForm, container))
         case _               => navigator.continueTo(mode, routes.TransportContainerController.displayContainerSummary)
@@ -99,7 +97,7 @@ class TransportContainerController @Inject()(
     }
 
   def submitContainerRemove(mode: Mode, containerId: String): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+    (authenticate andThen journeyType).async { implicit request =>
       removeContainerAnswer(mode, containerId)
     }
 

--- a/app/controllers/declaration/TransportLeavingTheBorderController.scala
+++ b/app/controllers/declaration/TransportLeavingTheBorderController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.TransportLeavingTheBorder
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, Mode}
 import play.api.i18n.I18nSupport
@@ -29,11 +27,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.transport_leaving_the_border
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TransportLeavingTheBorderController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +42,7 @@ class TransportLeavingTheBorderController @Inject()(
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.CLEARANCE)
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val form = TransportLeavingTheBorder.form(request.declarationType).withSubmissionErrors()
     request.cacheModel.transport.borderModeOfTransportCode match {
       case Some(data) => Ok(transportAtBorder(form.fill(data), mode))
@@ -52,7 +50,7 @@ class TransportLeavingTheBorderController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)).async { implicit request =>
     TransportLeavingTheBorder
       .form(request.declarationType)
       .bindFromRequest()

--- a/app/controllers/declaration/TransportPaymentController.scala
+++ b/app/controllers/declaration/TransportPaymentController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.TransportPayment
 import forms.declaration.TransportPayment._
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.i18n.I18nSupport
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.transport_payment
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class TransportPaymentController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -46,7 +44,7 @@ class TransportPaymentController @Inject()(
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL, DeclarationType.CLEARANCE)
 
   def displayPage(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)) { implicit request =>
+    (authenticate andThen journeyType(validTypes)) { implicit request =>
       val frm = form().withSubmissionErrors()
       request.cacheModel.transport.transportPayment match {
         case Some(data) => Ok(transportPayment(mode, frm.fill(data)))
@@ -55,7 +53,7 @@ class TransportPaymentController @Inject()(
     }
 
   def submitForm(mode: Mode): Action[AnyContent] =
-    (authenticate andThen verifyEmail andThen journeyType(validTypes)).async { implicit request =>
+    (authenticate andThen journeyType(validTypes)).async { implicit request =>
       form()
         .bindFromRequest()
         .fold(

--- a/app/controllers/declaration/UNDangerousGoodsCodeController.scala
+++ b/app/controllers/declaration/UNDangerousGoodsCodeController.scala
@@ -16,12 +16,10 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.UNDangerousGoodsCode
 import forms.declaration.UNDangerousGoodsCode.form
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -31,11 +29,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.un_dangerous_goods_code
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class UNDangerousGoodsCodeController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
@@ -44,7 +42,7 @@ class UNDangerousGoodsCodeController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.itemBy(itemId).flatMap(_.dangerousGoodsCode) match {
       case Some(dangerousGoodsCode) => Ok(unDangerousGoodsCodePage(mode, itemId, frm.fill(dangerousGoodsCode)))
@@ -52,7 +50,7 @@ class UNDangerousGoodsCodeController @Inject()(
     }
   }
 
-  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form
       .bindFromRequest()
       .fold(

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -16,11 +16,9 @@
 
 package controllers.declaration
 
-import controllers.actions.{AuthAction, JourneyAction, VerifiedEmailAction}
+import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.WarehouseIdentification
-
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -30,11 +28,11 @@ import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.{warehouse_identification, warehouse_identification_yesno}
 
+import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
 class WarehouseIdentificationController @Inject()(
   authenticate: AuthAction,
-  verifyEmail: VerifiedEmailAction,
   journeyType: JourneyAction,
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
@@ -44,7 +42,7 @@ class WarehouseIdentificationController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val frm = form().withSubmissionErrors()
     request.cacheModel.locations.warehouseIdentification match {
       case Some(data) => Ok(page(mode, frm.fill(data)))
@@ -52,7 +50,7 @@ class WarehouseIdentificationController @Inject()(
     }
   }
 
-  def saveIdentificationNumber(mode: Mode): Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>
+  def saveIdentificationNumber(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form()
       .bindFromRequest()
       .fold(

--- a/app/controllers/pdf/EADController.scala
+++ b/app/controllers/pdf/EADController.scala
@@ -16,23 +16,21 @@
 
 package controllers.pdf
 
-import java.time.LocalDate
-import controllers.actions.{AuthAction, VerifiedEmailAction}
-
-import javax.inject.Inject
+import controllers.actions.AuthAction
 import org.apache.xmlgraphics.util.MimeConstants
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.ead.EADService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 
+import java.time.LocalDate
+import javax.inject.Inject
 import scala.concurrent.ExecutionContext
 
-class EADController @Inject()(authenticate: AuthAction, verifyEmail: VerifiedEmailAction, mcc: MessagesControllerComponents, eadService: EADService)(
-  implicit ec: ExecutionContext
-) extends FrontendController(mcc) with I18nSupport {
+class EADController @Inject()(authenticate: AuthAction, mcc: MessagesControllerComponents, eadService: EADService)(implicit ec: ExecutionContext)
+    extends FrontendController(mcc) with I18nSupport {
 
-  def generatePdf(mrn: String): Action[AnyContent] = (authenticate andThen verifyEmail).async { implicit request =>
+  def generatePdf(mrn: String): Action[AnyContent] = authenticate.async { implicit request =>
     val fileName = s"EAD-${mrn}-${LocalDate.now}.pdf"
 
     eadService.generatePdf(mrn).map { pdf =>

--- a/app/models/requests/ItemRequest.scala
+++ b/app/models/requests/ItemRequest.scala
@@ -18,4 +18,4 @@ package models.requests
 import models.declaration.ExportItem
 
 class ItemRequest[A](val item: ExportItem, journeyRequest: JourneyRequest[A])
-    extends JourneyRequest[A](journeyRequest.verifiedEmailRequest, journeyRequest.cacheModel) {}
+    extends JourneyRequest[A](journeyRequest.authenticatedRequest, journeyRequest.cacheModel) {}

--- a/app/models/requests/JourneyRequest.scala
+++ b/app/models/requests/JourneyRequest.scala
@@ -21,12 +21,13 @@ import models.ExportsDeclaration
 import models.responses.FlashKeys
 import play.api.data.FormError
 
-class JourneyRequest[+A](val verifiedEmailRequest: VerifiedEmailRequest[A], val cacheModel: ExportsDeclaration)
-    extends AuthenticatedRequest[A](verifiedEmailRequest, verifiedEmailRequest.user) {
+class JourneyRequest[+A](val authenticatedRequest: AuthenticatedRequest[A], val cacheModel: ExportsDeclaration)
+    extends AuthenticatedRequest[A](authenticatedRequest, authenticatedRequest.user) {
+
   val declarationType: DeclarationType = cacheModel.`type`
   val sourceDecId: Option[String] = cacheModel.sourceId
   def isType(`type`: DeclarationType*): Boolean = `type`.contains(declarationType)
-  def eori: String = verifiedEmailRequest.user.eori
+  def eori: String = authenticatedRequest.user.eori
   def submissionErrors: Seq[FormError] = {
     val fieldName = flash.get(FlashKeys.fieldName)
     val errorMessage = flash.get(FlashKeys.errorMessage)

--- a/test/controllers/CancelDeclarationControllerSpec.scala
+++ b/test/controllers/CancelDeclarationControllerSpec.scala
@@ -43,7 +43,6 @@ class CancelDeclarationControllerSpec extends ControllerWithoutFormSpec with Err
       mockAuthAction,
       mockVerifiedEmailAction,
       mockCustomsDeclareExportsConnector,
-      mockErrorHandler,
       mockExportsMetrics,
       stubMessagesControllerComponents(),
       mockAuditService,

--- a/test/controllers/RemoveSavedDeclarationsControllerSpec.scala
+++ b/test/controllers/RemoveSavedDeclarationsControllerSpec.scala
@@ -35,8 +35,7 @@ class RemoveSavedDeclarationsControllerSpec extends ControllerWithoutFormSpec {
       mockVerifiedEmailAction,
       mockCustomsDeclareExportsConnector,
       stubMessagesControllerComponents(),
-      removeDeclarationPage,
-      config
+      removeDeclarationPage
     )(ec)
 
     authorizedUser()

--- a/test/controllers/declaration/AdditionalActorsAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalActorsAddControllerSpec.scala
@@ -37,7 +37,6 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
   val controller = new AdditionalActorsAddController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
@@ -40,7 +40,6 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
   val controller =
     new AdditionalActorsRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/AdditionalActorsSummaryControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalActorsSummaryControllerSpec.scala
@@ -39,7 +39,6 @@ class AdditionalActorsSummaryControllerSpec extends ControllerSpec with OptionVa
 
   val controller = new AdditionalActorsSummaryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
@@ -39,7 +39,6 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec {
 
   val controller = new AdditionalDeclarationTypeController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
@@ -38,7 +38,6 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
 
   val controller = new AdditionalFiscalReferencesAddController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
@@ -39,7 +39,6 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
   val controller =
     new AdditionalFiscalReferencesRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/AdditionalInformationAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationAddControllerSpec.scala
@@ -39,7 +39,6 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
   val controller = new AdditionalInformationAddController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
@@ -40,7 +40,6 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
   val controller = new AdditionalInformationChangeController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalInformationControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationControllerSpec.scala
@@ -37,7 +37,6 @@ class AdditionalInformationControllerSpec extends ControllerSpec with ErrorHandl
 
   val controller = new AdditionalInformationController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/AdditionalInformationRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationRemoveControllerSpec.scala
@@ -41,7 +41,6 @@ class AdditionalInformationRemoveControllerSpec extends ControllerSpec with Opti
   val controller =
     new AdditionalInformationRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
@@ -36,7 +36,6 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
   val controller = new AdditionalInformationRequiredController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/BorderTransportControllerSpec.scala
+++ b/test/controllers/declaration/BorderTransportControllerSpec.scala
@@ -17,7 +17,6 @@
 package controllers.declaration
 
 import base.ControllerSpec
-import controllers.declaration.BorderTransportController
 import forms.declaration.BorderTransport
 import forms.declaration.TransportCodes.IMOShipIDNumber
 import models.DeclarationType._
@@ -38,7 +37,6 @@ class BorderTransportControllerSpec extends ControllerSpec {
 
   val controller = new BorderTransportController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -39,7 +39,6 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
 
   val controller = new CarrierDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/CarrierEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/CarrierEoriNumberControllerSpec.scala
@@ -41,7 +41,6 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new CarrierEoriNumberController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/CommodityDetailsControllerSpec.scala
+++ b/test/controllers/declaration/CommodityDetailsControllerSpec.scala
@@ -38,7 +38,6 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new CommodityDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/CommodityMeasureControllerSpec.scala
+++ b/test/controllers/declaration/CommodityMeasureControllerSpec.scala
@@ -37,7 +37,6 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
   val controller = new CommodityMeasureController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ConfirmationControllerSpec.scala
+++ b/test/controllers/declaration/ConfirmationControllerSpec.scala
@@ -31,13 +31,7 @@ class ConfirmationControllerSpec extends ControllerWithoutFormSpec with Injector
     val draftConfirmationPage = instanceOf[draft_confirmation_page]
 
     val controller =
-      new ConfirmationController(
-        mockAuthAction,
-        mockVerifiedEmailAction,
-        stubMessagesControllerComponents(),
-        submissionConfirmationPage,
-        draftConfirmationPage
-      )
+      new ConfirmationController(mockAuthAction, stubMessagesControllerComponents(), submissionConfirmationPage, draftConfirmationPage)
 
     authorizedUser()
   }

--- a/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -38,7 +38,6 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
 
   val controller = new ConsigneeDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -38,7 +38,6 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec {
 
   val controller = new ConsignmentReferencesController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ConsignorDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ConsignorDetailsControllerSpec.scala
@@ -39,7 +39,6 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
   val controller = new ConsignorDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
@@ -41,7 +41,6 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new ConsignorEoriNumberController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/CusCodeControllerSpec.scala
+++ b/test/controllers/declaration/CusCodeControllerSpec.scala
@@ -37,15 +37,7 @@ class CusCodeControllerSpec extends ControllerSpec {
   val mockPage = mock[cus_code]
 
   val controller =
-    new CusCodeController(
-      mockAuthAction,
-      mockVerifiedEmailAction,
-      mockJourneyAction,
-      mockExportsCacheService,
-      navigator,
-      stubMessagesControllerComponents(),
-      mockPage
-    )(ec)
+    new CusCodeController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -39,7 +39,6 @@ class DeclarantDetailsControllerSpec extends ControllerSpec {
 
   val controller = new DeclarantDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarantExporterControllerSpec.scala
+++ b/test/controllers/declaration/DeclarantExporterControllerSpec.scala
@@ -37,7 +37,6 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new DeclarantExporterController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarationHolderAddControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderAddControllerSpec.scala
@@ -38,7 +38,6 @@ class DeclarationHolderAddControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new DeclarationHolderAddController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
@@ -38,7 +38,6 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
 
   val controller = new DeclarationHolderChangeController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarationHolderControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderControllerSpec.scala
@@ -39,7 +39,6 @@ class DeclarationHolderControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new DeclarationHolderController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarationHolderRemoveControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderRemoveControllerSpec.scala
@@ -38,7 +38,6 @@ class DeclarationHolderRemoveControllerSpec extends ControllerSpec with OptionVa
 
   val controller = new DeclarationHolderRemoveController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DeclarationHolderRequiredControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderRequiredControllerSpec.scala
@@ -38,7 +38,6 @@ class DeclarationHolderRequiredControllerSpec extends ControllerSpec with Option
 
   val controller = new DeclarationHolderRequiredController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DepartureTransportControllerSpec.scala
+++ b/test/controllers/declaration/DepartureTransportControllerSpec.scala
@@ -41,7 +41,6 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
   val controller = new DepartureTransportController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DestinationCountryControllerSpec.scala
+++ b/test/controllers/declaration/DestinationCountryControllerSpec.scala
@@ -39,7 +39,6 @@ class DestinationCountryControllerSpec extends ControllerSpec {
 
   val controller = new DestinationCountryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DocumentsProducedAddControllerSpec.scala
+++ b/test/controllers/declaration/DocumentsProducedAddControllerSpec.scala
@@ -37,7 +37,6 @@ class DocumentsProducedAddControllerSpec extends ControllerSpec with ErrorHandle
 
   val controller = new DocumentsProducedAddController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DocumentsProducedChangeControllerSpec.scala
+++ b/test/controllers/declaration/DocumentsProducedChangeControllerSpec.scala
@@ -38,7 +38,6 @@ class DocumentsProducedChangeControllerSpec extends ControllerSpec with ErrorHan
 
   val controller = new DocumentsProducedChangeController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DocumentsProducedControllerSpec.scala
+++ b/test/controllers/declaration/DocumentsProducedControllerSpec.scala
@@ -36,7 +36,6 @@ class DocumentsProducedControllerSpec extends ControllerSpec with ErrorHandlerMo
 
   val controller = new DocumentsProducedController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/DocumentsProducedRemoveControllerSpec.scala
+++ b/test/controllers/declaration/DocumentsProducedRemoveControllerSpec.scala
@@ -40,7 +40,6 @@ class DocumentsProducedRemoveControllerSpec extends ControllerSpec with OptionVa
   val controller =
     new DocumentsProducedRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/EntryIntoDeclarantsRecordsControllerSpec.scala
+++ b/test/controllers/declaration/EntryIntoDeclarantsRecordsControllerSpec.scala
@@ -40,7 +40,6 @@ class EntryIntoDeclarantsRecordsControllerSpec extends ControllerSpec with Scala
 
   private val controller = new EntryIntoDeclarantsRecordsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ExporterDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ExporterDetailsControllerSpec.scala
@@ -41,7 +41,6 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new ExporterDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/ExporterEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/ExporterEoriNumberControllerSpec.scala
@@ -41,7 +41,6 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
 
   val controller = new ExporterEoriNumberController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/FiscalInformationControllerSpec.scala
+++ b/test/controllers/declaration/FiscalInformationControllerSpec.scala
@@ -38,7 +38,6 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new FiscalInformationController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/InlandTransportDetailsControllerSpec.scala
+++ b/test/controllers/declaration/InlandTransportDetailsControllerSpec.scala
@@ -39,7 +39,6 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with BeforeAnd
 
   private val controller = new InlandTransportDetailsController(
     authenticate = mockAuthAction,
-    verifyEmail = mockVerifiedEmailAction,
     journeyType = mockJourneyAction,
     navigator = navigator,
     exportsCacheService = mockExportsCacheService,

--- a/test/controllers/declaration/IsExsControllerSpec.scala
+++ b/test/controllers/declaration/IsExsControllerSpec.scala
@@ -38,15 +38,8 @@ class IsExsControllerSpec extends ControllerSpec with ScalaFutures {
 
   private val isExsPage = mock[is_exs]
 
-  private val controller = new IsExsController(
-    mockAuthAction,
-    mockVerifiedEmailAction,
-    mockJourneyAction,
-    mockExportsCacheService,
-    navigator,
-    stubMessagesControllerComponents(),
-    isExsPage
-  )(ec)
+  private val controller =
+    new IsExsController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), isExsPage)(ec)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/declaration/ItemsSummaryControllerSpec.scala
+++ b/test/controllers/declaration/ItemsSummaryControllerSpec.scala
@@ -50,7 +50,6 @@ class ItemsSummaryControllerSpec extends ControllerWithoutFormSpec with OptionVa
 
   private val controller = new ItemsSummaryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/LocationControllerSpec.scala
+++ b/test/controllers/declaration/LocationControllerSpec.scala
@@ -37,7 +37,6 @@ class LocationControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new LocationController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     stubMessagesControllerComponents(),
     mockGoodsLocationPage,

--- a/test/controllers/declaration/NactCodeAddControllerSpec.scala
+++ b/test/controllers/declaration/NactCodeAddControllerSpec.scala
@@ -38,7 +38,6 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new NactCodeAddController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/NactCodeRemoveControllerSpec.scala
+++ b/test/controllers/declaration/NactCodeRemoveControllerSpec.scala
@@ -38,7 +38,6 @@ class NactCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new NactCodeRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/NactCodeSummaryControllerSpec.scala
+++ b/test/controllers/declaration/NactCodeSummaryControllerSpec.scala
@@ -35,15 +35,8 @@ class NactCodeSummaryControllerSpec extends ControllerSpec with OptionValues {
 
   val mockPage = mock[nact_codes]
 
-  val controller = new NactCodeSummaryController(
-    mockAuthAction,
-    mockVerifiedEmailAction,
-    mockJourneyAction,
-    mockExportsCacheService,
-    navigator,
-    stubMessagesControllerComponents(),
-    mockPage
-  )
+  val controller =
+    new NactCodeSummaryController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
+++ b/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
@@ -38,7 +38,6 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new NatureOfTransactionController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/NotEligibleControllerSpec.scala
+++ b/test/controllers/declaration/NotEligibleControllerSpec.scala
@@ -32,7 +32,7 @@ class NotEligibleControllerSpec extends ControllerWithoutFormSpec {
     val notDeclarantPage: not_declarant = mock[not_declarant]
 
     val controller =
-      new NotEligibleController(mockAuthAction, mockVerifiedEmailAction, stubMessagesControllerComponents(), notEligiblePage, notDeclarantPage)
+      new NotEligibleController(mockAuthAction, stubMessagesControllerComponents(), notEligiblePage, notDeclarantPage)
 
     authorizedUser()
     withNewCaching(aDeclaration(withType(DeclarationType.SUPPLEMENTARY)))

--- a/test/controllers/declaration/OfficeOfExitControllerSpec.scala
+++ b/test/controllers/declaration/OfficeOfExitControllerSpec.scala
@@ -37,7 +37,6 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
   val controller = new OfficeOfExitController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/OriginationCountryControllerSpec.scala
+++ b/test/controllers/declaration/OriginationCountryControllerSpec.scala
@@ -39,7 +39,6 @@ class OriginationCountryControllerSpec extends ControllerSpec {
 
   val controller = new OriginationCountryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/PackageInformationAddControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationAddControllerSpec.scala
@@ -38,7 +38,6 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
   val controller =
     new PackageInformationAddController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/PackageInformationRemoveControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationRemoveControllerSpec.scala
@@ -38,7 +38,6 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with OptionV
   val controller =
     new PackageInformationRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/PackageInformationSummaryControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationSummaryControllerSpec.scala
@@ -39,7 +39,6 @@ class PackageInformationSummaryControllerSpec extends ControllerSpec with Option
 
   val controller = new PackageInformationSummaryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
+++ b/test/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
@@ -41,7 +41,6 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
 
   private val controller = new PersonPresentingGoodsDetailsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
@@ -36,7 +36,6 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
   val controller = new PreviousDocumentsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
@@ -36,7 +36,6 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
   private val controller = new PreviousDocumentsRemoveController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/PreviousDocumentsSummaryControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsSummaryControllerSpec.scala
@@ -38,7 +38,6 @@ class PreviousDocumentsSummaryControllerSpec extends ControllerSpec {
 
   private val controller = new PreviousDocumentsSummaryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/ProcedureCodesControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodesControllerSpec.scala
@@ -40,7 +40,6 @@ class ProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks
 
   val controller = new ProcedureCodesController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/RepresentativeAgentControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeAgentControllerSpec.scala
@@ -37,7 +37,6 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
 
   val controller = new RepresentativeAgentController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/RepresentativeEntityControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeEntityControllerSpec.scala
@@ -38,7 +38,6 @@ class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new RepresentativeEntityController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/RepresentativeStatusControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeStatusControllerSpec.scala
@@ -39,7 +39,6 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new RepresentativeStatusController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/RoutingCountriesControllerSpec.scala
+++ b/test/controllers/declaration/RoutingCountriesControllerSpec.scala
@@ -37,7 +37,6 @@ class RoutingCountriesControllerSpec extends ControllerSpec {
 
   val controller = new RoutingCountriesController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/RoutingCountriesSummaryControllerSpec.scala
+++ b/test/controllers/declaration/RoutingCountriesSummaryControllerSpec.scala
@@ -38,7 +38,6 @@ class RoutingCountriesSummaryControllerSpec extends ControllerSpec {
 
   val controller = new RoutingCountriesSummaryController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/SealControllerSpec.scala
+++ b/test/controllers/declaration/SealControllerSpec.scala
@@ -43,7 +43,6 @@ class SealControllerSpec extends ControllerSpec with ErrorHandlerMocks {
 
   val controller = new SealController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockErrorHandler,

--- a/test/controllers/declaration/StatisticalValueControllerSpec.scala
+++ b/test/controllers/declaration/StatisticalValueControllerSpec.scala
@@ -39,9 +39,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
 
   val controller = new StatisticalValueController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
-    mockErrorHandler,
     mockExportsCacheService,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -37,7 +37,6 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
   private val controller = new SupervisingCustomsOfficeController(
     authenticate = mockAuthAction,
-    verifyEmail = mockVerifiedEmailAction,
     journeyType = mockJourneyAction,
     navigator = navigator,
     exportsCacheService = mockExportsCacheService,

--- a/test/controllers/declaration/TaricCodeAddControllerSpec.scala
+++ b/test/controllers/declaration/TaricCodeAddControllerSpec.scala
@@ -38,7 +38,6 @@ class TaricCodeAddControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeAddController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/TaricCodeRemoveControllerSpec.scala
+++ b/test/controllers/declaration/TaricCodeRemoveControllerSpec.scala
@@ -38,7 +38,6 @@ class TaricCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeRemoveController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/TaricCodeSummaryControllerSpec.scala
+++ b/test/controllers/declaration/TaricCodeSummaryControllerSpec.scala
@@ -38,7 +38,6 @@ class TaricCodeSummaryControllerSpec extends ControllerSpec with OptionValues {
   val controller =
     new TaricCodeSummaryController(
       mockAuthAction,
-      mockVerifiedEmailAction,
       mockJourneyAction,
       mockExportsCacheService,
       navigator,

--- a/test/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
+++ b/test/controllers/declaration/TotalNumberOfItemsControllerSpec.scala
@@ -61,7 +61,6 @@ class TotalNumberOfItemsControllerSpec extends ControllerSpec with OptionValues 
 
   val controller = new TotalNumberOfItemsController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     stubMessagesControllerComponents(),

--- a/test/controllers/declaration/TotalPackageQuantityControllerSpec.scala
+++ b/test/controllers/declaration/TotalPackageQuantityControllerSpec.scala
@@ -37,7 +37,6 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
 
   val controller = new TotalPackageQuantityController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     stubMessagesControllerComponents(),
     navigator,

--- a/test/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/controllers/declaration/TransportContainerControllerSpec.scala
@@ -41,7 +41,6 @@ class TransportContainerControllerSpec extends ControllerSpec with ErrorHandlerM
 
   val controller = new TransportContainerController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
+++ b/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
@@ -37,7 +37,6 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec {
 
   val controller = new TransportLeavingTheBorderController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -37,7 +37,6 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
   val controller = new TransportPaymentController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
+++ b/test/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
@@ -39,7 +39,6 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
 
   val controller = new UNDangerousGoodsCodeController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     mockExportsCacheService,
     navigator,

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -38,7 +38,6 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
   val controller = new WarehouseIdentificationController(
     mockAuthAction,
-    mockVerifiedEmailAction,
     mockJourneyAction,
     navigator,
     mockExportsCacheService,

--- a/test/controllers/pdf/EADControllerSpec.scala
+++ b/test/controllers/pdf/EADControllerSpec.scala
@@ -42,7 +42,7 @@ class EADControllerSpec extends ControllerWithoutFormSpec with Injector {
   val connector = mock[CustomsDeclareExportsConnector]
   val eADService = new EADService(barcodeService, pdfTemplate, playFop, connector)
 
-  val controller = new EADController(mockAuthAction, mockVerifiedEmailAction, mcc, eADService)
+  val controller = new EADController(mockAuthAction, mcc, eADService)
 
   override def beforeEach(): Unit = {
     when(connector.fetchMrnStatus(any())(any(), any())).thenReturn(Future.successful(Some(MrnStatusSpec.completeMrnStatus)))

--- a/test/mock/ItemActionMocks.scala
+++ b/test/mock/ItemActionMocks.scala
@@ -26,5 +26,5 @@ import scala.concurrent.ExecutionContext
 trait ItemActionMocks extends JourneyActionMocks with MockAuthAction with VerifiedEmailMocks {
   self: MockitoSugar with Suite with BeforeAndAfterEach =>
 
-  val mockItemAction = new ItemActionBuilder(mockAuthAction, mockVerifiedEmailAction, mockJourneyAction)(ExecutionContext.global)
+  val mockItemAction = new ItemActionBuilder(mockAuthAction, mockJourneyAction)(ExecutionContext.global)
 }


### PR DESCRIPTION
Endpoints that still have email verification:

/choice
/declaration/declaration-choice
/declaration/summary
/declaration/amend-summary
/declaration/saved-summary
/submissions
/submissions/{id}
/submissions/{id}/information
/submissions/{id}/view
/submissions/{id}/previously-submitted-answers
/submissions/{id}/rejected-notifications
/submissions/{id}/{url}/{pattern}/{messageKey}
/saved-declarations
/saved-declarations/{id}
/saved-declarations/{id}/remove
/cancel-declaration