### PR TITLE
[CEDS-3203] New validation rules for handling APC 000

### DIFF
--- a/app/controllers/declaration/AdditionalProcedureCodesController.scala
+++ b/app/controllers/declaration/AdditionalProcedureCodesController.scala
@@ -23,9 +23,11 @@ import controllers.navigation.Navigator
 import controllers.util.MultipleItemsHelper.remove
 import controllers.util._
 import forms.declaration.procedurecodes.AdditionalProcedureCode
-import forms.declaration.procedurecodes.AdditionalProcedureCode.form
 import javax.inject.Inject
+import forms.declaration.procedurecodes.AdditionalProcedureCode._
+import models.{ExportsDeclaration, Mode}
 import models.codes.{ProcedureCode, AdditionalProcedureCode => AdditionalProcedureCodeModel}
+import models.codes.AdditionalProcedureCode.NO_APC_APPLIES_CODE
 import models.declaration.ProcedureCodesData
 import models.declaration.ProcedureCodesData.limitOfCodes
 import models.requests.JourneyRequest
@@ -37,6 +39,7 @@ import services.ProcedureCodeService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
+
 import views.html.declaration.procedureCodes.additional_procedure_codes
 
 class AdditionalProcedureCodesController @Inject()(
@@ -135,12 +138,22 @@ class AdditionalProcedureCodesController @Inject()(
 
       case (None, _) =>
         returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
-          Seq(("additionalProcedureCode", "declaration.additionalProcedureCodes.error.empty"))
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.empty"))
+        )
+
+      case (Some(NO_APC_APPLIES_CODE), cachedAdditionalProcedureCodes) if cachedAdditionalProcedureCodes.length != 0 =>
+        returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.tripleZero.notFirstCode"))
+        )
+
+      case (Some(_), cachedAdditionalProcedureCodes) if cachedAdditionalProcedureCodes.contains(NO_APC_APPLIES_CODE) =>
+        returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.tripleZero.alreadyPresent"))
         )
 
       case (Some(code), cachedAdditionalProcedureCodes) if cachedAdditionalProcedureCodes.contains(code) =>
         returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
-          Seq(("additionalProcedureCode", "declaration.additionalProcedureCodes.error.duplication"))
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.duplication"))
         )
 
       case (Some(code), cachedAdditionalProcedureCodes) =>
@@ -163,7 +176,7 @@ class AdditionalProcedureCodesController @Inject()(
 
       case AdditionalProcedureCode(None) =>
         returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
-          Seq(("additionalProcedureCode", "declaration.additionalProcedureCodes.error.empty"))
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.empty"))
         )
     }
 
@@ -175,7 +188,7 @@ class AdditionalProcedureCodesController @Inject()(
 
       case AdditionalProcedureCode(Some(additionalCode)) if cachedData.additionalProcedureCodes.contains(additionalCode) =>
         returnErrorPage(mode, itemId, userInput, procedureCode, cachedData.additionalProcedureCodes, validAdditionalProcedureCodes)(
-          Seq(("additionalProcedureCode", "declaration.additionalProcedureCodes.error.duplication"))
+          Seq((additionalProcedureCodeKey, "declaration.additionalProcedureCodes.error.duplication"))
         )
 
       case AdditionalProcedureCode(Some(additionalCode)) =>

--- a/app/models/codes/AdditionalProcedureCode.scala
+++ b/app/models/codes/AdditionalProcedureCode.scala
@@ -17,3 +17,7 @@
 package models.codes
 
 case class AdditionalProcedureCode(code: String, description: String) extends CommonCode
+
+object AdditionalProcedureCode {
+  val NO_APC_APPLIES_CODE = "000"
+}

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -809,6 +809,8 @@ declaration.additionalProcedureCodes.error.empty = Enter an additional procedure
 declaration.additionalProcedureCodes.error.invalid = Additional procedure code must be 3 characters, containing only letters and numbers
 declaration.additionalProcedureCodes.error.maximumAmount = Maximum amount of additional procedure codes added
 declaration.additionalProcedureCodes.error.duplication = You have already added this code for this item
+declaration.additionalProcedureCodes.error.tripleZero.alreadyPresent = Additional procedure code '000' is added: no further additional procedure codes are permitted
+declaration.additionalProcedureCodes.error.tripleZero.notFirstCode = Additional procedure code ‘000’ not permitted with any other additional procedure codes
 
 declaration.officeOfExit.title = Where is the customs office of exit?
 declaration.officeOfExit.hint = This is the office where goods are officially recorded as having left the UK.


### PR DESCRIPTION
Don't allow '000' if another code already exists and
don't allow another code if '000' already exists.