### PR TITLE
CEDS-3237 Fix Change link for 'Authorisations for this declaration'

### DIFF
--- a/app/controllers/declaration/AuthorisationProcedureCodeChoiceController.scala
+++ b/app/controllers/declaration/AuthorisationProcedureCodeChoiceController.scala
@@ -16,19 +16,22 @@
 
 package controllers.declaration
 
-import scala.concurrent.{ExecutionContext, Future}
-
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.AuthorisationProcedureCodeChoice
-import javax.inject.Inject
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.STANDARD_PRE_LODGED
+import models.DeclarationType._
+import models.declaration.AuthorisationProcedureCode._
 import models.requests.JourneyRequest
-import models.{DeclarationType, ExportsDeclaration, Mode}
+import models.{ExportsDeclaration, Mode}
 import play.api.i18n.I18nSupport
-import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.authorisation_procedure_code_choice
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 class AuthorisationProcedureCodeChoiceController @Inject()(
   authenticate: AuthAction,
@@ -40,8 +43,7 @@ class AuthorisationProcedureCodeChoiceController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  private val validTypes =
-    Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY, DeclarationType.SIMPLIFIED, DeclarationType.CLEARANCE)
+  private val validTypes = Seq(STANDARD, SUPPLEMENTARY, SIMPLIFIED, CLEARANCE)
 
   def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validTypes)) { implicit request =>
     val form = AuthorisationProcedureCodeChoice.form().withSubmissionErrors()
@@ -57,7 +59,7 @@ class AuthorisationProcedureCodeChoiceController @Inject()(
       .bindFromRequest()
       .fold(
         errors => Future.successful(BadRequest(authorisationProcedureCodeChoice(errors, mode))),
-        updateCache(_).map(_ => navigator.continueTo(mode, routes.DeclarationHolderSummaryController.displayPage))
+        updateCache(_).map(exportsDeclarationUpdated => navigator.continueTo(mode, nextPage(exportsDeclarationUpdated)))
       )
   }
 
@@ -65,4 +67,15 @@ class AuthorisationProcedureCodeChoiceController @Inject()(
     choice: AuthorisationProcedureCodeChoice
   )(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(_.updateAuthorisationProcedureCodeChoice(choice))
+
+  private def nextPage(exportsDeclarationOpt: Option[ExportsDeclaration]): Mode => Call =
+    (for {
+      exportsDeclaration <- exportsDeclarationOpt
+      authProcedureCodeChoice <- exportsDeclaration.parties.authorisationProcedureCodeChoice.map(_.code)
+
+    } yield (exportsDeclaration.`type`, exportsDeclaration.additionalDeclarationType, authProcedureCodeChoice)) match {
+      case Some((STANDARD, Some(STANDARD_PRE_LODGED), Code1040 | CodeOther)) => routes.DeclarationHolderRequiredController.displayPage
+      case _                                                                 => routes.DeclarationHolderSummaryController.displayPage
+    }
+
 }

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -31,9 +31,6 @@ import views.html.declaration.consignee_details
 import javax.inject.Inject
 import scala.concurrent.{ExecutionContext, Future}
 
-/**
-  * This controller is not used in supp dec journey
-  */
 class ConsigneeDetailsController @Inject()(
   authenticate: AuthAction,
   journeyType: JourneyAction,
@@ -69,7 +66,7 @@ class ConsigneeDetailsController @Inject()(
       case (DeclarationType.CLEARANCE, true) =>
         controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage
       case (DeclarationType.CLEARANCE, false) =>
-        controllers.declaration.routes.DeclarationHolderSummaryController.displayPage
+        controllers.declaration.routes.DeclarationHolderRequiredController.displayPage
       case _ =>
         controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
     }

--- a/app/controllers/declaration/DeclarationHolderRequiredController.scala
+++ b/app/controllers/declaration/DeclarationHolderRequiredController.scala
@@ -21,7 +21,7 @@ import controllers.navigation.Navigator
 import controllers.util.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
-import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
+import models.DeclarationType.{STANDARD, SUPPLEMENTARY}
 import models.declaration.DeclarationHoldersData
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -45,15 +45,13 @@ class DeclarationHolderRequiredController @Inject()(
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
-  private val validJourneys = Seq(STANDARD, SUPPLEMENTARY, OCCASIONAL, CLEARANCE, SIMPLIFIED)
-
-  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)) { implicit request =>
+  def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
     val holders = cachedHolders
     if (holders.isEmpty) Ok(declarationHolderRequired(mode, formWithPreviousAnswer.withSubmissionErrors()))
     else navigator.continueTo(mode, routes.DeclarationHolderSummaryController.displayPage(_))
   }
 
-  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType(validJourneys)).async { implicit request =>
+  def submitForm(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
     form
       .bindFromRequest()
       .fold(

--- a/app/views/declaration/summary/PartiesSectionHoldersHelper.scala
+++ b/app/views/declaration/summary/PartiesSectionHoldersHelper.scala
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration.summary
+
+import models.DeclarationType._
+import models.{ExportsDeclaration, Mode}
+import play.api.mvc.Call
+
+import javax.inject.Singleton
+
+@Singleton
+class PartiesSectionHoldersHelper {
+
+  def changeLinkTarget(exportsDeclaration: ExportsDeclaration): Mode => Call = { mode =>
+    exportsDeclaration.`type` match {
+      case CLEARANCE if exportsDeclaration.isNotEntryIntoDeclarantsRecords =>
+        controllers.declaration.routes.DeclarationHolderRequiredController.displayPage(mode)
+      case OCCASIONAL =>
+        controllers.declaration.routes.DeclarationHolderRequiredController.displayPage(mode)
+      case _ =>
+        controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage(mode)
+    }
+  }
+}

--- a/app/views/declaration/summary/parties_section.scala.html
+++ b/app/views/declaration/summary/parties_section.scala.html
@@ -255,6 +255,6 @@
     )
 
     @declarationData.parties.declarationHoldersData.map(data =>
-        holdersSection(mode, data.holders, actionsEnabled)
+        holdersSection(mode, declarationData, actionsEnabled)
     )
 }

--- a/app/views/declaration/summary/parties_section_holders.scala.html
+++ b/app/views/declaration/summary/parties_section_holders.scala.html
@@ -18,6 +18,7 @@
 @import services.view.HolderOfAuthorisationCodes
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.components.gds.ActionItemBuilder._
+@import views.declaration.summary.PartiesSectionHoldersHelper
 @import views.declaration.summary.TableCell
 @import views.html.components.gds.{link, linkContent, spanVisuallyHidden, summary_list}
 
@@ -27,10 +28,11 @@
     linkContent: linkContent,
     spanVisuallyHidden: spanVisuallyHidden,
     summaryList: summary_list,
-    holderOfAuthorisationCodes: HolderOfAuthorisationCodes
+    holderOfAuthorisationCodes: HolderOfAuthorisationCodes,
+    partiesSectionHoldersHelper: PartiesSectionHoldersHelper
 )
 
-@(mode: Mode, holders: Seq[DeclarationHolderAdd], actionsEnabled: Boolean = true)(implicit messages: Messages)
+@(mode: Mode, declarationData: ExportsDeclaration, actionsEnabled: Boolean = true)(implicit messages: Messages)
 
 @actions(action: Actions) = @{
     if(actionsEnabled) Some(action)
@@ -51,11 +53,15 @@
             changeLink(
                 messages("site.change"),
                 Some(messages("declaration.summary.parties.holders.change", holder.authorisationTypeCode.getOrElse(""), holderEori(holder))),
-                controllers.declaration.routes.DeclarationHolderSummaryController.displayPage(mode)
+                partiesSectionHoldersHelper.changeLinkTarget(declarationData)(mode)
             )
         else
             ""
     }
+}
+
+@holders = @{
+  declarationData.parties.declarationHoldersData.map(_.holders).getOrElse(Seq.empty)
 }
 
 @if(holders.isEmpty) {
@@ -71,7 +77,7 @@
             actions = actions(Actions(
                 items = Seq(
                     actionItem(
-                        href = controllers.declaration.routes.DeclarationHolderSummaryController.displayPage(mode).url,
+                        href = partiesSectionHoldersHelper.changeLinkTarget(declarationData)(mode).url,
                         content = HtmlContent(linkContent(messages("site.change"))),
                         visuallyHiddenText = Some(messages("declaration.summary.parties.holders.empty.change"))
                     )

--- a/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -128,7 +128,7 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
         "form is correct and EIDR is false" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withEntryIntoDeclarantsRecords(YesNoAnswers.no)))
 
-          testFormSubmitRedirectsTo(controllers.declaration.routes.DeclarationHolderSummaryController.displayPage())
+          testFormSubmitRedirectsTo(controllers.declaration.routes.DeclarationHolderRequiredController.displayPage())
         }
 
         "form is correct and EIDR is true" in {

--- a/test/views/declaration/summary/PartiesSectionHoldersHelperSpec.scala
+++ b/test/views/declaration/summary/PartiesSectionHoldersHelperSpec.scala
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package views.declaration.summary
+
+import base.JourneyTypeTestRunner
+import forms.common.YesNoAnswer.YesNoAnswers
+import models.DeclarationType._
+import models.Mode
+
+class PartiesSectionHoldersHelperSpec extends JourneyTypeTestRunner {
+
+  private val partiesSectionHoldersHelper = new PartiesSectionHoldersHelper
+
+  "PartiesSectionHoldersHelper on changeLinkUrl" when {
+
+    onJourney(OCCASIONAL) { request =>
+      "return DeclarationHolderRequiredController call" in {
+        val exportsDeclaration = aDeclaration(withType(request.declarationType))
+
+        val result = partiesSectionHoldersHelper.changeLinkTarget(exportsDeclaration)
+
+        result(Mode.Normal) mustBe controllers.declaration.routes.DeclarationHolderRequiredController.displayPage(Mode.Normal)
+      }
+    }
+
+    onJourney(CLEARANCE) { request =>
+      "it is EntryIntoDeclarantsRecords" should {
+        "return AuthorisationProcedureCodeChoiceController call" in {
+          val exportsDeclaration = aDeclaration(withType(request.declarationType), withEntryIntoDeclarantsRecords(YesNoAnswers.yes))
+
+          val result = partiesSectionHoldersHelper.changeLinkTarget(exportsDeclaration)
+
+          result(Mode.Normal) mustBe controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage(Mode.Normal)
+        }
+      }
+
+      "it is NOT EntryIntoDeclarantsRecords" should {
+        "return DeclarationHolderRequiredController call" in {
+          val exportsDeclaration = aDeclaration(withType(request.declarationType))
+
+          val result = partiesSectionHoldersHelper.changeLinkTarget(exportsDeclaration)
+
+          result(Mode.Normal) mustBe controllers.declaration.routes.DeclarationHolderRequiredController.displayPage(Mode.Normal)
+        }
+      }
+    }
+
+    onJourney(STANDARD, SIMPLIFIED, SUPPLEMENTARY) { request =>
+      "return AuthorisationProcedureCodeChoiceController call" in {
+        val exportsDeclaration = aDeclaration(withType(request.declarationType))
+
+        val result = partiesSectionHoldersHelper.changeLinkTarget(exportsDeclaration)
+
+        result(Mode.Normal) mustBe controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage(Mode.Normal)
+      }
+    }
+  }
+}


### PR DESCRIPTION
This implementation allows for different 'Change' link
destinations depending on the logic around authorisation
pages.
This logic is defined in a view helper class for clarity and 
easier testing.