### PR TITLE
BAU Change a few template helpers to singleton classes

### DIFF
--- a/app/views/declaration/additionalDocuments/additional_document_add.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_document_add.scala.html
@@ -19,7 +19,7 @@
 @import models.requests.JourneyRequest
 @import forms.declaration.additionaldocuments.AdditionalDocument
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
-@import views.helpers.{AdditionalDocument => AD, BackButton, Title}
+@import views.helpers.{AdditionalDocument => AdditionalDocHelper, BackButton, Title}
 @import views.html.components.gds._
 
 @this(
@@ -31,7 +31,7 @@
 @(mode: Mode, itemId: String, form: Form[AdditionalDocument])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
-    title = Title(AD.title, "declaration.section.5"),
+    title = Title(AdditionalDocHelper.title, "declaration.section.5"),
     backButton = Some(BackButton(messages("site.back"), Navigator.backLink(AdditionalDocument, mode, ItemId(itemId))))) {
 
     @formHelper(action = AdditionalDocumentAddController.submitForm(mode, itemId), 'autoComplete -> "off") {

--- a/app/views/declaration/additionalDocuments/additional_document_change.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_document_change.scala.html
@@ -18,7 +18,7 @@
 @import models.requests.JourneyRequest
 @import forms.declaration.additionaldocuments.AdditionalDocument
 @import uk.gov.hmrc.govukfrontend.views.html.components.FormWithCSRF
-@import views.helpers.{AdditionalDocument => AD, BackButton, Title}
+@import views.helpers.{AdditionalDocument => AdditionalDocHelper, BackButton, Title}
 @import views.html.components.gds._
 
 @this(
@@ -30,7 +30,7 @@
 @(mode: Mode, itemId: String, documentId: String, form: Form[AdditionalDocument])(implicit request: JourneyRequest[_], messages: Messages)
 
 @govukLayout(
-    title = Title(AD.title, "declaration.section.5"),
+    title = Title(AdditionalDocHelper.title, "declaration.section.5"),
     backButton = Some(BackButton(messages("site.back"), AdditionalDocumentsController.displayPage(mode, itemId)))
 ) {
 

--- a/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
@@ -40,6 +40,7 @@
     tariffExpander: tariffExpander,
     saveButtons: saveButtons,
     link: link,
+    additionalDocument: AD,
     appConfig: AppConfig
 )
 
@@ -180,7 +181,7 @@
         @exportsInputText(
             field = form(documentTypeCodeKey),
             labelKey = "declaration.additionalDocument.documentTypeCode",
-            hintKey = Some(AD.documentCodeHint),
+            hintKey = Some(additionalDocument.documentCodeHint),
             inputClasses = Some("govuk-input--width-4")
         )
         @govukDetails(Details(
@@ -195,7 +196,7 @@
             inputClasses = Some("govuk-input--width-30")
         )
         @{
-            AD.documentIdentifierInsets
+            additionalDocument.documentIdentifierInsets
         }
         @exportsInputText(
             field = form(documentStatusKey),
@@ -242,7 +243,7 @@
             isPageHeading = true
         )),
         html = HtmlFormat.fill(immutable.Seq(
-            AD.pageHint,
+            additionalDocument.pageHint,
             govukDetails(Details(
                 summary = Text(messages("declaration.additionalDocument.expander.title")),
                 content = HtmlContent(expander1Content),

--- a/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
@@ -22,7 +22,7 @@
 @import play.twirl.api.HtmlFormat
 @import scala.collection.immutable
 @import views.components.gds.Styles._
-@import views.helpers.{AdditionalDocument => AD}
+@import views.helpers.{AdditionalDocument => AdditionalDocHelper}
 @import views.html.components.gds._
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 
@@ -40,7 +40,7 @@
     tariffExpander: tariffExpander,
     saveButtons: saveButtons,
     link: link,
-    additionalDocument: AD,
+    additionalDocument: AdditionalDocHelper,
     appConfig: AppConfig
 )
 
@@ -238,7 +238,7 @@
 
     @govukFieldset(Fieldset(
         legend = Some(Legend(
-            content = Text(messages(AD.title)),
+            content = Text(messages(AdditionalDocHelper.title)),
             classes = gdsPageLegend,
             isPageHeading = true
         )),

--- a/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
+++ b/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
@@ -22,7 +22,7 @@
 @import services.view.HolderOfAuthorisationCodes
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.components.gds.Styles._
-@import views.helpers.DeclarationHolder._
+@import views.helpers.DeclarationHolder
 @import views.html.components.fields.field_accessible_autocomplete
 @import views.html.components.gds._
 
@@ -37,6 +37,7 @@
     sectionHeader: sectionHeader,
     govukHint: govukHint,
     pageTitle: pageTitle,
+    declarationHolder: DeclarationHolder,
     exportsInputText: exportsInputText,
     tariffExpander: tariffExpander,
     addButton: addButton,
@@ -51,18 +52,18 @@
 @formContent = {
     @formGroupWrapper(field = form(DeclarationHolderFormGroupId)) {
 
-        @bodyForDeclarationHolderEditPage(appConfig)
+        @declarationHolder.bodyForDeclarationHolderEditPage(appConfig)
 
         @field_accessible_autocomplete(
             field = form("authorisationTypeCode"),
             label = messages("declaration.declarationHolder.authorisationCode"),
             labelClass = Some("govuk-label--m"),
-            hintParagraphs = hintForAuthorisationCode,
+            hintParagraphs = declarationHolder.hintForAuthorisationCode,
             emptySelectValue = messages("declaration.declarationHolder.authorisationCode.empty"),
             items = holderOfAuthorisationCodes.asListOfAutoCompleteItems(messages.lang.toLocale)
         )
 
-        @insetTextBelowAuthorisationCode(appConfig)
+        @declarationHolder.insetTextBelowAuthorisationCode(appConfig)
 
         @exportsInputText(
             field = form("eori"),

--- a/app/views/declaration/declarationHolder/declaration_holder_required.scala.html
+++ b/app/views/declaration/declarationHolder/declaration_holder_required.scala.html
@@ -24,7 +24,7 @@
 @import play.twirl.api.HtmlFormat
 @import uk.gov.hmrc.govukfrontend.views.html.components._
 @import views.helpers.{BackButton, Title}
-@import views.helpers.DeclarationHolder.bodyForDeclarationHolderRequiredPage
+@import views.helpers.DeclarationHolder
 @import views.components.gds.Styles._
 @import views.helpers.ErrorMapper.yesNoErrors
 @import views.html.components.gds._
@@ -34,6 +34,7 @@
     govukFieldset: GovukFieldset,
     errorSummary: errorSummary,
     sectionHeader: sectionHeader,
+    declarationHolder: DeclarationHolder,
     saveButtons: saveButtons,
     tariffExpander: tariffExpander,
     insetText: exportsInsetText,
@@ -84,7 +85,7 @@
                 isPageHeading = true
             )),
             html = HtmlFormat.fill(List(
-                bodyForDeclarationHolderRequiredPage,
+                declarationHolder.bodyForDeclarationHolderRequiredPage,
                 yesNoRadios(form),
                 maybeInset,
                 tariffExpander(DeclarationHolderRequired, request.declarationType)(messages, appConfig),

--- a/app/views/helpers/AdditionalDocument.scala
+++ b/app/views/helpers/AdditionalDocument.scala
@@ -16,6 +16,7 @@
 
 package views.helpers
 
+import javax.inject.{Inject, Singleton}
 import models.requests.JourneyRequest
 import play.api.i18n.Messages
 import play.twirl.api.{Html, HtmlFormat}
@@ -25,7 +26,8 @@ import uk.gov.hmrc.govukfrontend.views.viewmodels.hint.Hint
 import uk.gov.hmrc.govukfrontend.views.viewmodels.insettext.InsetText
 import views.html.components.gds.paragraphBody
 
-object AdditionalDocument {
+@Singleton
+class AdditionalDocument @Inject()(hintPartial: govukHint, insetTextPartial: govukInsetText, paragraphBody: paragraphBody) {
 
   def documentCodeHint(implicit request: JourneyRequest[_]): String =
     if (request.cacheModel.isAuthCodeRequiringAdditionalDocuments) "declaration.additionalDocument.documentTypeCode.hint.fromAuthCode"
@@ -35,12 +37,12 @@ object AdditionalDocument {
     if (request.cacheModel.isAuthCodeRequiringAdditionalDocuments) {
       val html = new Html(
         List(
-          new paragraphBody()(messages("declaration.additionalDocument.documentIdentifier.inset.fromAuthCode.paragraph1")),
-          new paragraphBody()(messages("declaration.additionalDocument.documentIdentifier.inset.fromAuthCode.paragraph2"))
+          paragraphBody(messages("declaration.additionalDocument.documentIdentifier.inset.fromAuthCode.paragraph1")),
+          paragraphBody(messages("declaration.additionalDocument.documentIdentifier.inset.fromAuthCode.paragraph2"))
         )
       )
 
-      val insets = new govukInsetText()(InsetText(content = HtmlContent(html)))
+      val insets = insetTextPartial(InsetText(content = HtmlContent(html)))
       Some(insets)
     } else None
 
@@ -48,12 +50,15 @@ object AdditionalDocument {
     if (request.cacheModel.isAuthCodeRequiringAdditionalDocuments)
       new Html(
         List(
-          new govukHint()(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint.fromAuthCode.paragraph1")))),
-          new govukHint()(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint.fromAuthCode.paragraph2"))))
+          hintPartial(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint.fromAuthCode.paragraph1")))),
+          hintPartial(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint.fromAuthCode.paragraph2"))))
         )
       )
     else
-      new Html(List(new govukHint()(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint"))))))
+      new Html(List(hintPartial(Hint(content = HtmlContent(messages("declaration.additionalDocument.hint"))))))
+}
+
+object AdditionalDocument {
 
   def title(implicit request: JourneyRequest[_]): String =
     if (request.cacheModel.isAuthCodeRequiringAdditionalDocuments) "declaration.additionalDocument.title.fromAuthCode"

--- a/app/views/helpers/DeclarationHolder.scala
+++ b/app/views/helpers/DeclarationHolder.scala
@@ -20,6 +20,7 @@ import config.AppConfig
 import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.AuthorisationProcedureCodeChoice.{Choice1007, Choice1040, ChoiceOthers}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
+import javax.inject.{Inject, Singleton}
 import models.DeclarationType._
 import models.ExportsDeclaration
 import models.requests.JourneyRequest
@@ -29,11 +30,17 @@ import play.twirl.api.{Html, HtmlFormat}
 import uk.gov.hmrc.govukfrontend.views.html.components.govukInsetText
 import uk.gov.hmrc.govukfrontend.views.viewmodels.content.HtmlContent
 import uk.gov.hmrc.govukfrontend.views.viewmodels.insettext.InsetText
+import views.helpers.DeclarationHolder.bodyClassId
 import views.html.components.gds.{bulletList, link, numberedList, paragraphBody}
 
-object DeclarationHolder {
-
-  val bodyClassId = "text-under-h1"
+@Singleton
+class DeclarationHolder @Inject()(
+  bulletList: bulletList,
+  insetTextPartial: govukInsetText,
+  link: link,
+  numberedList: numberedList,
+  paragraphBody: paragraphBody
+) {
 
   def bodyForDeclarationHolderEditPage(appConfig: AppConfig)(implicit messages: Messages, request: JourneyRequest[_]): Option[Html] = {
     val messageList = valuesToMatch(request.cacheModel) match {
@@ -53,7 +60,7 @@ object DeclarationHolder {
     }
 
     if (messageList.isEmpty) None
-    else Some(HtmlFormat.fill(messageList.map(message => new paragraphBody()(message, s"govuk-body $bodyClassId"))))
+    else Some(HtmlFormat.fill(messageList.map(message => paragraphBody(message, s"govuk-body $bodyClassId"))))
   }
 
   def bodyForDeclarationHolderRequiredPage(implicit messages: Messages, request: JourneyRequest[_]): Html = {
@@ -66,7 +73,7 @@ object DeclarationHolder {
     }
 
     val body = keys.map { key =>
-      new paragraphBody()(messages(s"declaration.declarationHolderRequired.body.$key"))
+      paragraphBody(messages(s"declaration.declarationHolderRequired.body.$key"))
     }
 
     HtmlFormat.fill(body)
@@ -103,29 +110,29 @@ object DeclarationHolder {
     List(
       messages(
         s"declaration.declarationHolder.body.$key.1007",
-        new link()(messages("declaration.declarationHolder.body.1007.link"), None, Call("GET", appConfig.permanentExportOrDispatch.section), "_blank")
+        link(messages("declaration.declarationHolder.body.1007.link"), None, Call("GET", appConfig.permanentExportOrDispatch.section), "_blank")
       )
     )
 
   private val insetKey = "declaration.declarationHolder.authCode.inset"
 
   private def insetText(appendable: Html, key: String)(implicit messages: Messages): Option[Html] = {
-    val html = new Html(List(new paragraphBody()(messages(s"$insetKey.$key.title"), "govuk-label--s"), appendable))
-    Some(new govukInsetText()(InsetText(content = HtmlContent(html))))
+    val html = new Html(List(paragraphBody(messages(s"$insetKey.$key.title"), "govuk-label--s"), appendable))
+    Some(insetTextPartial(InsetText(content = HtmlContent(html))))
   }
 
   private def insetTextForExciseRemovals(appConfig: AppConfig)(implicit messages: Messages): Option[Html] = {
     val call1 = Call("GET", appConfig.permanentExportOrDispatch.authHolder)
-    val link1 = new link()(messages(s"$insetKey.excise.bullet1.link"), None, call1, "_blank")
+    val link1 = link(messages(s"$insetKey.excise.bullet1.link"), None, call1, "_blank")
 
     val call2 = Call("GET", appConfig.permanentExportOrDispatch.conditions)
-    val link2 = new link()(messages(s"$insetKey.excise.bullet2.link"), None, call2, "_blank")
+    val link2 = link(messages(s"$insetKey.excise.bullet2.link"), None, call2, "_blank")
 
     val call3 = Call("GET", appConfig.permanentExportOrDispatch.documents)
-    val link3 = new link()(messages(s"$insetKey.excise.bullet3.link"), None, call3, "_blank")
+    val link3 = link(messages(s"$insetKey.excise.bullet3.link"), None, call3, "_blank")
 
     insetText(
-      new bulletList()(
+      bulletList(
         List(
           Html(messages(s"$insetKey.excise.bullet1", link1)),
           Html(messages(s"$insetKey.excise.bullet2", link2)),
@@ -138,10 +145,10 @@ object DeclarationHolder {
 
   private def insetTextForNonStandardProcedures(appConfig: AppConfig)(implicit messages: Messages): Option[Html] = {
     val call1 = Call("GET", appConfig.previousProcedureCodesUrl)
-    val link1 = new link()(messages(s"$insetKey.special.bullet1.link"), None, call1, "_blank")
+    val link1 = link(messages(s"$insetKey.special.bullet1.link"), None, call1, "_blank")
 
     insetText(
-      new numberedList()(
+      numberedList(
         List(
           Html(messages(s"$insetKey.special.bullet1", link1)),
           Html(messages(s"$insetKey.special.bullet2")),
@@ -158,4 +165,9 @@ object DeclarationHolder {
 
   private def valuesToMatch(model: ExportsDeclaration) =
     (model.`type`, model.additionalDeclarationType, model.parties.authorisationProcedureCodeChoice, model.parties.isEntryIntoDeclarantsRecords)
+}
+
+object DeclarationHolder {
+
+  val bodyClassId = "text-under-h1"
 }

--- a/app/views/helpers/TimelineEvents.scala
+++ b/app/views/helpers/TimelineEvents.scala
@@ -19,7 +19,7 @@ package views.helpers
 import java.time.ZonedDateTime
 
 import config.featureFlags.{SecureMessagingInboxConfig, SfusConfig}
-import javax.inject.Inject
+import javax.inject.{Inject, Singleton}
 import models.declaration.notifications.Notification
 import models.declaration.submissions.Submission
 import play.api.i18n.Messages
@@ -30,7 +30,9 @@ import views.html.components.upload_files_partial_for_timeline
 
 case class TimelineEvent(title: String, dateTime: ZonedDateTime, content: Option[Html])
 
+@Singleton
 class TimelineEvents @Inject()(
+  linkButton: linkButton,
   secureMessagingInboxConfig: SecureMessagingInboxConfig,
   sfusConfig: SfusConfig,
   uploadFilesPartialForTimeline: upload_files_partial_for_timeline
@@ -75,7 +77,7 @@ class TimelineEvents @Inject()(
 
   private def fixAndResubmitContent(declarationID: String)(implicit messages: Messages): Option[Html] = {
     val call = controllers.routes.RejectedNotificationsController.displayPage(declarationID)
-    val element = new linkButton()("submissions.declarationDetails.fix.resubmit.button", call)
+    val element = linkButton("submissions.declarationDetails.fix.resubmit.button", call)
     Some(new Html(List(element)))
   }
 
@@ -85,7 +87,7 @@ class TimelineEvents @Inject()(
   }
 
   private def viewQueriesContent(isPrimary: Boolean)(implicit messages: Messages): Option[Html] = {
-    val element = new linkButton()(
+    val element = linkButton(
       "submissions.declarationDetails.view.queries.button",
       Call("GET", secureMessagingInboxConfig.sfusInboxLink),
       if (isPrimary) "govuk-button" else "govuk-button govuk-button--secondary"

--- a/test/views/helpers/TimelineEventsSpec.scala
+++ b/test/views/helpers/TimelineEventsSpec.scala
@@ -26,6 +26,7 @@ import models.declaration.submissions.{Submission, SubmissionStatus}
 import org.mockito.Mockito.when
 import org.scalatest.BeforeAndAfterEach
 import views.declaration.spec.UnitViewSpec
+import views.html.components.gds.linkButton
 import views.html.components.upload_files_partial_for_timeline
 
 class TimelineEventsSpec extends UnitViewSpec with BeforeAndAfterEach with Injector {
@@ -44,7 +45,7 @@ class TimelineEventsSpec extends UnitViewSpec with BeforeAndAfterEach with Injec
 
   private def createTimeline(notifications: Seq[Notification], enableSfusConfig: Boolean = true): Seq[TimelineEvent] = {
     when(sfusConfig.isSfusUploadEnabled).thenReturn(enableSfusConfig)
-    new TimelineEvents(secureMessagingInboxConfig, sfusConfig, uploadFilesPartialForTimeline)(submission, notifications)
+    new TimelineEvents(new linkButton(), secureMessagingInboxConfig, sfusConfig, uploadFilesPartialForTimeline)(submission, notifications)
   }
 
   "TimelineEvents" should {


### PR DESCRIPTION
Change a few template helpers to singleton classes in order to inject the component/partial instances used, instead of creating new ones at every call.