### PR TITLE
CEDS-3246 Fix a caching problem with the APC page

### DIFF
--- a/app/controllers/declaration/AdditionalProcedureCodesController.scala
+++ b/app/controllers/declaration/AdditionalProcedureCodesController.scala
@@ -206,7 +206,7 @@ class AdditionalProcedureCodesController @Inject()(
 
         val model = maybeModel.fold(request.cacheModel)(identity)
         if (SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesNotVerified(model)) Future.successful(continueToCommodityDetails)
-        else SupervisingCustomsOfficeHelper.resetCache(this).map(_ => continueToCommodityDetails)
+        else SupervisingCustomsOfficeHelper.resetCache(this, model).map(_ => continueToCommodityDetails)
     }
 
   private def returnErrorPage(

--- a/app/controllers/declaration/ModelCacheable.scala
+++ b/app/controllers/declaration/ModelCacheable.scala
@@ -27,6 +27,9 @@ trait ModelCacheable {
 
   def exportsCacheService: ExportsCacheService
 
+  def updateExportsDeclarationSyncDirect(declaration: ExportsDeclaration)(implicit hc: HeaderCarrier): Future[Option[ExportsDeclaration]] =
+    exportsCacheService.update(declaration)
+
   def updateExportsDeclarationSyncDirect(
     update: ExportsDeclaration => ExportsDeclaration
   )(implicit hc: HeaderCarrier, request: JourneyRequest[_]): Future[Option[ExportsDeclaration]] =

--- a/app/controllers/util/SupervisingCustomsOfficeHelper.scala
+++ b/app/controllers/util/SupervisingCustomsOfficeHelper.scala
@@ -51,6 +51,6 @@ object SupervisingCustomsOfficeHelper {
       case DeclarationType.CLEARANCE                                => routes.DepartureTransportController.displayPage
     }
 
-  def resetCache(modelCacheable: ModelCacheable)(implicit hc: HeaderCarrier, request: JourneyRequest[_]): Future[Option[ExportsDeclaration]] =
-    modelCacheable.updateExportsDeclarationSyncDirect(_.removeSupervisingCustomsOffice)
+  def resetCache(modelCacheable: ModelCacheable, declaration: ExportsDeclaration)(implicit hc: HeaderCarrier): Future[Option[ExportsDeclaration]] =
+    modelCacheable.updateExportsDeclarationSyncDirect(declaration.removeSupervisingCustomsOffice)
 }


### PR DESCRIPTION
Fix a caching problem with the APC page when not clicking the 'Add' button but directly clicking the 'Save and continue' button.