### PR TITLE
CEDS-3553 Non-consecutive blanks now accepted for 'Document reference' on page at '/add-previous-document'

### DIFF
--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -44,14 +44,15 @@ object Document extends DeclarationPage {
 
   private def documentReferenceMapping: (String, Mapping[String]) =
     "documentReference" -> text()
+      .transform(_.trim, (s: String) => s)
       .verifying("declaration.previousDocuments.documentReference.empty", nonEmpty)
-      .verifying(
-        "declaration.previousDocuments.documentReference.error",
-        isEmpty or (isAlphanumericWithSpecialCharacters(Set('-', '/', ':')) and noLongerThan(35))
-      )
+      .verifying("declaration.previousDocuments.documentReference.error", isEmpty or isAlphanumericWithSpecialCharacters(Set(' ', '-', '/', ':')))
+      .verifying("declaration.previousDocuments.documentReference.error.spaces", isEmpty or notContainsConsecutiveSpaces)
+      .verifying("declaration.previousDocuments.documentReference.error.length", isEmpty or noLongerThan(35))
 
   private def goodsIdentifierMapping: (String, Mapping[Option[String]]) =
-    "goodsItemIdentifier" -> optional(text.verifying("declaration.previousDocuments.goodsItemIdentifier.error", isNumeric and noLongerThan(3)))
+    "goodsItemIdentifier" ->
+      optional(text.verifying("declaration.previousDocuments.goodsItemIdentifier.error", isNumeric and noLongerThan(3)))
 
   override def defineTariffContentKeys(decType: DeclarationType): Seq[TariffContentKey] =
     Seq(TariffContentKey(s"tariff.declaration.addPreviousDocument.${DeclarationPage.getJourneyTypeSpecialisation(decType)}"))

--- a/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
+++ b/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
@@ -64,6 +64,7 @@ object AdditionalDocument extends DeclarationPage {
   val issuingAuthorityNameKey = "issuingAuthorityName"
   val dateOfValidityKey = "dateOfValidity"
 
+  // scalastyle:off
   private def mapping(cacheModel: ExportsDeclaration): Mapping[AdditionalDocument] = {
     val keyWhenDocumentTypeCodeEmpty =
       if (cacheModel.isAuthCodeRequiringAdditionalDocuments) "declaration.additionalDocument.documentTypeCode.empty.fromAuthCode"
@@ -117,6 +118,7 @@ object AdditionalDocument extends DeclarationPage {
         documentWriteOffKey -> optional(DocumentWriteOff.mapping)
       )(form2data)(AdditionalDocument.unapply)
   }
+  // scalastyle:on
 
   private def form2data(
     documentTypeCode: Option[String],

--- a/app/utils/validators/forms/FieldValidator.scala
+++ b/app/utils/validators/forms/FieldValidator.scala
@@ -116,6 +116,8 @@ object FieldValidator {
 
   val containsNotOnlyZeros: String => Boolean = (input: String) => input.isEmpty || input.exists(char => char != '0')
 
+  val notContainsConsecutiveSpaces: String => Boolean = (input: String) => !input.contains("  ")
+
   val isTailNumeric: String => Boolean = (input: String) =>
     Try(input.tail) match {
       case Success(value) => isNumeric(value)

--- a/app/views/helpers/PreviousDocumentsHelper.scala
+++ b/app/views/helpers/PreviousDocumentsHelper.scala
@@ -72,9 +72,9 @@ class PreviousDocumentsHelper @Inject()(
     versionSelection match {
       case 1 => paragraph("v1.documentReference.body")
       case 2 => paragraph("v2.documentReference.body")
-      case 3 => new Html(List(paragraph("v3.documentReference.body"), hint("v3.documentReference.hint")))
-      case 4 => new Html(List(paragraph("v4.documentReference.body"), hint("v4.documentReference.hint")))
-      case 5 => new Html(List(paragraph("v5.documentReference.body"), hint("v5.documentReference.hint")))
+      case 3 => new Html(List(paragraph("v3.documentReference.body"), hint("documentReference.hint")))
+      case 4 => new Html(List(paragraph("v4.documentReference.body"), hint("documentReference.hint")))
+      case 5 => new Html(List(paragraph("v5.documentReference.body"), hint("documentReference.hint")))
       case 6 => paragraph("v6.documentReference.body")
     }
 

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1424,13 +1424,13 @@ declaration.previousDocuments.documentReference = Document reference
 declaration.previousDocuments.v1.documentReference.body = Enter the unique invoice number or packing reference printed on the document.
 declaration.previousDocuments.v2.documentReference.body = For excise, enter the excise guarantee reference or the stock reference number, as required.
 declaration.previousDocuments.v3.documentReference.body = For special procedures, enter the excise guarantee reference or the movement reference number of the previous declaration, as required.
-declaration.previousDocuments.v3.documentReference.hint = Enter the invoice or other reference using letters, numbers and standard alternative characters, but no spaces. For example, SMITH-321/890.
 declaration.previousDocuments.v4.documentReference.body = Enter a reference.
-declaration.previousDocuments.v4.documentReference.hint = For example, the unique invoice number or packing reference printed on the document.
 declaration.previousDocuments.v5.documentReference.body = Enter a reference.
-declaration.previousDocuments.v5.documentReference.hint = For example, the unique invoice number or packing reference printed on the document.
 declaration.previousDocuments.v6.documentReference.body = Enter the unique invoice number or packing reference printed on the document.
-declaration.previousDocuments.documentReference.error = The document reference must be 35 characters or fewer
+declaration.previousDocuments.documentReference.hint = You can use letters, numbers, spaces and standard alternative characters. For example, SMITH 321/890.
+declaration.previousDocuments.documentReference.error = Document reference must contain only letters, numbers, hyphens and forward slash
+declaration.previousDocuments.documentReference.error.length = The document reference must be 35 characters or fewer
+declaration.previousDocuments.documentReference.error.spaces = Document reference must not contain double spaces
 declaration.previousDocuments.documentReference.empty = Enter a document reference
 
 declaration.previousDocuments.goodsItemIdentifier = Item number

--- a/test/views/declaration/previousDocuments/PreviousDocumentsViewSpec.scala
+++ b/test/views/declaration/previousDocuments/PreviousDocumentsViewSpec.scala
@@ -333,7 +333,7 @@ class PreviousDocumentsViewSpec extends UnitViewSpec with ExportsTestData with I
 
       if (version >= 3 && version <= 5) {
         val hintHelp = bodyHelp.nextElementSibling
-        hintHelp.text mustBe messages(s"declaration.previousDocuments.v$version.documentReference.hint")
+        hintHelp.text mustBe messages("declaration.previousDocuments.documentReference.hint")
       }
 
       view.getElementById("documentReference").attr("value") mustBe empty


### PR DESCRIPTION
In addition, `hint` is now unified for versions 3-5.