### PR TITLE
CEDS-3485 - Removed superfluous type attribute

### DIFF
--- a/app/views/components/gds/gdsMainTemplate.scala.html
+++ b/app/views/components/gds/gdsMainTemplate.scala.html
@@ -75,13 +75,13 @@
 }
 
 @scripts = {
-    <script src="@Assets.versioned("javascripts/show-hide-content.js")" type="text/javascript"></script>
+    <script src='@Assets.versioned("javascripts/show-hide-content.js")'></script>
 
     <script src='@Assets.versioned("lib/govuk-frontend/govuk/all.js")'></script>
     <script src='@Assets.versioned("lib/hmrc-frontend/hmrc/all.js")'></script>
     <script>window.HMRCFrontend.initAll();</script>
     <script>window.GOVUKFrontend.initAll();</script>
-    }
+}
 
 @beforeContentBlock = {
     @if(betaBannerConfig.isBetaBannerEnabled) {


### PR DESCRIPTION
Removing an unnecessary type attribute - should remove 200 lines of INFO from the VNU/AXE testing report.

Also a tiny bit of tidy up around that block.