### PR TITLE
CEDS-3484 - Removed duplicate tracking consent reference

### DIFF
--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -51,10 +51,10 @@
   navigationBanner: Html = HtmlFormat.empty
 )(contentBlock: Html)(implicit request: Request[_], messages: Messages)
 
-@useTimeoutDialog = @{ request.isInstanceOf[AuthenticatedRequest[_]]}
+@userIsSignedIn = @{ request.isInstanceOf[AuthenticatedRequest[_]]}
 
 @head = {
-    @if(useTimeoutDialog) {
+    @if(userIsSignedIn) {
         @hmrcHead(
             headBlock = Some(hmrcTimeoutDialogHelper(
                 signOutUrl = SignOutController.signOut(models.SignOutReason.SessionTimeout).url,

--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -38,6 +38,7 @@
   betaBannerConfig: BetaBannerConfig,
   hmrcHead: HmrcHead,
   hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
+  hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
   hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
   hmrcFooter: HmrcStandardFooter,
   appConfig: AppConfig
@@ -62,6 +63,8 @@
                 countdown = Some(timeoutDialogConfig.countdown.toSeconds.toInt)
             ))
         )
+    } else {
+        @hmrcTrackingConsentSnippet()
     }
 
     <link rel="shortcut icon" href='@Assets.versioned("/lib/govuk-frontend/govuk/assets/images/favicon.ico")' type="image/x-icon" />

--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -65,8 +65,6 @@
         )
     }
 
-    @hmrcTrackingConsentSnippet()
-
     <link rel="shortcut icon" href='@Assets.versioned("/lib/govuk-frontend/govuk/assets/images/favicon.ico")' type="image/x-icon" />
     <link rel="shortcut icon" href='@Assets.versioned("lib/accessible-autocomplete/dist/accessible-autocomplete.min.css")' rel="stylesheet" type="text/css" />
     <meta name="format-detection" content="telephone=no" />

--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -38,7 +38,6 @@
   betaBannerConfig: BetaBannerConfig,
   hmrcHead: HmrcHead,
   hmrcTimeoutDialogHelper: HmrcTimeoutDialogHelper,
-  hmrcTrackingConsentSnippet: HmrcTrackingConsentSnippet,
   hmrcReportTechnicalIssue: HmrcReportTechnicalIssue,
   hmrcFooter: HmrcStandardFooter,
   appConfig: AppConfig

--- a/test/tools/Stubs.scala
+++ b/test/tools/Stubs.scala
@@ -126,7 +126,6 @@ trait Stubs {
     betaBannerConfig = betaBannerConfig,
     hmrcHead = new HmrcHead(hmrcTrackingConsentSnippet, new AssetsConfig),
     hmrcTimeoutDialogHelper = hmrcTimeoutDialogHelper,
-    hmrcTrackingConsentSnippet = hmrcTrackingConsentSnippet,
     hmrcReportTechnicalIssue = hmrcReportTechnicalIssue,
     hmrcFooter = hmrcFooter,
     appConfig = minimalAppConfig

--- a/test/tools/Stubs.scala
+++ b/test/tools/Stubs.scala
@@ -126,6 +126,7 @@ trait Stubs {
     betaBannerConfig = betaBannerConfig,
     hmrcHead = new HmrcHead(hmrcTrackingConsentSnippet, new AssetsConfig),
     hmrcTimeoutDialogHelper = hmrcTimeoutDialogHelper,
+    hmrcTrackingConsentSnippet = hmrcTrackingConsentSnippet,
     hmrcReportTechnicalIssue = hmrcReportTechnicalIssue,
     hmrcFooter = hmrcFooter,
     appConfig = minimalAppConfig


### PR DESCRIPTION
Removing duplicate tracking consent script from the layout:

![Screenshot from 2021-09-22 09-43-02](https://user-images.githubusercontent.com/2183310/134314519-3393c006-cd6d-49a2-9f9c-2fd4029f9757.png)

![Screenshot from 2021-09-22 09-55-32](https://user-images.githubusercontent.com/2183310/134314513-6027c176-002c-45da-b03f-8f70516c67d6.png)

This is called in the HmrcHead now, so no need for a standalone reference unless user is no longer signed in.
