### PR TITLE
[CEDS-3131] Trim white spaces

### DIFF
--- a/app/forms/CancelDeclaration.scala
+++ b/app/forms/CancelDeclaration.scala
@@ -39,6 +39,7 @@ object CancelDeclaration {
   val mapping = Forms.mapping(
     functionalReferenceIdKey -> Lrn.mapping("cancellation.functionalReferenceId"),
     mrnKey -> text()
+      .transform(_.trim, (s: String) => s)
       .verifying("cancellation.mrn.error.empty", nonEmpty)
       .verifying("cancellation.mrn.error.length", isEmpty or hasSpecificLength(mrnLength))
       .verifying("cancellation.mrn.error.wrongFormat", isEmpty or isAlphanumeric),

--- a/app/forms/declaration/GoodsLocationForm.scala
+++ b/app/forms/declaration/GoodsLocationForm.scala
@@ -70,6 +70,7 @@ object GoodsLocationForm extends DeclarationPage {
 
   val mapping = Forms.mapping(
     "code" -> text()
+      .transform(_.trim, (s: String) => s)
       .verifying("declaration.goodsLocation.code.empty", nonEmpty)
       .verifying(
         "declaration.goodsLocation.code.error",

--- a/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
+++ b/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
@@ -79,6 +79,7 @@ object AdditionalDocument extends DeclarationPage {
         documentTypeCodeKey -> documentTypeCodeRequired,
         documentIdentifierKey -> optional(
           text()
+            .transform(_.trim, (s: String) => s)
             .verifying(
               "declaration.additionalDocument.documentIdentifier.error",
               nonEmpty and isAlphanumericWithAllowedSpecialCharacters and noLongerThan(35)

--- a/test/forms/CancelDeclarationSpec.scala
+++ b/test/forms/CancelDeclarationSpec.scala
@@ -17,25 +17,30 @@
 package forms
 
 import base.UnitSpec
+import play.api.data.Form
 import play.api.libs.json.{JsObject, JsString}
 
 class CancelDeclarationSpec extends UnitSpec {
 
-  def formData(lrn: String = "lrn", mrn: String = "123456789012345678", description: String = "description", reason: String = "1") =
-    JsObject(
-      Map(
-        "functionalReferenceId" -> JsString(lrn),
-        "mrn" -> JsString(mrn),
-        "statementDescription" -> JsString(description),
-        "changeReason" -> JsString(reason)
-      )
+  private val validMrn = "123456789012345678"
+  def getBoundedForm(lrn: String = "lrn", mrn: String = validMrn, description: String = "description", reason: String = "1") =
+    CancelDeclaration.form.bind(
+      JsObject(
+        Map(
+          "functionalReferenceId" -> JsString(lrn),
+          "mrn" -> JsString(mrn),
+          "statementDescription" -> JsString(description),
+          "changeReason" -> JsString(reason)
+        )
+      ),
+      Form.FromJsonMaxChars
     )
 
   "Validation defined in CancelDeclaration mapping" should {
 
     "attach errors to form" when {
       "provided with empty lrn" in {
-        val form = CancelDeclaration.form.bind(formData(lrn = ""))
+        val form = getBoundedForm(lrn = "")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -43,7 +48,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with too long lrn" in {
-        val form = CancelDeclaration.form.bind(formData(lrn = "1234567890" * 3))
+        val form = getBoundedForm(lrn = "1234567890" * 3)
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -51,7 +56,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with invalid lrn" in {
-        val form = CancelDeclaration.form.bind(formData(lrn = "inv@l!d"))
+        val form = getBoundedForm(lrn = "inv@l!d")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -59,7 +64,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with empty mrn" in {
-        val form = CancelDeclaration.form.bind(formData(mrn = ""))
+        val form = getBoundedForm(mrn = "")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -67,7 +72,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with too long mrn" in {
-        val form = CancelDeclaration.form.bind(formData(mrn = "1234567890123456789"))
+        val form = getBoundedForm(mrn = "1234567890123456789")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -75,7 +80,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with invalid mrn" in {
-        val form = CancelDeclaration.form.bind(formData(mrn = "12345678901234567~"))
+        val form = getBoundedForm(mrn = "12345678901234567~")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -83,7 +88,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with empty description" in {
-        val form = CancelDeclaration.form.bind(formData(description = ""))
+        val form = getBoundedForm(description = "")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -91,7 +96,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with too long description" in {
-        val form = CancelDeclaration.form.bind(formData(description = "A23456789B" * 60))
+        val form = getBoundedForm(description = "A23456789B" * 60)
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -99,7 +104,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with invalid description" in {
-        val form = CancelDeclaration.form.bind(formData(description = "~23456789@"))
+        val form = getBoundedForm(description = "~23456789@")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -107,7 +112,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with missing reason" in {
-        val form = CancelDeclaration.form.bind(formData(reason = ""))
+        val form = getBoundedForm(reason = "")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -115,7 +120,7 @@ class CancelDeclarationSpec extends UnitSpec {
       }
 
       "provided with invalid reason" in {
-        val form = CancelDeclaration.form.bind(formData(reason = "17"))
+        val form = getBoundedForm(reason = "17")
 
         form.hasErrors must be(true)
         form.errors.length must equal(1)
@@ -125,11 +130,17 @@ class CancelDeclarationSpec extends UnitSpec {
 
     "not attach any error" when {
       "provided with valid input" in {
-        val form = CancelDeclaration.form.bind(formData())
+        val form = getBoundedForm()
 
-        form.errors must be(Seq.empty)
+        form.errors mustBe empty
+      }
+
+      "provided with an MRN string requiring trimming" in {
+        val form = getBoundedForm(mrn = s"\n \t${validMrn}\t \n")
+
+        form.errors mustBe empty
+        form.value.map(_.mrn) must be(Some(validMrn))
       }
     }
   }
-
 }

--- a/test/forms/declaration/AdditionalDocumentSpec.scala
+++ b/test/forms/declaration/AdditionalDocumentSpec.scala
@@ -180,6 +180,7 @@ class AdditionalDocumentSpec extends UnitSpec {
 
       def testFailedValidationErrors(input: Map[String, String], expectedErrors: Seq[FormError]): Unit = {
         val form = AdditionalDocument.form(declaration).bind(input)
+
         expectedErrors.foreach(form.errors must contain(_))
       }
     }
@@ -216,7 +217,17 @@ class AdditionalDocumentSpec extends UnitSpec {
         form.errors mustBe empty
         form.value.flatMap(_.documentStatus) must be(Some("AB"))
       }
+    }
 
+    "trim white spaces" when {
+      "provided with document identifier with white spaces at beginning and end of string" in {
+        val trimmedValue = TestHelper.createRandomAlphanumericString(20)
+        val input = Map(documentTypeCodeKey -> "AB12", documentIdentifierKey -> s"\n \t${trimmedValue}\t \n")
+        val form = AdditionalDocument.form(declaration).bind(input)
+
+        form.errors mustBe empty
+        form.value.flatMap(_.documentIdentifier) must be(Some(trimmedValue))
+      }
     }
   }
 }

--- a/test/forms/declaration/GoodsLocationFormSpec.scala
+++ b/test/forms/declaration/GoodsLocationFormSpec.scala
@@ -16,25 +16,103 @@
 
 package forms.declaration
 
+import base.TestHelper
 import forms.common.DeclarationPageBaseSpec
+import play.api.data.Form
 import play.api.libs.json.{JsObject, JsString}
 
 class GoodsLocationFormSpec extends DeclarationPageBaseSpec {
 
+  private val validCode = "GBAUFXTFXTFXT"
+
   "GoodsLocation form" should {
 
+    "return form with errors" when {
+
+      "provided with a Code" which {
+
+        "is missing" in {
+          val form = GoodsLocationForm.form().bind(JsObject(Map("unexpected" -> JsString(""))), Form.FromJsonMaxChars)
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("error.required")
+        }
+
+        "is empty" in {
+          val form = getBoundedForm("")
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.empty")
+        }
+
+        "is longer than 39 characters" in {
+          val form = getBoundedForm(TestHelper.createRandomAlphanumericString(40))
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+
+        "is shorter than 10 characters" in {
+          val form = getBoundedForm(TestHelper.createRandomAlphanumericString(9))
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+
+        "is alphanumeric" in {
+          val form = getBoundedForm(s"${validCode}*")
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+
+        "does not contain a valid country" in {
+          val form = getBoundedForm(s"XX${validCode}")
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+
+        "does not contain a valid location type" in {
+          val form = getBoundedForm(s"GBX${validCode}")
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+
+        "does not contain a valid qualifier code" in {
+          val form = getBoundedForm(s"GBAX${validCode}")
+
+          form.hasErrors must be(true)
+          form.errors.length must equal(1)
+          form.errors.head.message must equal("declaration.goodsLocation.code.error")
+        }
+      }
+    }
+
     "convert to upper case" in {
+      val form = getBoundedForm(validCode.toLowerCase)
 
-      def formData(code: String) =
-        JsObject(Map("code" -> JsString(code)))
+      form.value.map(_.code) must be(Some(validCode))
+    }
 
-      val form = GoodsLocationForm.form().bind(formData("plaucorrect"))
+    "trim white spaces" in {
+      val form = getBoundedForm(s"\n \t${validCode}\t \n")
 
-      form.value.map(_.code) must be(Some("PLAUCORRECT"))
+      form.value.map(_.code) must be(Some(validCode))
     }
   }
 
   "GoodsLocationForm" when {
     testTariffContentKeys(GoodsLocationForm, "tariff.declaration.locationOfGoods")
   }
+
+  private def getBoundedForm(code: String) = GoodsLocationForm.form().bind(JsObject(Map("code" -> JsString(code))), Form.FromJsonMaxChars)
 }

--- a/test/views/declaration/DeclarationHolderAddViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderAddViewSpec.scala
@@ -17,7 +17,6 @@
 package views.declaration
 
 import base.{Injector, TestHelper}
-import controllers.declaration.routes
 import controllers.util.SaveAndReturn
 import forms.common.{Eori, YesNoAnswer}
 import forms.declaration.declarationHolder.DeclarationHolderAdd


### PR DESCRIPTION
Auto trim strings on certain fields so that users do not need
to worry if they accidentally paste a white space char at the
beginning or end of a value