### PR TITLE
[CEDS-3292] Limit to just SDP Journeys

### DIFF
--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -44,7 +44,7 @@ class ConsignmentReferencesController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    val frm = form(request.declarationType).withSubmissionErrors()
+    val frm = form(request.declarationType, request.cacheModel.additionalDeclarationType).withSubmissionErrors()
     request.cacheModel.consignmentReferences match {
       case Some(data) => Ok(consignmentReferencesPage(mode, frm.fill(data)))
       case _          => Ok(consignmentReferencesPage(mode, frm))
@@ -52,7 +52,7 @@ class ConsignmentReferencesController @Inject()(
   }
 
   def submitConsignmentReferences(mode: Mode): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    form(request.declarationType)
+    form(request.declarationType, request.cacheModel.additionalDeclarationType)
       .bindFromRequest()
       .fold(
         (formWithErrors: Form[ConsignmentReferences]) => Future.successful(BadRequest(consignmentReferencesPage(mode, formWithErrors))),

--- a/app/forms/declaration/ConsignmentReferences.scala
+++ b/app/forms/declaration/ConsignmentReferences.scala
@@ -17,6 +17,8 @@
 package forms.declaration
 
 import forms.{DeclarationPage, Ducr, Lrn, Mrn}
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.AdditionalDeclarationType
 import models.viewmodels.TariffContentKey
 import models.DeclarationType.{CLEARANCE, DeclarationType, SUPPLEMENTARY}
 import play.api.data.{Form, Forms}
@@ -30,7 +32,7 @@ object ConsignmentReferences extends DeclarationPage {
 
   implicit val format = Json.format[ConsignmentReferences]
 
-  def form(decType: DeclarationType): Form[ConsignmentReferences] = {
+  def form(decType: DeclarationType, additionalDecType: Option[AdditionalDeclarationType]): Form[ConsignmentReferences] = {
 
     def form2Model: (Ducr, Lrn, Option[Mrn]) => ConsignmentReferences = {
       case (ducr, lrn, mrn) =>
@@ -47,8 +49,8 @@ object ConsignmentReferences extends DeclarationPage {
           case None       => Some((model.ducr, model.lrn, None))
       }
 
-    val mrnMapping = decType match {
-      case SUPPLEMENTARY =>
+    val mrnMapping = (decType, additionalDecType) match {
+      case (SUPPLEMENTARY, Some(AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED)) =>
         optional(Mrn.mapping("declaration.consignmentReferences.supplementary.mrn"))
           .verifying("declaration.consignmentReferences.supplementary.mrn.error.empty", isPresent(_))
       case _ =>

--- a/app/views/declaration/consignment_references.scala.html
+++ b/app/views/declaration/consignment_references.scala.html
@@ -17,6 +17,7 @@
 @import controllers.declaration.routes._
 @import controllers.navigation.Navigator
 @import forms.declaration.ConsignmentReferences
+@import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.SUPPLEMENTARY_SIMPLIFIED
 @import models.requests.JourneyRequest
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.helpers.{BackButton, Title}
@@ -41,7 +42,12 @@
         appConfig: AppConfig
 )
 
+
 @(mode: Mode, form: Form[ConsignmentReferences])(implicit request: JourneyRequest[_], messages: Messages)
+
+@isSupplementaryPlusSimplified = @{
+    request.declarationType == DeclarationType.SUPPLEMENTARY && request.cacheModel.additionalDeclarationType.getOrElse("") == SUPPLEMENTARY_SIMPLIFIED
+}
 
 @ducrHintSectionSupplementary = {
     @paragraphBody(messages("declaration.consignmentReferences.supplementary.ducr.hint1"))
@@ -65,14 +71,14 @@
 }
 
 @ducrHintSection = @{
-  if (request.declarationType == DeclarationType.SUPPLEMENTARY)
+  if (isSupplementaryPlusSimplified)
       ducrHintSectionSupplementary
   else
       ducrHintSectionOthers
 }
 
 @lrnHintSection = @{
-    if (request.declarationType == DeclarationType.SUPPLEMENTARY)
+    if (isSupplementaryPlusSimplified)
         paragraphBody(messages("declaration.consignmentReferences.supplementary.lrn.hint"))
     else
         paragraphBody(messages("declaration.consignmentReferences.lrn.hint"), "govuk-hint")
@@ -84,7 +90,7 @@
 }
 
 @optionalMrnSection = @{
-    if (request.declarationType == DeclarationType.SUPPLEMENTARY)
+    if (isSupplementaryPlusSimplified)
         exportsInputText(
             field = form("mrn"),
             inputClasses = Some("govuk-input"),
@@ -96,14 +102,14 @@
 }
 
 @optionalDucrInsetText = @{
-    if (request.declarationType == DeclarationType.SUPPLEMENTARY)
+    if (isSupplementaryPlusSimplified)
         HtmlFormat.empty
     else
         insetText(content = HtmlContent(messages("declaration.consignmentReferences.ducr.inset")))
 }
 
 @optionalLrnInsetText = @{
-    if (request.declarationType == DeclarationType.SUPPLEMENTARY)
+    if (isSupplementaryPlusSimplified)
         HtmlFormat.empty
     else
         insetText(content = HtmlContent(messages("declaration.consignmentReferences.lrn.inset")))

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -19,6 +19,7 @@ package controllers.declaration
 import base.ControllerSpec
 import forms.declaration.ConsignmentReferences
 import forms.{Ducr, Lrn}
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.{SUPPLEMENTARY_EIDR, SUPPLEMENTARY_SIMPLIFIED}
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
 import org.mockito.ArgumentCaptor
@@ -120,10 +121,22 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec {
       }
     }
 
-    onJourney(SUPPLEMENTARY) { implicit request =>
-      "return 303 (SEE_OTHER) and redirect to 'Link DUCR to MUCR' page" in {
+    onJourney(SUPPLEMENTARY) { req =>
+      "return 303 (SEE_OTHER) and redirect to 'Link DUCR to MUCR' page for SUPPLEMENTARY_SIMPLIFIED" in {
+        implicit val request = journeyRequest(aDeclaration(withType(req.declarationType), withAdditionalDeclarationType(SUPPLEMENTARY_SIMPLIFIED)))
         withNewCaching(request.cacheModel)
         val correctForm = Json.toJson(ConsignmentReferences(Ducr(DUCR), LRN, Some(MRN)))
+
+        val result = controller.submitConsignmentReferences(Mode.Normal)(postRequest(correctForm))
+
+        await(result) mustBe aRedirectToTheNextPage
+        thePageNavigatedTo mustBe routes.LinkDucrToMucrController.displayPage()
+      }
+
+      "return 303 (SEE_OTHER) and redirect to 'Link DUCR to MUCR' page for SUPPLEMENTARY_EIDR" in {
+        implicit val request = journeyRequest(aDeclaration(withType(req.declarationType), withAdditionalDeclarationType(SUPPLEMENTARY_EIDR)))
+        withNewCaching(request.cacheModel)
+        val correctForm = Json.toJson(ConsignmentReferences(Ducr(DUCR), LRN))
 
         val result = controller.submitConsignmentReferences(Mode.Normal)(postRequest(correctForm))
 


### PR DESCRIPTION
New MRN field should only be displayed for SUPPLEMENTARY_SIMPLIFIED
additional declaration types (not for SUPPLEMENTARY_EIDR journeys!)