### PR TITLE
[CEDS-3614] Skip conditionality for C21 FTI and postal

### DIFF
--- a/app/controllers/helpers/SupervisingCustomsOfficeHelper.scala
+++ b/app/controllers/helpers/SupervisingCustomsOfficeHelper.scala
@@ -17,6 +17,7 @@
 package controllers.helpers
 
 import controllers.declaration.routes
+import forms.declaration.ModeOfTransportCode.{FixedTransportInstallations, PostalConsignment}
 import models.codes.AdditionalProcedureCode.NO_APC_APPLIES_CODE
 import models.declaration.ProcedureCodesData
 import models.requests.JourneyRequest
@@ -45,6 +46,12 @@ object SupervisingCustomsOfficeHelper {
     request.declarationType match {
       case DeclarationType.SUPPLEMENTARY | DeclarationType.STANDARD => routes.InlandTransportDetailsController.displayPage
       case DeclarationType.SIMPLIFIED | DeclarationType.OCCASIONAL  => routes.ExpressConsignmentController.displayPage
-      case DeclarationType.CLEARANCE                                => routes.DepartureTransportController.displayPage
+      case DeclarationType.CLEARANCE                                => dependsOnTransportLeavingTheBoarder
+    }
+
+  private def dependsOnTransportLeavingTheBoarder(implicit request: JourneyRequest[_]): Mode => Call =
+    request.cacheModel.transportLeavingBoarderCode match {
+      case Some(FixedTransportInstallations) | Some(PostalConsignment) => routes.ExpressConsignmentController.displayPage
+      case _                                                           => routes.DepartureTransportController.displayPage
     }
 }

--- a/app/models/ExportsDeclaration.scala
+++ b/app/models/ExportsDeclaration.scala
@@ -55,6 +55,7 @@ case class ExportsDeclaration(
   def lrn: Option[String] = consignmentReferences.map(_.lrn.value)
   def ducr: Option[String] = consignmentReferences.map(_.ducr.ducr)
   def inlandModeOfTransportCode: Option[ModeOfTransportCode] = locations.inlandModeOfTransportCode.flatMap(_.inlandModeOfTransportCode)
+  def transportLeavingBoarderCode: Option[ModeOfTransportCode] = transport.borderModeOfTransportCode.flatMap(_.code)
 
   def additionalDocumentsIfAny(itemId: String): Option[AdditionalDocuments] =
     itemBy(itemId).flatMap(_.additionalDocuments)

--- a/docs/Customs Declare Exports AutoComplete.js
+++ b/docs/Customs Declare Exports AutoComplete.js
@@ -196,18 +196,19 @@ function declarationChoice(){
             case 'C':
                 selectRadioOptionFromInputs(inputs, 1);
                 break;
+            case 'K':
+            case 'J':
+                selectRadioOptionFromInputs(inputs, 2);
+                break;
             case 'Y':
             case 'Z':
-                selectRadioOptionFromInputs(inputs, 2);
+                selectRadioOptionFromInputs(inputs, 3);
                 break;
             case 'E':
             case 'B':
-                selectRadioOptionFromInputs(inputs, 3);
-                break;
-            case 'K':
-            case 'J':
                 selectRadioOptionFromInputs(inputs, 4);
                 break;
+
         }
         document.getElementById('submit').click()
     }
@@ -1010,7 +1011,6 @@ function addDocuments(){
                 break;
             case 'E':
             case 'K':
-                document.getElementById('submit').click();
             default:
                 document.getElementById('documentTypeCode').value ='C501';
                 document.getElementById('documentIdentifier').value ='GBAEOC717572504502801';

--- a/test/controllers/UnverifiedEmailControllerSpec.scala
+++ b/test/controllers/UnverifiedEmailControllerSpec.scala
@@ -19,7 +19,7 @@ package controllers
 import base.ControllerWithoutFormSpec
 import config.AppConfig
 import org.mockito.ArgumentMatchers.any
-import org.mockito.Mockito.{reset, when}
+import org.mockito.Mockito.when
 import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.{undeliverable_email, unverified_email}

--- a/test/services/cache/ExportsDeclarationBuilder.scala
+++ b/test/services/cache/ExportsDeclarationBuilder.scala
@@ -297,17 +297,19 @@ trait ExportsDeclarationBuilder {
     )
   }
 
-  def withoutBorderModeOfTransportCode(): ExportsDeclarationModifier = declaration => {
-    declaration.copy(transport = declaration.transport.copy(borderModeOfTransportCode = None))
-  }
+  def withBorderModeOfTransportCode(maybeModeOfTransportCode: Option[ModeOfTransportCode]): ExportsDeclarationModifier =
+    declaration =>
+      declaration.copy(transport = declaration.transport.copy(borderModeOfTransportCode = Some(TransportLeavingTheBorder(maybeModeOfTransportCode))))
 
-  def withoutMeansOfTransportOnDepartureType(): ExportsDeclarationModifier = declaration => {
-    declaration.copy(transport = declaration.transport.copy(meansOfTransportOnDepartureType = None, meansOfTransportOnDepartureIDNumber = None))
-  }
+  def withoutBorderModeOfTransportCode(): ExportsDeclarationModifier =
+    declaration => declaration.copy(transport = declaration.transport.copy(borderModeOfTransportCode = None))
 
-  def withoutTransportPayment(): ExportsDeclarationModifier = declaration => {
-    declaration.copy(transport = declaration.transport.copy(expressConsignment = No, transportPayment = None))
-  }
+  def withoutMeansOfTransportOnDepartureType(): ExportsDeclarationModifier =
+    declaration =>
+      declaration.copy(transport = declaration.transport.copy(meansOfTransportOnDepartureType = None, meansOfTransportOnDepartureIDNumber = None))
+
+  def withoutTransportPayment(): ExportsDeclarationModifier =
+    declaration => declaration.copy(transport = declaration.transport.copy(expressConsignment = No, transportPayment = None))
 
   def withBorderTransport(details: BorderTransport): ExportsDeclarationModifier = declaration => {
     declaration.copy(


### PR DESCRIPTION
Skip the /departure-transport page if user enters
'Fixed transport installation' OR 'Postal'
on /transport-leaving-the-border page.

Also fixing the AutoComplete.js for dec type choice page.