### PR TITLE
BAU-Fix_error_link_not_going_to_supervising_customs_office_page

### DIFF
--- a/app/views/helpers/PointerHelper.scala
+++ b/app/views/helpers/PointerHelper.scala
@@ -158,7 +158,7 @@ object PointerHelper extends Logging {
     "declaration.previousDocuments.$.goodsItemIdentifier" -> routes.PreviousDocumentsSummaryController.displayPage, //?? PreviousDocumentsChangeController.displayPage
     "declaration.locations.warehouseIdentification.identificationNumber" -> routes.WarehouseIdentificationController.displayPage,
     "declaration.locations.warehouseIdentification.identificationType" -> routes.WarehouseIdentificationController.displayPage,
-    "declaration.locations.warehouseIdentification.supervisingCustomsOffice" -> routes.WarehouseIdentificationController.displayPage,
+    "declaration.locations.warehouseIdentification.supervisingCustomsOffice" -> routes.SupervisingCustomsOfficeController.displayPage,
     "declaration.consignmentReferences.ucr" -> routes.ConsignmentReferencesController.displayPage
   )
 }


### PR DESCRIPTION
Instead of pointing to /supervising-customs-office it was mistakenly
mapped to /warehouse-details as part of moving the urls from the BE
to the FE.