### PR TITLE
CEDS-3650 Add config to stop asset request auditing

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -143,6 +143,13 @@ auditing {
   }
 }
 
+controllers {
+  # Avoid auditing requests for static assets to meet splunk storage requirements  
+  controllers.Assets.needsAuditing = false   
+  uk.gov.hmrc.govukfrontend.controllers.Assets.needsAuditing = false  
+  uk.gov.hmrc.hmrcfrontend.controllers.Assets.needsAuditing = false
+}
+
 google-analytics {
   token = N/A
   host = auto


### PR DESCRIPTION
To meet splunk storage requirements.