### PR TITLE
CEDS-3407 Fix the erroneous removal of DUCR from the 'Consignment References' page

### DIFF
--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -22,7 +22,7 @@ import connectors.CustomsDeclareExportsConnector
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
 import forms.declaration.ConsignmentReferences
-import forms.declaration.ConsignmentReferences.form
+import forms.declaration.ConsignmentReferences.{ducrId, form}
 import javax.inject.Inject
 import models.DeclarationType.SUPPLEMENTARY
 import models.Mode
@@ -80,7 +80,8 @@ class ConsignmentReferencesController @Inject()(
   ): Future[Result] =
     exportsConnector.findSubmissionByDucr(consignmentReferences.ducr).flatMap {
       _.fold(updateCacheAndContinue(mode, consignmentReferences)) { _ =>
-        val formWithErrors = form.copy(data = Map("lrn" -> consignmentReferences.lrn.value), errors = ConsignmentReferences.duplicatedDucr)
+        val data = Map(ducrId -> consignmentReferences.ducr.ducr, "lrn" -> consignmentReferences.lrn.value)
+        val formWithErrors = form.copy(data = data, errors = ConsignmentReferences.duplicatedDucr)
         Future.successful(BadRequest(consignmentReferencesPage(mode, formWithErrors)))
       }
     }


### PR DESCRIPTION
The DUCR entered by the user must not be removed from the page in case the pair EORI-DUCR is already present in the Submissions collection. While showing the error message `DUCR already submitted` the DUCR must be retained on the page.