### PR TITLE
CEDS-3438 Add new validation check to page at '/add-authorisation-required'

### DIFF
--- a/app/controllers/SubmissionsController.scala
+++ b/app/controllers/SubmissionsController.scala
@@ -22,7 +22,7 @@ import config.PaginationConfig
 import connectors.CustomsDeclareExportsConnector
 import connectors.exchange.ExportsDeclarationExchange
 import controllers.actions.{AuthAction, VerifiedEmailAction}
-import controllers.util.SubmissionDisplayHelper
+import controllers.helpers.SubmissionDisplayHelper
 import javax.inject.Inject
 import models.Mode.ErrorFix
 import models._

--- a/app/controllers/declaration/AdditionalActorsAddController.scala
+++ b/app/controllers/declaration/AdditionalActorsAddController.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalActorsAddController.AdditionalActorsFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.NoneOfTheAbove
 import forms.declaration.DeclarationAdditionalActors
 import forms.declaration.DeclarationAdditionalActors.form

--- a/app/controllers/declaration/AdditionalDocumentAddController.scala
+++ b/app/controllers/declaration/AdditionalDocumentAddController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util._
+import controllers.helpers._
 import forms.declaration.additionaldocuments.AdditionalDocument
 import forms.declaration.additionaldocuments.AdditionalDocument._
 import javax.inject.Inject

--- a/app/controllers/declaration/AdditionalDocumentChangeController.scala
+++ b/app/controllers/declaration/AdditionalDocumentChangeController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util._
+import controllers.helpers._
 import forms.declaration.additionaldocuments.AdditionalDocument
 import forms.declaration.additionaldocuments.AdditionalDocument._
 import models.declaration.AdditionalDocuments

--- a/app/controllers/declaration/AdditionalDocumentRemoveController.scala
+++ b/app/controllers/declaration/AdditionalDocumentRemoveController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper.remove
+import controllers.helpers.MultipleItemsHelper.remove
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.additionaldocuments.AdditionalDocument

--- a/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalFiscalReferencesAddController.AdditionalFiscalReferencesFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.AdditionalFiscalReference.form
 import forms.declaration.AdditionalFiscalReferencesData._
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}

--- a/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper.remove
+import controllers.helpers.MultipleItemsHelper.remove
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}

--- a/app/controllers/declaration/AdditionalInformationAddController.scala
+++ b/app/controllers/declaration/AdditionalInformationAddController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
 import models.declaration.AdditionalInformationData

--- a/app/controllers/declaration/AdditionalInformationChangeController.scala
+++ b/app/controllers/declaration/AdditionalInformationChangeController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.AdditionalInformationAddController.AdditionalInformationFormGroupId
 import controllers.navigation.Navigator
-import controllers.util._
+import controllers.helpers._
 import forms.declaration.AdditionalInformation
 import forms.declaration.AdditionalInformation.form
 import models.declaration.AdditionalInformationData

--- a/app/controllers/declaration/AdditionalInformationRemoveController.scala
+++ b/app/controllers/declaration/AdditionalInformationRemoveController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper.remove
+import controllers.helpers.MultipleItemsHelper.remove
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.AdditionalInformation

--- a/app/controllers/declaration/AdditionalProcedureCodesController.scala
+++ b/app/controllers/declaration/AdditionalProcedureCodesController.scala
@@ -20,9 +20,9 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper.remove
-import controllers.util.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
-import controllers.util._
+import controllers.helpers.MultipleItemsHelper.remove
+import controllers.helpers.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
+import controllers.helpers._
 import forms.declaration.procedurecodes.AdditionalProcedureCode
 import forms.declaration.procedurecodes.AdditionalProcedureCode._
 import javax.inject.Inject

--- a/app/controllers/declaration/DeclarationHolderAddController.scala
+++ b/app/controllers/declaration/DeclarationHolderAddController.scala
@@ -23,6 +23,7 @@ import controllers.helpers.DeclarationHolderHelper._
 import controllers.helpers.MultipleItemsHelper
 import controllers.navigation.Navigator
 import forms.declaration.declarationHolder.DeclarationHolder
+import forms.declaration.declarationHolder.DeclarationHolder.{validateMutuallyExclusiveAuthCodes, DeclarationHolderFormGroupId}
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
 import models.declaration.DeclarationHoldersData.limitOfHolders

--- a/app/controllers/declaration/DeclarationHolderAddController.scala
+++ b/app/controllers/declaration/DeclarationHolderAddController.scala
@@ -18,8 +18,8 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.DeclarationHolderHelper._
-import controllers.util._
+import controllers.helpers.DeclarationHolderHelper._
+import controllers.helpers._
 import forms.declaration.declarationHolder.DeclarationHolder
 import forms.declaration.declarationHolder.DeclarationHolder.form
 import models.declaration.DeclarationHoldersData

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -19,11 +19,11 @@ package controllers.declaration
 import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.routes.DeclarationHolderSummaryController
 import controllers.helpers.DeclarationHolderHelper._
 import controllers.helpers.MultipleItemsHelper
 import controllers.navigation.Navigator
 import forms.declaration.declarationHolder.DeclarationHolder
-import forms.declaration.declarationHolder.DeclarationHolder.form
 import handlers.ErrorHandler
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData
@@ -49,21 +49,21 @@ class DeclarationHolderChangeController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val maybeExistingHolder = cachedHolders.find(_.id.equals(id))
+    val maybeExistingHolder = declarationHolders.find(_.id.equals(id))
 
-    maybeExistingHolder.fold(errorHandler.displayErrorPage()) { holder =>
-      Future.successful(Ok(declarationHolderChangePage(mode, id, form(request.eori).fill(holder).withSubmissionErrors(), request.eori)))
+    maybeExistingHolder.fold(errorHandler.displayErrorPage) { holder =>
+      Future.successful(Ok(declarationHolderChangePage(mode, id, form.fill(holder).withSubmissionErrors, request.eori)))
     }
   }
 
   def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val boundForm = form(request.eori).bindFromRequest()
-    val maybeExistingHolder = cachedHolders.find(_.id.equals(id))
+    val boundForm = form.bindFromRequest
+    val maybeExistingHolder = declarationHolders.find(_.id.equals(id))
 
     boundForm.fold(
       formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, id, formWithErrors, request.eori))),
       newHolder => {
-        maybeExistingHolder.fold(errorHandler.displayErrorPage()) { existingHolder =>
+        maybeExistingHolder.fold(errorHandler.displayErrorPage) { existingHolder =>
           changeHolder(mode, existingHolder, newHolder, boundForm)
         }
       }
@@ -74,24 +74,16 @@ class DeclarationHolderChangeController @Inject()(
     implicit request: JourneyRequest[AnyContent]
   ): Future[Result] = {
 
-    val sourceHolders = cachedHolders
-    val holdersWithoutExisting: Seq[DeclarationHolder] = sourceHolders.filterNot(_ == existingHolder)
+    val cachedHolders = declarationHolders
+    val holdersWithoutExisting: Seq[DeclarationHolder] = cachedHolders.filterNot(_ == existingHolder)
 
     MultipleItemsHelper
       .add(boundForm, holdersWithoutExisting, limitOfHolders, DeclarationHolderFormGroupId, "declaration.declarationHolder")
       .fold(
         formWithErrors => Future.successful(BadRequest(declarationHolderChangePage(mode, existingHolder.id, formWithErrors, request.eori))),
         _ => {
-          validateAuthCode(boundForm.value) match {
-            case Some(error) =>
-              val formWithError = boundForm.copy(errors = Seq(error))
-              Future.successful(BadRequest(declarationHolderChangePage(mode, existingHolder.id, formWithError, request.eori)))
-
-            case _ =>
-              val updatedHolders = sourceHolders.map(holder => if (holder == existingHolder) newHolder else holder)
-              updateExportsCache(updatedHolders)
-                .map(_ => navigator.continueTo(mode, routes.DeclarationHolderSummaryController.displayPage))
-          }
+          val updatedHolders = cachedHolders.map(holder => if (holder == existingHolder) newHolder else holder)
+          updateExportsCache(updatedHolders).map(_ => navigator.continueTo(mode, DeclarationHolderSummaryController.displayPage))
         }
       )
   }
@@ -99,8 +91,7 @@ class DeclarationHolderChangeController @Inject()(
   private def updateExportsCache(holders: Seq[DeclarationHolder])(implicit r: JourneyRequest[_]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => {
       val isRequired = model.parties.declarationHoldersData.flatMap(_.isRequired)
-      val updatedParties =
-        model.parties.copy(declarationHoldersData = Some(DeclarationHoldersData(holders, isRequired)))
+      val updatedParties = model.parties.copy(declarationHoldersData = Some(DeclarationHoldersData(holders, isRequired)))
       model.copy(parties = updatedParties)
     })
 }

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -18,8 +18,8 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.DeclarationHolderHelper._
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.DeclarationHolderHelper._
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.declarationHolder.DeclarationHolder.form
 import forms.declaration.declarationHolder.DeclarationHolder
 import handlers.ErrorHandler

--- a/app/controllers/declaration/DeclarationHolderChangeController.scala
+++ b/app/controllers/declaration/DeclarationHolderChangeController.scala
@@ -24,6 +24,7 @@ import controllers.helpers.DeclarationHolderHelper._
 import controllers.helpers.MultipleItemsHelper
 import controllers.navigation.Navigator
 import forms.declaration.declarationHolder.DeclarationHolder
+import forms.declaration.declarationHolder.DeclarationHolder.DeclarationHolderFormGroupId
 import handlers.ErrorHandler
 import javax.inject.Inject
 import models.declaration.DeclarationHoldersData

--- a/app/controllers/declaration/DeclarationHolderRemoveController.scala
+++ b/app/controllers/declaration/DeclarationHolderRemoveController.scala
@@ -16,14 +16,17 @@
 
 package controllers.declaration
 
+import scala.concurrent.{ExecutionContext, Future}
+
 import controllers.actions.{AuthAction, JourneyAction}
+import controllers.declaration.routes._
+import controllers.helpers.DeclarationHolderHelper.declarationHolders
 import controllers.navigation.Navigator
-import controllers.helpers.DeclarationHolderHelper
-import controllers.helpers.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.declarationHolder.DeclarationHolder
 import handlers.ErrorHandler
+import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -32,9 +35,6 @@ import play.api.mvc._
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.declarationHolder.declaration_holder_remove
-
-import javax.inject.Inject
-import scala.concurrent.{ExecutionContext, Future}
 
 class DeclarationHolderRemoveController @Inject()(
   authenticate: AuthAction,
@@ -48,29 +48,27 @@ class DeclarationHolderRemoveController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val maybeExistingHolder = cachedHolders.find(_.id.equals(id))
+    val maybeExistingHolder = declarationHolders.find(_.id.equals(id))
 
-    maybeExistingHolder.fold(errorHandler.displayErrorPage()) { holder =>
-      Future.successful(Ok(holderRemovePage(mode, holder, removeYesNoForm.withSubmissionErrors())))
+    maybeExistingHolder.fold(errorHandler.displayErrorPage) { holder =>
+      Future.successful(Ok(holderRemovePage(mode, holder, removeYesNoForm.withSubmissionErrors)))
     }
   }
 
   def submitForm(mode: Mode, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    val maybeExistingHolder = cachedHolders.find(_.id.equals(id))
+    val maybeExistingHolder = declarationHolders.find(_.id.equals(id))
 
-    maybeExistingHolder.fold(errorHandler.displayErrorPage()) { holderToRemove =>
-      removeYesNoForm
-        .bindFromRequest()
+    maybeExistingHolder.fold(errorHandler.displayErrorPage) { holderToRemove =>
+      removeYesNoForm.bindFromRequest
         .fold(
-          (formWithErrors: Form[YesNoAnswer]) => Future.successful(BadRequest(holderRemovePage(mode, holderToRemove, formWithErrors))),
-          formData => {
-            formData.answer match {
-              case YesNoAnswers.yes =>
-                updateExportsCache(holderToRemove)
-                  .map(declarationAfterRemoval => navigator.continueTo(mode, nextPageAfterRemoval(declarationAfterRemoval)))
-              case YesNoAnswers.no =>
-                Future.successful(navigator.continueTo(mode, routes.DeclarationHolderSummaryController.displayPage))
-            }
+          formWithErrors => Future.successful(BadRequest(holderRemovePage(mode, holderToRemove, formWithErrors))),
+          _.answer match {
+            case YesNoAnswers.yes =>
+              updateExportsCache(holderToRemove)
+                .map(declarationAfterRemoval => navigator.continueTo(mode, nextPageAfterRemoval(declarationAfterRemoval)))
+
+            case YesNoAnswers.no =>
+              Future.successful(navigator.continueTo(mode, DeclarationHolderSummaryController.displayPage))
           }
         )
     }
@@ -78,22 +76,16 @@ class DeclarationHolderRemoveController @Inject()(
 
   private val removeYesNoForm: Form[YesNoAnswer] = YesNoAnswer.form(errorKey = "declaration.declarationHolders.remove.empty")
 
-  private def updateExportsCache(
-    holderToRemove: DeclarationHolder
-  )(implicit request: JourneyRequest[AnyContent]): Future[Option[ExportsDeclaration]] =
+  private def updateExportsCache(holderToRemove: DeclarationHolder)(implicit r: JourneyRequest[_]): Future[Option[ExportsDeclaration]] =
     updateExportsDeclarationSyncDirect(model => {
-      val updatedHolders =
-        model.parties.declarationHoldersData.map(_.copy(holders = DeclarationHolderHelper.cachedHolders.filterNot(_ == holderToRemove)))
-      val updatedParties = model.parties.copy(declarationHoldersData = updatedHolders)
-      model.copy(parties = updatedParties)
+      val updatedHolders = declarationHolders.filterNot(_ == holderToRemove)
+      val updatedHoldersData = model.parties.declarationHoldersData.map(_.copy(holders = updatedHolders))
+      model.copy(parties = model.parties.copy(declarationHoldersData = updatedHoldersData))
     })
 
   private def nextPageAfterRemoval(declarationAfterRemoval: Option[ExportsDeclaration]): Mode => Call = {
     val holdersData = declarationAfterRemoval.flatMap(_.parties.declarationHoldersData)
-    if (holdersData.exists(_.holders.isEmpty) && holdersData.exists(_.isRequired.isDefined))
-      routes.DeclarationHolderRequiredController.displayPage
-    else
-      routes.DeclarationHolderSummaryController.displayPage
+    if (holdersData.exists(_.holders.isEmpty) && holdersData.exists(_.isRequired.isDefined)) DeclarationHolderRequiredController.displayPage
+    else DeclarationHolderSummaryController.displayPage
   }
-
 }

--- a/app/controllers/declaration/DeclarationHolderRemoveController.scala
+++ b/app/controllers/declaration/DeclarationHolderRemoveController.scala
@@ -18,8 +18,8 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.DeclarationHolderHelper
-import controllers.util.DeclarationHolderHelper.cachedHolders
+import controllers.helpers.DeclarationHolderHelper
+import controllers.helpers.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.declarationHolder.DeclarationHolder

--- a/app/controllers/declaration/DeclarationHolderRequiredController.scala
+++ b/app/controllers/declaration/DeclarationHolderRequiredController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.DeclarationHolderHelper.cachedHolders
+import controllers.helpers.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import models.DeclarationType.{STANDARD, SUPPLEMENTARY}

--- a/app/controllers/declaration/DeclarationHolderSummaryController.scala
+++ b/app/controllers/declaration/DeclarationHolderSummaryController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.DeclarationHolderHelper.cachedHolders
+import controllers.helpers.DeclarationHolderHelper.cachedHolders
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import models.DeclarationType.{STANDARD, SUPPLEMENTARY}

--- a/app/controllers/declaration/ItemsSummaryController.scala
+++ b/app/controllers/declaration/ItemsSummaryController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.{FormAction, SaveAndReturn, SupervisingCustomsOfficeHelper}
+import controllers.helpers.{FormAction, SaveAndReturn, SupervisingCustomsOfficeHelper}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import javax.inject.Inject

--- a/app/controllers/declaration/NactCodeAddController.scala
+++ b/app/controllers/declaration/NactCodeAddController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.NactCode.nactCodeLimit
 import forms.declaration.{NactCode, NactCodeFirst}
 import javax.inject.Inject

--- a/app/controllers/declaration/PackageInformationAddController.scala
+++ b/app/controllers/declaration/PackageInformationAddController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.PackageInformationAddController.PackageInformationFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.PackageInformation
 import forms.declaration.PackageInformation.form
 import models.requests.JourneyRequest

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.{Document, PreviousDocumentsData}
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -21,7 +21,7 @@ import scala.concurrent.{ExecutionContext, Future}
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.declaration.PreviousDocumentsController.PreviousDocumentsFormGroupId
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.Document.form
 import forms.declaration.{Document, PreviousDocumentsData}
 import forms.declaration.PreviousDocumentsData.maxAmountOfItems

--- a/app/controllers/declaration/PreviousDocumentsRemoveController.scala
+++ b/app/controllers/declaration/PreviousDocumentsRemoveController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.Document

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -18,8 +18,8 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper.saveAndContinue
-import controllers.util.{FormAction, Remove}
+import controllers.helpers.MultipleItemsHelper.saveAndContinue
+import controllers.helpers.{FormAction, Remove}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.Seal

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.SupervisingCustomsOfficeHelper
+import controllers.helpers.SupervisingCustomsOfficeHelper
 import forms.declaration.SupervisingCustomsOffice
 import forms.declaration.SupervisingCustomsOffice.form
 import javax.inject.Inject

--- a/app/controllers/declaration/TaricCodeAddController.scala
+++ b/app/controllers/declaration/TaricCodeAddController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.MultipleItemsHelper
+import controllers.helpers.MultipleItemsHelper
 import forms.declaration.TaricCode.taricCodeLimit
 import forms.declaration.{TaricCode, TaricCodeFirst}
 import models.requests.JourneyRequest

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -18,7 +18,7 @@ package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.{FormAction, Remove}
+import controllers.helpers.{FormAction, Remove}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{ContainerAdd, ContainerFirst}

--- a/app/controllers/declaration/TransportLeavingTheBorderController.scala
+++ b/app/controllers/declaration/TransportLeavingTheBorderController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.SupervisingCustomsOfficeHelper
+import controllers.helpers.SupervisingCustomsOfficeHelper
 import forms.declaration.TransportLeavingTheBorder
 import javax.inject.Inject
 import models.requests.JourneyRequest

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -20,7 +20,7 @@ import scala.concurrent.{ExecutionContext, Future}
 
 import controllers.actions.{AuthAction, JourneyAction}
 import controllers.navigation.Navigator
-import controllers.util.SupervisingCustomsOfficeHelper
+import controllers.helpers.SupervisingCustomsOfficeHelper
 import forms.declaration.WarehouseIdentification
 import javax.inject.Inject
 import models.requests.JourneyRequest

--- a/app/controllers/helpers/DeclarationHolderHelper.scala
+++ b/app/controllers/helpers/DeclarationHolderHelper.scala
@@ -16,8 +16,10 @@
 
 package controllers.helpers
 
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
 import forms.declaration.declarationHolder.DeclarationHolder
 import models.requests.JourneyRequest
+import play.api.data.FormError
 
 object DeclarationHolderHelper {
 
@@ -25,4 +27,32 @@ object DeclarationHolderHelper {
 
   def cachedHolders(implicit request: JourneyRequest[_]): Seq[DeclarationHolder] =
     request.cacheModel.parties.declarationHoldersData.map(_.holders).getOrElse(Seq.empty)
+
+  def validateAuthCode(maybeDeclarationHolder: Option[DeclarationHolder])(implicit r: JourneyRequest[_]): Option[FormError] =
+    maybeDeclarationHolder match {
+      case Some(DeclarationHolder(Some(authorisationCode), _, _)) =>
+        if (isExrrSelectedForPrelodgedDecl(authorisationCode, r.cacheModel.additionalDeclarationType))
+          Some(FormError(DeclarationHolderFormGroupId, "declaration.declarationHolder.EXRR.error.prelodged"))
+        else
+          validateMutuallyExclusiveAuthCodes(authorisationCode, cachedHolders)
+
+      case _ => None
+    }
+
+  private val nonExrrAdditionalDeclarationTypes =
+    List(STANDARD_PRE_LODGED, SIMPLIFIED_PRE_LODGED, OCCASIONAL_PRE_LODGED, CLEARANCE_PRE_LODGED)
+
+  private def isExrrSelectedForPrelodgedDecl(authorisationCode: String, declarationType: Option[AdditionalDeclarationType]): Boolean =
+    declarationType.fold(false)(authorisationCode == "EXRR" && nonExrrAdditionalDeclarationTypes.contains(_))
+
+  private val mutuallyExclusiveAuthorisationCodes = List("CSE", "EXRR")
+
+  private def validateMutuallyExclusiveAuthCodes(authorisationCode: String, holders: Seq[DeclarationHolder]): Option[FormError] =
+    if (!mutuallyExclusiveAuthorisationCodes.contains(authorisationCode)) None
+    else {
+      val mustNotAlreadyContainCodes = mutuallyExclusiveAuthorisationCodes.filter(_ != authorisationCode)
+
+      if (!holders.map(_.authorisationTypeCode.getOrElse("")).containsSlice(mustNotAlreadyContainCodes)) None
+      else Some(FormError(DeclarationHolderFormGroupId, s"declaration.declarationHolder.${authorisationCode}.error.exclusive"))
+    }
 }

--- a/app/controllers/helpers/DeclarationHolderHelper.scala
+++ b/app/controllers/helpers/DeclarationHolderHelper.scala
@@ -22,23 +22,8 @@ import play.api.data.{Form, FormError}
 
 object DeclarationHolderHelper {
 
-  val DeclarationHolderFormGroupId: String = "declarationHolder"
-
   def declarationHolders(implicit request: JourneyRequest[_]): Seq[DeclarationHolder] = request.cacheModel.declarationHolders
 
   def form(implicit request: JourneyRequest[_]): Form[DeclarationHolder] =
     DeclarationHolder.form(request.eori, request.cacheModel.additionalDeclarationType)
-
-  private val mutuallyExclusiveAuthorisationCodes = List("CSE", "EXRR")
-
-  def validateMutuallyExclusiveAuthCodes(maybeHolder: Option[DeclarationHolder], holders: Seq[DeclarationHolder]): Option[FormError] =
-    maybeHolder match {
-      case Some(DeclarationHolder(Some(code), _, _)) if mutuallyExclusiveAuthorisationCodes.contains(code) =>
-        val mustNotAlreadyContainCodes = mutuallyExclusiveAuthorisationCodes.filter(_ != code)
-
-        if (!holders.map(_.authorisationTypeCode.getOrElse("")).containsSlice(mustNotAlreadyContainCodes)) None
-        else Some(FormError(DeclarationHolderFormGroupId, s"declaration.declarationHolder.${code}.error.exclusive"))
-
-      case _ => None
-    }
 }

--- a/app/controllers/helpers/DeclarationHolderHelper.scala
+++ b/app/controllers/helpers/DeclarationHolderHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import forms.declaration.declarationHolder.DeclarationHolder
 import models.requests.JourneyRequest

--- a/app/controllers/helpers/FormAction.scala
+++ b/app/controllers/helpers/FormAction.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import play.api.mvc.{AnyContent, Request}
 

--- a/app/controllers/helpers/MultipleItemsHelper.scala
+++ b/app/controllers/helpers/MultipleItemsHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import play.api.data.{Form, FormError}
 

--- a/app/controllers/helpers/SubmissionDisplayHelper.scala
+++ b/app/controllers/helpers/SubmissionDisplayHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import models.declaration.notifications.Notification
 import models.declaration.submissions.Submission

--- a/app/controllers/helpers/SupervisingCustomsOfficeHelper.scala
+++ b/app/controllers/helpers/SupervisingCustomsOfficeHelper.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import controllers.declaration.routes
 import models.codes.AdditionalProcedureCode.NO_APC_APPLIES_CODE

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -18,8 +18,8 @@ package controllers.navigation
 
 import config.AppConfig
 import controllers.declaration.routes
-import controllers.util.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
-import controllers.util._
+import controllers.helpers.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
+import controllers.helpers._
 import forms.Choice.AllowedChoiceValues
 import forms.common.YesNoAnswer
 import forms.declaration.RoutingCountryQuestionYesNo.{ChangeCountryPage, RemoveCountryPage, RoutingCountryQuestionPage}

--- a/app/models/ExportsDeclaration.scala
+++ b/app/models/ExportsDeclaration.scala
@@ -28,6 +28,7 @@ import play.api.libs.json._
 import java.time.{Clock, Instant}
 
 import forms.declaration.additionaldocuments.AdditionalDocument
+import forms.declaration.declarationHolder.DeclarationHolder
 
 case class ExportsDeclaration(
   id: String,
@@ -84,6 +85,8 @@ case class ExportsDeclaration(
   def containers: Seq[Container] = transport.containers.getOrElse(Seq.empty)
 
   def containRoutingCountries(): Boolean = locations.routingCountries.nonEmpty
+
+  def declarationHolders: Seq[DeclarationHolder] = parties.declarationHoldersData.map(_.holders).getOrElse(Seq.empty)
 
   def hasContainers: Boolean = containers.nonEmpty
 

--- a/app/models/SubmissionsPagesElements.scala
+++ b/app/models/SubmissionsPagesElements.scala
@@ -17,7 +17,7 @@
 package models
 
 import config.PaginationConfig
-import controllers.util.SubmissionDisplayHelper.filterSubmissions
+import controllers.helpers.SubmissionDisplayHelper.filterSubmissions
 import models.declaration.notifications.Notification
 import models.declaration.submissions.{Submission, SubmissionStatus}
 

--- a/app/models/declaration/DeclarationHoldersData.scala
+++ b/app/models/declaration/DeclarationHoldersData.scala
@@ -17,7 +17,6 @@
 package models.declaration
 
 import forms.common.YesNoAnswer
-import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.declarationHolder.DeclarationHolder
 import play.api.libs.json.Json
 

--- a/app/views/components/add_save_button.scala.html
+++ b/app/views/components/add_save_button.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.{Add, SaveAndContinue}
+@import controllers.helpers.{Add, SaveAndContinue}
 
 @(
     saveKey: String = "site.save_and_continue",

--- a/app/views/components/buttons/add_button.scala.html
+++ b/app/views/components/buttons/add_button.scala.html
@@ -14,8 +14,8 @@
  * limitations under the License.
  *@
 
-@import controllers.util.Add
-@import controllers.util.AddField
+@import controllers.helpers.Add
+@import controllers.helpers.AddField
 
 @(addKey: String = "site.add", addHint: String = "site.add", fieldId: Option[String] = None)(implicit messages: Messages)
 

--- a/app/views/components/buttons/remove_button.scala.html
+++ b/app/views/components/buttons/remove_button.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.Remove
+@import controllers.helpers.Remove
 @import views.components.fields.LabelledValue
 
 @(element: LabelledValue, label: String = "site.remove", buttonClass: String = "button--secondary", hint: String = "site.remove.hint")(implicit messages: Messages)

--- a/app/views/components/buttons/save_and_continue_button.scala.html
+++ b/app/views/components/buttons/save_and_continue_button.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.SaveAndContinue
+@import controllers.helpers.SaveAndContinue
 
 @(messageKey: String = "site.save_and_continue")(implicit messages: Messages)
 

--- a/app/views/components/buttons/save_and_return_later_button.scala.html
+++ b/app/views/components/buttons/save_and_return_later_button.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.SaveAndReturn
+@import controllers.helpers.SaveAndReturn
 
 @(messageKey: String = "site.save_and_come_back_later")(implicit messages: Messages)
 

--- a/app/views/components/fields/field_multiple_values.scala.html
+++ b/app/views/components/fields/field_multiple_values.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.{Add, Remove}
+@import controllers.helpers.{Add, Remove}
 @import components.buttons.add_button
 @import views.components.fields.LabelledValue
 

--- a/app/views/components/fields/field_text_multiple_values.scala.html
+++ b/app/views/components/fields/field_text_multiple_values.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.{Add, Remove}
+@import controllers.helpers.{Add, Remove}
 @import components.inputs.input_text
 
 @(

--- a/app/views/components/fields/removable_elements_table.scala.html
+++ b/app/views/components/fields/removable_elements_table.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.Remove
+@import controllers.helpers.Remove
 
 @import views.components.fields.LabelledValue
 @import views.html.components.buttons.remove_button

--- a/app/views/components/gds/saveAsDraft.scala.html
+++ b/app/views/components/gds/saveAsDraft.scala.html
@@ -14,7 +14,7 @@
  * limitations under the License.
  *@
 
-@import controllers.util.SaveAndReturn
+@import controllers.helpers.SaveAndReturn
 
 @(messageKey: String = "site.save_and_come_back_later")(implicit messages: Messages)
 <button id="submit_and_return" class="button-link govuk-link govuk-link--no-visited-state focus" name="@SaveAndReturn.toString">@messages(messageKey)</button>

--- a/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
+++ b/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
@@ -15,7 +15,7 @@
  *@
 
 @import config.AppConfig
-@import controllers.util.DeclarationHolderHelper.DeclarationHolderFormGroupId
+@import controllers.helpers.DeclarationHolderHelper.DeclarationHolderFormGroupId
 @import forms.declaration.declarationHolder.DeclarationHolder
 @import forms.declaration.declarationHolder.DeclarationHolder.eoriSource
 @import models.requests.JourneyRequest

--- a/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
+++ b/app/views/declaration/declarationHolder/declaration_holder_edit_content.scala.html
@@ -15,9 +15,8 @@
  *@
 
 @import config.AppConfig
-@import controllers.helpers.DeclarationHolderHelper.DeclarationHolderFormGroupId
 @import forms.declaration.declarationHolder.DeclarationHolder
-@import forms.declaration.declarationHolder.DeclarationHolder.eoriSource
+@import forms.declaration.declarationHolder.DeclarationHolder.{DeclarationHolderFormGroupId, eoriSource}
 @import models.requests.JourneyRequest
 @import models.declaration.EoriSource._
 @import play.twirl.api.HtmlFormat

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -837,8 +837,9 @@ declaration.declarationHolders.add.another.empty = Select yes if you need to add
 declaration.declarationHolders.remove.empty = Select yes if you want to remove this authorisation
 declaration.declarationHolder.remove.title = Are you sure you want to remove this authorisation?
 declaration.declarationHolder.error.duplicate = You have already entered this EORI number for this authorisation
-declaration.declarationHolder.EXRR.error.exclusive = You have already added a CSE authorisation. If you want to use RoRo transport you must use EXRR instead of CSE.
 declaration.declarationHolder.CSE.error.exclusive = You have already added an EXRR authorisation. If you want to use RoRo transport you cannot add CSE authorisation as well.
+declaration.declarationHolder.EXRR.error.exclusive = You have already added a CSE authorisation. If you want to use RoRo transport you must use EXRR instead of CSE.
+declaration.declarationHolder.EXRR.error.prelodged = EXRR cannot be used with a pre-lodged declaration
 
 declaration.originationCountry.title = Which country are the goods being dispatched from?
 declaration.originationCountry.empty = Select a country of dispatch

--- a/test/base/ControllerSpec.scala
+++ b/test/base/ControllerSpec.scala
@@ -18,7 +18,7 @@ package base
 
 import scala.concurrent.{ExecutionContext, Future}
 
-import controllers.util.{Add, AddField, SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{Add, AddField, SaveAndContinue, SaveAndReturn}
 import mock.{JourneyActionMocks, VerifiedEmailMocks}
 import models.ExportsDeclaration
 import models.requests.{ExportsSessionKeys, JourneyRequest}

--- a/test/base/TestHelper.scala
+++ b/test/base/TestHelper.scala
@@ -16,7 +16,7 @@
 
 package base
 
-import controllers.util.{Add, Remove, SaveAndContinue}
+import controllers.helpers.{Add, Remove, SaveAndContinue}
 
 import scala.util.Random
 

--- a/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import base.ControllerSpec
-import controllers.util.SaveAndContinue
+import controllers.helpers.SaveAndContinue
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.{apply => _, values => _, _}
 import models.DeclarationType._
 import models.Mode

--- a/test/controllers/declaration/AdditionalProcedureCodesControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalProcedureCodesControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers.declaration
 import java.util.{Locale, UUID}
 
 import base.ControllerSpec
-import controllers.util.Remove
+import controllers.helpers.Remove
 import forms.declaration.SupervisingCustomsOffice
 import forms.declaration.procedurecodes.AdditionalProcedureCode
 import forms.declaration.procedurecodes.AdditionalProcedureCode.additionalProcedureCodeKey

--- a/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
@@ -143,38 +143,6 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with ErrorHan
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
         }
-
-        "user adds mutually exclusive data" when {
-
-          "attempted to change to EXRR when already having CSE present" in {
-            withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1, declarationHolder2)))
-
-            val requestBody = List(
-              "authorisationTypeCode" -> "EXRR",
-              "eori" -> declarationHolder1.eori.map(_.value).value,
-              "eoriSource" -> declarationHolder1.eoriSource.map(_.toString).value
-            )
-            val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
-
-            status(result) mustBe BAD_REQUEST
-            verifyChangePageInvoked()
-          }
-
-          "attempted to change to CSE when already having EXRR present" in {
-            val declarationHolder3 = declarationHolder2.copy(authorisationTypeCode = Some("EXRR"))
-            withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1, declarationHolder3)))
-
-            val requestBody = List(
-              "authorisationTypeCode" -> "CSE",
-              "eori" -> declarationHolder1.eori.map(_.value).value,
-              "eoriSource" -> declarationHolder1.eoriSource.map(_.toString).value
-            )
-            val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
-
-            status(result) mustBe BAD_REQUEST
-            verifyChangePageInvoked()
-          }
-        }
       }
 
       "return 303 (SEE_OTHER)" when {

--- a/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderChangeControllerSpec.scala
@@ -18,21 +18,23 @@ package controllers.declaration
 
 import base.ControllerSpec
 import forms.common.Eori
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
 import forms.declaration.declarationHolder.DeclarationHolder
 import mock.ErrorHandlerMocks
+import models.DeclarationType._
 import models.Mode
 import models.declaration.{DeclarationHoldersData, EoriSource}
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, times, verify, verifyNoInteractions, when}
-import org.scalatest.OptionValues
+import org.mockito.Mockito._
+import org.scalatest.{GivenWhenThen, OptionValues}
 import play.api.data.Form
 import play.api.mvc.{AnyContentAsEmpty, Request}
 import play.api.test.Helpers._
-import play.twirl.api.HtmlFormat
+import play.twirl.api.{Html, HtmlFormat}
 import views.html.declaration.declarationHolder.declaration_holder_change
 
-class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionValues with ErrorHandlerMocks {
+class DeclarationHolderChangeControllerSpec extends ControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
 
   val mockChangePage = mock[declaration_holder_change]
 
@@ -70,21 +72,18 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
     captor.getValue
   }
 
-  private def verifyChangePageInvoked(numberOfTimes: Int = 1) =
+  private def verifyChangePageInvoked(numberOfTimes: Int = 1): Html =
     verify(mockChangePage, times(numberOfTimes)).apply(any(), any(), any(), any())(any(), any())
 
-  val declarationHolder1: DeclarationHolder = DeclarationHolder(Some("ACE"), Some(Eori("GB42354735346235")), Some(EoriSource.UserEori))
-  val declarationHolder2: DeclarationHolder = DeclarationHolder(Some("ACE"), Some(Eori("FR65435642343253")), Some(EoriSource.OtherEori))
+  val declarationHolder1 = DeclarationHolder(Some("ACE"), Some(Eori("GB42354735346235")), Some(EoriSource.UserEori))
+  val declarationHolder2 = DeclarationHolder(Some("CSE"), Some(Eori("FR65435642343253")), Some(EoriSource.OtherEori))
 
   "DeclarationHolder Change Controller" must {
 
     onEveryDeclarationJourney() { request =>
       "return 200 (OK)" when {
         "display page method is invoked" in {
-
-          withNewCaching(
-            aDeclarationAfter(request.cacheModel, withDeclarationHolders(Some("ACE"), Some(Eori("GB42354735346235")), Some(EoriSource.UserEori)))
-          )
+          withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1)))
 
           val result = controller.displayPage(Mode.Normal, declarationHolder1.id)(getRequest())
 
@@ -96,6 +95,7 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
       }
 
       "return 400 (BAD_REQUEST)" when {
+
         "display page method is invoked with invalid holderId" in {
           withNewCaching(request.cacheModel)
 
@@ -108,12 +108,12 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
         "submit page method is invoked with invalid holderId" in {
           withNewCaching(request.cacheModel)
 
-          val requestBody =
-            Seq(
-              "authorisationTypeCode" -> declarationHolder2.authorisationTypeCode.get,
-              "eori" -> declarationHolder2.eori.map(_.value).get,
-              "eoriSource" -> declarationHolder2.eoriSource.map(_.toString).get
-            )
+          val requestBody = List(
+            "authorisationTypeCode" -> declarationHolder2.authorisationTypeCode.get,
+            "eori" -> declarationHolder2.eori.map(_.value).get,
+            "eoriSource" -> declarationHolder2.eoriSource.map(_.toString).get
+          )
+
           val result = controller.submitForm(Mode.Normal, "invalid")(postRequestAsFormUrlEncoded(requestBody: _*))
 
           status(result) mustBe BAD_REQUEST
@@ -123,7 +123,7 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
         "user edits with invalid data" in {
           withNewCaching(request.cacheModel)
 
-          val requestBody = Seq("authorisationTypeCode" -> "inva!id", "eori" -> "inva!id", "eoriSource" -> "inva!id")
+          val requestBody = List("authorisationTypeCode" -> "inva!id", "eori" -> "inva!id", "eoriSource" -> "inva!id")
           val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
 
           status(result) mustBe BAD_REQUEST
@@ -133,16 +133,47 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
         "user edit leads to duplicate data" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1, declarationHolder2)))
 
-          val requestBody =
-            Seq(
-              "authorisationTypeCode" -> declarationHolder2.authorisationTypeCode.get,
-              "eori" -> declarationHolder2.eori.map(_.value).get,
-              "eoriSource" -> declarationHolder2.eoriSource.map(_.toString).get
-            )
+          val requestBody = List(
+            "authorisationTypeCode" -> declarationHolder2.authorisationTypeCode.get,
+            "eori" -> declarationHolder2.eori.map(_.value).get,
+            "eoriSource" -> declarationHolder2.eoriSource.map(_.toString).get
+          )
           val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+        }
+
+        "user adds mutually exclusive data" when {
+
+          "attempted to change to EXRR when already having CSE present" in {
+            withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1, declarationHolder2)))
+
+            val requestBody = List(
+              "authorisationTypeCode" -> "EXRR",
+              "eori" -> declarationHolder1.eori.map(_.value).value,
+              "eoriSource" -> declarationHolder1.eoriSource.map(_.toString).value
+            )
+            val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
+
+            status(result) mustBe BAD_REQUEST
+            verifyChangePageInvoked()
+          }
+
+          "attempted to change to CSE when already having EXRR present" in {
+            val declarationHolder3 = declarationHolder2.copy(authorisationTypeCode = Some("EXRR"))
+            withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1, declarationHolder3)))
+
+            val requestBody = List(
+              "authorisationTypeCode" -> "CSE",
+              "eori" -> declarationHolder1.eori.map(_.value).value,
+              "eoriSource" -> declarationHolder1.eoriSource.map(_.toString).value
+            )
+            val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
+
+            status(result) mustBe BAD_REQUEST
+            verifyChangePageInvoked()
+          }
         }
       }
 
@@ -151,7 +182,7 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
           withNewCaching(aDeclarationAfter(request.cacheModel, withDeclarationHolders(declarationHolder1)))
 
           val requestBody =
-            Seq(
+            List(
               "authorisationTypeCode" -> declarationHolder2.authorisationTypeCode.get,
               "eori" -> declarationHolder2.eori.map(_.value).get,
               "eoriSource" -> declarationHolder2.eoriSource.map(_.toString).get
@@ -162,7 +193,35 @@ class DeclarationHolderChangeControllerSpec extends ControllerSpec with OptionVa
           thePageNavigatedTo mustBe controllers.declaration.routes.DeclarationHolderSummaryController.displayPage(Mode.Normal)
 
           val savedHolder = theCacheModelUpdated.parties.declarationHoldersData
-          savedHolder mustBe Some(DeclarationHoldersData(Seq(declarationHolder2)))
+          savedHolder mustBe Some(DeclarationHoldersData(List(declarationHolder2)))
+        }
+      }
+    }
+
+    "return 400 (BAD_REQUEST)" when {
+
+      onJourney(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE) { implicit request =>
+        "the user enters 'EXRR' as authorisationTypeCode" in {
+          And("the declaration is of type PRE_LODGED")
+          val additionalDeclarationType = request.declarationType match {
+            case STANDARD   => STANDARD_PRE_LODGED
+            case SIMPLIFIED => SIMPLIFIED_PRE_LODGED
+            case OCCASIONAL => OCCASIONAL_PRE_LODGED
+            case CLEARANCE  => CLEARANCE_PRE_LODGED
+          }
+          withNewCaching(
+            aDeclarationAfter(
+              request.cacheModel,
+              withAdditionalDeclarationType(additionalDeclarationType),
+              withDeclarationHolders(declarationHolder1)
+            )
+          )
+
+          val requestBody = List("authorisationTypeCode" -> "EXRR", "eori" -> "GB42354735346235", "eoriSource" -> "OtherEori")
+          val result = controller.submitForm(Mode.Normal, declarationHolder1.id)(postRequestAsFormUrlEncoded(requestBody: _*))
+
+          status(result) mustBe BAD_REQUEST
+          verifyChangePageInvoked()
         }
       }
     }

--- a/test/controllers/declaration/ItemsSummaryControllerSpec.scala
+++ b/test/controllers/declaration/ItemsSummaryControllerSpec.scala
@@ -20,7 +20,7 @@ import scala.concurrent.Await
 import scala.concurrent.duration._
 
 import base.ControllerWithoutFormSpec
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers

--- a/test/controllers/declaration/SealControllerSpec.scala
+++ b/test/controllers/declaration/SealControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import base.ControllerSpec
-import controllers.util.{Remove, SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{Remove, SaveAndContinue, SaveAndReturn}
 import forms.common.YesNoAnswer
 import forms.declaration.Seal
 import mock.ErrorHandlerMocks

--- a/test/controllers/declaration/TransportContainerControllerSpec.scala
+++ b/test/controllers/declaration/TransportContainerControllerSpec.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import base.{ControllerSpec, Injector}
-import controllers.util.Remove
+import controllers.helpers.Remove
 import forms.common.YesNoAnswer
 import forms.declaration.{ContainerAdd, ContainerFirst, Seal}
 import mock.ErrorHandlerMocks

--- a/test/controllers/helpers/MultipleItemsHelperSpec.scala
+++ b/test/controllers/helpers/MultipleItemsHelperSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import base.UnitSpec
 import play.api.data.Forms.{mapping, text}

--- a/test/controllers/helpers/SubmissionDisplayHelperSpec.scala
+++ b/test/controllers/helpers/SubmissionDisplayHelperSpec.scala
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import models.declaration.notifications.Notification
 import models.declaration.submissions.{Submission, SubmissionStatus}

--- a/test/controllers/helpers/SupervisingCustomsOfficeHelperSpec.scala
+++ b/test/controllers/helpers/SupervisingCustomsOfficeHelperSpec.scala
@@ -14,10 +14,10 @@
  * limitations under the License.
  */
 
-package controllers.util
+package controllers.helpers
 
 import base.UnitSpec
-import controllers.util.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
+import controllers.helpers.SupervisingCustomsOfficeHelper.isConditionForAllProcedureCodesVerified
 import models.codes.AdditionalProcedureCode.NO_APC_APPLIES_CODE
 import services.cache.{ExportsDeclarationBuilder, ExportsItemBuilder}
 

--- a/test/controllers/navigation/NavigatorSpec.scala
+++ b/test/controllers/navigation/NavigatorSpec.scala
@@ -22,7 +22,7 @@ import scala.concurrent.Future
 import scala.concurrent.duration.FiniteDuration
 import base.{MockExportCacheService, RequestBuilder, UnitWithMocksSpec}
 import config.AppConfig
-import controllers.util._
+import controllers.helpers._
 import forms.declaration.carrier.CarrierDetails
 import models.requests.{ExportsSessionKeys, JourneyRequest}
 import models.responses.FlashKeys

--- a/test/forms/declaration/declarationHolder/DeclarationHolderSpec.scala
+++ b/test/forms/declaration/declarationHolder/DeclarationHolderSpec.scala
@@ -19,37 +19,40 @@ package forms.declaration.declarationHolder
 import base.ExportsTestData._
 import base.JourneyTypeTestRunner
 import forms.common.{DeclarationPageBaseSpec, Eori}
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.STANDARD_PRE_LODGED
+import forms.declaration.declarationHolder.DeclarationHolder.nonExrrAdditionalDeclarationTypes
 import models.declaration.EoriSource
 import models.declaration.ExportDeclarationTestData.correctDeclarationHolder
+import org.scalatest.Inspectors.forAll
 
 class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTestRunner {
 
   private val eoriSource = EoriSource.OtherEori.toString
+  private val authorisationTypeCode = correctDeclarationHolder.authorisationTypeCode.get
 
   "DeclarationHolder mandatoryMapping" should {
 
-    val mapping = DeclarationHolder.mapping(eori)
+    val mapping = DeclarationHolder.mapping(eori, Some(STANDARD_PRE_LODGED))
 
     "mapping.bind return no errors" when {
       "provided with all fields" in {
-        val input = Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get, "eori" -> eori, "eoriSource" -> eoriSource)
-
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode, "eori" -> eori, "eoriSource" -> eoriSource)
         mapping.bind(input).isRight mustBe true
       }
 
       "provided with a authorisationTypeCode and eoriSource of 'UserEori' but no eori value, set eori value to users eori" in {
-        val input = Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get, "eoriSource" -> EoriSource.UserEori.toString)
-
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode, "eoriSource" -> EoriSource.UserEori.toString)
         val boundForm = mapping.bind(input)
 
         boundForm.isRight mustBe true
-        boundForm.right.get.authorisationTypeCode mustBe Some(correctDeclarationHolder.authorisationTypeCode.get)
+        boundForm.right.get.authorisationTypeCode mustBe Some(authorisationTypeCode)
         boundForm.right.get.eori mustBe Some(Eori(eori))
         boundForm.right.get.eoriSource mustBe Some(EoriSource.UserEori)
       }
     }
 
     "mapping.bind return errors" when {
+
       "provided with no values" in {
         val input = Map.empty[String, String]
         val result = mapping.bind(input)
@@ -73,7 +76,7 @@ class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTest
       }
 
       "provided with code only" in {
-        val input = Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get)
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode)
         val result = mapping.bind(input)
 
         result.isLeft mustBe true
@@ -115,7 +118,7 @@ class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTest
       }
 
       "provided with a authorisationTypeCode and eoriSource of 'OtherEori' but no eori value" in {
-        val input = Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get, "eoriSource" -> eoriSource)
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode, "eoriSource" -> eoriSource)
         val result = mapping.bind(input)
 
         result.isLeft mustBe true
@@ -125,7 +128,7 @@ class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTest
       }
 
       "provided with a authorisationTypeCode and eori but no eoriSource value" in {
-        val input = Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get, "eori" -> eori)
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode, "eori" -> eori)
         val result = mapping.bind(input)
 
         result.isLeft mustBe true
@@ -135,14 +138,25 @@ class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTest
       }
 
       "provided with incorrect eori" in {
-        val input =
-          Map("authorisationTypeCode" -> correctDeclarationHolder.authorisationTypeCode.get, "eori" -> "INCORRECT_EORI", "eoriSource" -> eoriSource)
+        val input = Map("authorisationTypeCode" -> authorisationTypeCode, "eori" -> "INCORRECT_EORI", "eoriSource" -> eoriSource)
         val result = mapping.bind(input)
 
         result.isLeft mustBe true
         val errors = result.left.get
         errors.size mustBe 1
         errors.head.message mustBe "declaration.eori.error.format"
+      }
+
+      "provided with 'EXRR' as authorisationTypeCode with a pre-lodged declaration" in {
+        val input = Map("authorisationTypeCode" -> "EXRR", "eori" -> eori, "eoriSource" -> eoriSource)
+        forAll(nonExrrAdditionalDeclarationTypes) { additionalDeclarationType =>
+          val result = DeclarationHolder.mapping(eori, Some(additionalDeclarationType)).bind(input)
+
+          result.isLeft mustBe true
+          val errors = result.left.get
+          errors.size mustBe 1
+          errors.head.message mustBe "declaration.declarationHolder.EXRR.error.prelodged"
+        }
       }
     }
 
@@ -180,6 +194,7 @@ class DeclarationHolderSpec extends DeclarationPageBaseSpec with JourneyTypeTest
   }
 
   "DeclarationHolder on requireAdditionalDocumentation" should {
+
     "return true" when {
       AuthorizationTypeCodes.CodesRequiringDocumentation.foreach { code =>
         s"authorisationTypeCode contains $code code" in {

--- a/test/views/declaration/AdditionalActorsAddViewSpec.scala
+++ b/test/views/declaration/AdditionalActorsAddViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
-import controllers.util.{SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{SaveAndContinue, SaveAndReturn}
 import forms.common.Eori
 import forms.declaration.DeclarationAdditionalActors
 import models.DeclarationType._

--- a/test/views/declaration/AdditionalDocumentEditViewSpec.scala
+++ b/test/views/declaration/AdditionalDocumentEditViewSpec.scala
@@ -17,7 +17,7 @@
 package views.declaration
 
 import base.{Injector, TestHelper}
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.Date.{dayKey, monthKey, yearKey}
 import forms.common.Eori
 import forms.declaration.AdditionalDocumentSpec._

--- a/test/views/declaration/AdditionalDocumentsViewSpec.scala
+++ b/test/views/declaration/AdditionalDocumentsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer
 import forms.declaration.AdditionalDocumentSpec._
 import forms.declaration.additionaldocuments.AdditionalDocument

--- a/test/views/declaration/AdditionalInformationAddViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationAddViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.{Injector, TestHelper}
 import controllers.declaration.routes
-import controllers.util.{SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{SaveAndContinue, SaveAndReturn}
 import forms.declaration.AdditionalInformation
 import models.Mode
 import models.requests.JourneyRequest

--- a/test/views/declaration/AdditionalInformationViewSpec.scala
+++ b/test/views/declaration/AdditionalInformationViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.{SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{SaveAndContinue, SaveAndReturn}
 import forms.common.YesNoAnswer
 import forms.declaration.AdditionalInformation
 import models.requests.JourneyRequest

--- a/test/views/declaration/AuthorisationProcedureCodeChoiceViewSpec.scala
+++ b/test/views/declaration/AuthorisationProcedureCodeChoiceViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer._
 import forms.declaration.AuthorisationProcedureCodeChoice
 import models.Mode

--- a/test/views/declaration/CarrierDetailsViewSpec.scala
+++ b/test/views/declaration/CarrierDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.{Address, AddressSpec}
 import forms.declaration.EntityDetails
 import forms.declaration.carrier.CarrierDetails

--- a/test/views/declaration/ConsigneeDetailsViewSpec.scala
+++ b/test/views/declaration/ConsigneeDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.common.{Address, AddressSpec}
 import forms.declaration._

--- a/test/views/declaration/ConsignmentReferencesViewSpec.scala
+++ b/test/views/declaration/ConsignmentReferencesViewSpec.scala
@@ -19,7 +19,7 @@ package views.declaration
 import base.{Injector, TestHelper}
 import base.ExportsTestData._
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.{Ducr, Lrn, Mrn}
 import forms.declaration.ConsignmentReferences
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.{SUPPLEMENTARY_EIDR, SUPPLEMENTARY_SIMPLIFIED}

--- a/test/views/declaration/ConsignorDetailsViewSpec.scala
+++ b/test/views/declaration/ConsignorDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.{Address, AddressSpec}
 import forms.declaration.EntityDetails
 import forms.declaration.consignor.ConsignorDetails

--- a/test/views/declaration/DeclarantDetailsViewSpec.scala
+++ b/test/views/declaration/DeclarantDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarantEoriConfirmation
 import forms.declaration.DeclarantEoriConfirmation.form

--- a/test/views/declaration/DeclarantExporterViewSpec.scala
+++ b/test/views/declaration/DeclarantExporterViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.DeclarantIsExporter
 import models.DeclarationType.{OCCASIONAL, SIMPLIFIED, STANDARD}

--- a/test/views/declaration/DeclarationHolderAddViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderAddViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.{Injector, TestHelper}
 import base.ExportsTestData._
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.Eori
 import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.declarationHolder.DeclarationHolder

--- a/test/views/declaration/DeclarationHolderAddViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderAddViewSpec.scala
@@ -16,15 +16,17 @@
 
 package views.declaration
 
-import base.{Injector, TestHelper}
 import base.ExportsTestData._
+import base.Injector
+import base.TestHelper.createRandomAlphanumericString
 import controllers.helpers.SaveAndReturn
 import forms.common.Eori
 import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.declarationHolder.DeclarationHolder
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
 import models.Mode
-import models.declaration.{DeclarationHoldersData, EoriSource, Parties}
+import models.declaration.EoriSource.{OtherEori, UserEori}
+import models.declaration.{DeclarationHoldersData, Parties}
 import models.requests.JourneyRequest
 import org.jsoup.nodes.Document
 import play.api.data.Form
@@ -39,46 +41,47 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
 
   private val declarationHolderPage = instanceOf[declaration_holder_add]
 
-  private def createView(form: Form[DeclarationHolder] = DeclarationHolder.form(eori))(implicit request: JourneyRequest[_]): Document =
+  private def createForm(implicit request: JourneyRequest[_]): Form[DeclarationHolder] =
+    DeclarationHolder.form(eori, request.cacheModel.additionalDeclarationType)
+
+  private def createView(form: Form[DeclarationHolder])(implicit request: JourneyRequest[_]): Document =
     declarationHolderPage(Mode.Normal, form, eori)(request, messages)
 
   "Declaration Holder View on empty page" should {
     onEveryDeclarationJourney() { implicit request =>
-      val view = createView()
+      val view = createView(createForm)
 
       "display page title" in {
-        view.getElementsByTag("h1").text() mustBe messages("declaration.declarationHolder.title")
+        view.getElementsByTag("h1").text mustBe messages("declaration.declarationHolder.title")
       }
 
       "display section header" in {
-        view.getElementById("section-header").text() must include(messages("declaration.section.2"))
+        view.getElementById("section-header").text must include(messages("declaration.section.2"))
       }
 
       "display empty input with label for Authorisation Code" in {
-        view.getElementById("authorisationTypeCode-label").text() mustBe messages("declaration.declarationHolder.authorisationCode")
+        view.getElementById("authorisationTypeCode-label").text mustBe messages("declaration.declarationHolder.authorisationCode")
         view.getElementById("authorisationTypeCode").attr("value") mustBe empty
       }
 
       "display unselected radio buttons with labels" in {
-        val view = createView()
-
         view
           .getElementById("UserEori")
           .getElementsByAttribute("checked")
-          .size() mustBe 0
+          .size mustBe 0
 
         view.getElementsByAttributeValue("for", "UserEori").text mustBe messages("declaration.declarationHolder.eori.user.text", eori)
 
         view
           .getElementById("OtherEori")
           .getElementsByAttribute("checked")
-          .size() mustBe 0
+          .size mustBe 0
 
         view.getElementsByAttributeValue("for", "OtherEori").text mustBe messages("declaration.declarationHolder.eori.other.text")
       }
 
       "do not display the Eori text form field" in {
-        createView().getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe true
+        view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe true
       }
 
       "display empty input with label and hint for EORI" in {
@@ -89,10 +92,10 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
 
       "display 'Save and continue' button on page" in {
         val saveAndContinueButton = view.getElementById("submit")
-        saveAndContinueButton.text() mustBe messages(saveAndContinueCaption)
+        saveAndContinueButton.text mustBe messages(saveAndContinueCaption)
 
         val saveAndReturnButton = view.getElementById("submit_and_return")
-        saveAndReturnButton.text() mustBe messages(saveAndReturnCaption)
+        saveAndReturnButton.text mustBe messages(saveAndReturnCaption)
         saveAndReturnButton.attr("name") mustBe SaveAndReturn.toString
       }
     }
@@ -104,7 +107,7 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
             val parties = Parties(declarationHoldersData = Some(DeclarationHoldersData(Seq.empty, answer)))
             val req = journeyRequest(request.cacheModel.copy(parties = parties))
 
-            val view = createView()(req)
+            val view = createView(createForm)(req)
             view must containElementWithID("back-link")
             view.getElementById("back-link") must haveHref(
               controllers.declaration.routes.DeclarationHolderRequiredController.displayPage(Mode.Normal)
@@ -116,7 +119,7 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
 
       "cache does NOT contain DeclarationHoldersData.isRequired field" should {
         "display back link to Authorisation Procedure Code Choice page" in {
-          val view = createView()
+          val view = createView(createForm)
           view must containElementWithID("back-link")
           view.getElementById("back-link") must haveHref(
             controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage(Mode.Normal)
@@ -127,7 +130,7 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
 
     onJourney(OCCASIONAL) { implicit request =>
       "display back link to Other Parties page" in {
-        val view = createView()
+        val view = createView(createForm)
         view must containElementWithID("back-link")
         view.getElementById("back-link") must haveHref(controllers.declaration.routes.AdditionalActorsSummaryController.displayPage(Mode.Normal))
       }
@@ -139,7 +142,7 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
           val parties = Parties(isEntryIntoDeclarantsRecords = Yes)
           val req = journeyRequest(request.cacheModel.copy(parties = parties))
 
-          val view = createView()(req)
+          val view = createView(createForm)(req)
           view must containElementWithID("back-link")
           view.getElementById("back-link") must haveHref(
             controllers.declaration.routes.AuthorisationProcedureCodeChoiceController.displayPage(Mode.Normal)
@@ -152,7 +155,7 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
           val parties = Parties(isEntryIntoDeclarantsRecords = No)
           val req = journeyRequest(request.cacheModel.copy(parties = parties))
 
-          val view = createView()(req)
+          val view = createView(createForm)(req)
           view must containElementWithID("back-link")
           view.getElementById("back-link") must haveHref(controllers.declaration.routes.ConsigneeDetailsController.displayPage(Mode.Normal))
         }
@@ -167,11 +170,9 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
        * no point to distinguish them and move to controller test
        */
       "display error for empty Authorisation code" in {
-        val view = createView(
-          DeclarationHolder
-            .form(eori)
-            .fillAndValidate(DeclarationHolder(None, Some(Eori(TestHelper.createRandomAlphanumericString(17))), Some(EoriSource.OtherEori)))
-        )
+        val eori = Eori(createRandomAlphanumericString(17))
+        val declarationHolder = DeclarationHolder(None, Some(eori), Some(OtherEori))
+        val view = createView(createForm.fillAndValidate(declarationHolder))
 
         view must haveGovukGlobalErrorSummary
         view must containErrorElementWithTagAndHref("a", "#authorisationTypeCode")
@@ -180,11 +181,9 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
       }
 
       "display error for incorrect EORI" in {
-        val view = createView(
-          DeclarationHolder
-            .form(eori)
-            .fillAndValidate(DeclarationHolder(Some("ACE"), Some(Eori(TestHelper.createRandomAlphanumericString(18))), Some(EoriSource.OtherEori)))
-        )
+        val eori = Eori(createRandomAlphanumericString(18))
+        val declarationHolder = DeclarationHolder(Some("ACE"), Some(eori), Some(OtherEori))
+        val view = createView(createForm.fillAndValidate(declarationHolder))
 
         view must haveGovukGlobalErrorSummary
         view must containErrorElementWithTagAndHref("a", "#eori")
@@ -193,11 +192,9 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
       }
 
       "display error for both incorrect fields" in {
-        val view = createView(
-          DeclarationHolder
-            .form(eori)
-            .fillAndValidate(DeclarationHolder(None, Some(Eori(TestHelper.createRandomAlphanumericString(18))), Some(EoriSource.OtherEori)))
-        )
+        val eori = Eori(createRandomAlphanumericString(18))
+        val declarationHolder = DeclarationHolder(None, Some(eori), Some(OtherEori))
+        val view = createView(createForm.fillAndValidate(declarationHolder))
 
         view must haveGovukGlobalErrorSummary
 
@@ -213,34 +210,38 @@ class DeclarationHolderAddViewSpec extends UnitViewSpec with CommonMessages with
   "Declaration Holder View when filled" should {
     onEveryDeclarationJourney() { implicit request =>
       "display data in Authorisation Code input only" in {
-        val view = createView(DeclarationHolder.form(eori).fill(DeclarationHolder(Some("test"), None, Some(EoriSource.OtherEori))))
+        val declarationHolder = DeclarationHolder(Some("test"), None, Some(OtherEori))
+        val view = createView(createForm.fill(declarationHolder))
 
         view.getElementById("authorisationTypeCode").attr("value") mustBe "test"
         view.getElementById("eori").attr("value") mustBe empty
       }
 
       "display UserEori checked" in {
-        val view = createView(DeclarationHolder.form(eori).fill(DeclarationHolder(Some("test"), Some(Eori("test1")), Some(EoriSource.UserEori))))
+        val declarationHolder = DeclarationHolder(Some("test"), Some(Eori("test1")), Some(UserEori))
+        val view = createView(createForm.fill(declarationHolder))
 
         view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe true
-        view.getElementById("UserEori").getElementsByAttribute("checked").size() mustBe 1
+        view.getElementById("UserEori").getElementsByAttribute("checked").size mustBe 1
       }
 
       "display OtherEori checked and data is present in EORI input only" in {
-        val view = createView(DeclarationHolder.form(eori).fill(DeclarationHolder(None, Some(Eori("test")), Some(EoriSource.OtherEori))))
+        val declarationHolder = DeclarationHolder(None, Some(Eori("test")), Some(OtherEori))
+        val view = createView(createForm.fill(declarationHolder))
 
         view.getElementById("authorisationTypeCode").attr("value") mustBe empty
         view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe false
-        view.getElementById("OtherEori").getElementsByAttribute("checked").size() mustBe 1
+        view.getElementById("OtherEori").getElementsByAttribute("checked").size mustBe 1
         view.getElementById("eori").attr("value") mustBe "test"
       }
 
       "display data in both inputs" in {
-        val view = createView(DeclarationHolder.form(eori).fill(DeclarationHolder(Some("test"), Some(Eori("test1")), Some(EoriSource.OtherEori))))
+        val declarationHolder = DeclarationHolder(Some("test"), Some(Eori("test1")), Some(OtherEori))
+        val view = createView(createForm.fill(declarationHolder))
 
         view.getElementById("authorisationTypeCode").attr("value") mustBe "test"
         view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe false
-        view.getElementById("OtherEori").getElementsByAttribute("checked").size() mustBe 1
+        view.getElementById("OtherEori").getElementsByAttribute("checked").size mustBe 1
         view.getElementById("eori").attr("value") mustBe "test1"
       }
     }

--- a/test/views/declaration/DeclarationHolderChangeViewSpec.scala
+++ b/test/views/declaration/DeclarationHolderChangeViewSpec.scala
@@ -19,7 +19,7 @@ package views.declaration
 import base.{Injector, TestHelper}
 import base.ExportsTestData.eori
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.Eori
 import forms.declaration.declarationHolder.DeclarationHolder
 import models.Mode

--- a/test/views/declaration/DeclarationHolderEditContentSpec.scala
+++ b/test/views/declaration/DeclarationHolderEditContentSpec.scala
@@ -93,8 +93,10 @@ class DeclarationHolderEditContentSpec extends UnitViewSpec with GivenWhenThen w
 
     val declarationHolderPage = instanceOf[declaration_holder_edit_content]
 
-    def createPartial(implicit request: JourneyRequest[_]): Document =
-      declarationHolderPage(Mode.Normal, DeclarationHolder.form(eori), eori)(request, messages)
+    def createPartial(implicit request: JourneyRequest[_]): Document = {
+      val form = DeclarationHolder.form(eori, request.cacheModel.additionalDeclarationType)
+      declarationHolderPage(Mode.Normal, form, eori)(request, messages)
+    }
 
     "display the expected body (the text under page's H1)" when {
 
@@ -224,7 +226,7 @@ class DeclarationHolderEditContentSpec extends UnitViewSpec with GivenWhenThen w
       ) { implicit request =>
         And("the Procedure Code is 1007")
 
-        val insetText = createPartial.getElementsByClass(insetId).get(0).children()
+        val insetText = createPartial.getElementsByClass(insetId).get(0).children
         insetText.get(0).text mustBe messages(s"$prefix.authCode.inset.special.title")
 
         val list = insetText.get(1).child(0)
@@ -245,7 +247,7 @@ class DeclarationHolderEditContentSpec extends UnitViewSpec with GivenWhenThen w
       def verifyInsetTextForExciseRemovals(implicit request: JourneyRequest[_]): Assertion = {
         And("the Procedure Code is 1007")
 
-        val insetText = createPartial.getElementsByClass(insetId).get(0).children()
+        val insetText = createPartial.getElementsByClass(insetId).get(0).children
         insetText.get(0).text mustBe messages(s"$prefix.authCode.inset.excise.title")
 
         val list = insetText.get(1).child(0)

--- a/test/views/declaration/DepartureTransportViewSpec.scala
+++ b/test/views/declaration/DepartureTransportViewSpec.scala
@@ -20,7 +20,7 @@ import java.util.UUID
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.declaration.DepartureTransport
 import forms.declaration.TransportCodes._
 import models.DeclarationType._

--- a/test/views/declaration/EntryIntoDeclarantsRecordsViewSpec.scala
+++ b/test/views/declaration/EntryIntoDeclarantsRecordsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.{No, Yes, YesNoAnswers}
 import forms.declaration.EntryIntoDeclarantsRecords

--- a/test/views/declaration/ExporterDetailsViewSpec.scala
+++ b/test/views/declaration/ExporterDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.{Address, AddressSpec}
 import forms.declaration.EntityDetails
 import forms.declaration.exporter.ExporterDetails

--- a/test/views/declaration/IsExsViewSpec.scala
+++ b/test/views/declaration/IsExsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{DeclarantIsExporter, IsExs}
 import models.Mode

--- a/test/views/declaration/PersonPresentingGoodsDetailsViewSpec.scala
+++ b/test/views/declaration/PersonPresentingGoodsDetailsViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.common.Eori
 import forms.declaration.PersonPresentingGoodsDetails
 import models.{DeclarationType, Mode}

--- a/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
+++ b/test/views/declaration/TransportLeavingTheBorderViewSpec.scala
@@ -18,7 +18,7 @@ package views.declaration
 
 import base.Injector
 import controllers.declaration.routes
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.declaration.TransportLeavingTheBorder
 import models.DeclarationType._
 import models.Mode

--- a/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
+++ b/test/views/declaration/destinationCountries/OriginationCountryViewSpec.scala
@@ -18,7 +18,6 @@ package views.declaration.destinationCountries
 
 import base.Injector
 import controllers.declaration.routes
-import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.countries.Countries.OriginationCountryPage
 import forms.declaration.countries.{Countries, Country}

--- a/test/views/declaration/fiscalInformation/AdditionalFiscalReferencesAddViewSpec.scala
+++ b/test/views/declaration/fiscalInformation/AdditionalFiscalReferencesAddViewSpec.scala
@@ -17,7 +17,7 @@
 package views.declaration.fiscalInformation
 
 import base.Injector
-import controllers.util.{SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{SaveAndContinue, SaveAndReturn}
 import forms.declaration.AdditionalFiscalReference
 import models.DeclarationType._
 import models.Mode

--- a/test/views/declaration/fiscalInformation/AdditionalFiscalReferencesViewSpec.scala
+++ b/test/views/declaration/fiscalInformation/AdditionalFiscalReferencesViewSpec.scala
@@ -17,7 +17,7 @@
 package views.declaration.fiscalInformation
 
 import base.Injector
-import controllers.util.{SaveAndContinue, SaveAndReturn}
+import controllers.helpers.{SaveAndContinue, SaveAndReturn}
 import forms.common.YesNoAnswer
 import forms.declaration.AdditionalFiscalReference
 import models.Mode

--- a/test/views/declaration/fiscalInformation/FiscalInformationViewSpec.scala
+++ b/test/views/declaration/fiscalInformation/FiscalInformationViewSpec.scala
@@ -17,7 +17,7 @@
 package views.declaration.fiscalInformation
 
 import base.Injector
-import controllers.util.SaveAndReturn
+import controllers.helpers.SaveAndReturn
 import forms.declaration.FiscalInformation
 import models.Mode
 import models.requests.JourneyRequest


### PR DESCRIPTION
1st commit is just renaming package `controllers.util` to `controllers.helpers` for uniformity with `views.helpers`

2nd commit adds a new validation check (EXRR authorisation code with pre-lodged decls is not allowed) to the page at  `/add-authorisation-required`