### PR TITLE
[CEDS-3628] Prevent user in TDR from trying to register for CDS

### DIFF
--- a/app/config/featureFlags/TdrUnauthorisedMsgConfig.scala
+++ b/app/config/featureFlags/TdrUnauthorisedMsgConfig.scala
@@ -14,20 +14,15 @@
  * limitations under the License.
  */
 
-package features
+package config.featureFlags
 
-import play.api.mvc.PathBindable
+import features.Feature
+import play.api.Configuration
 
-object Feature extends Enumeration {
-  type Feature = Value
-  val betaBanner, default, ead, sfus, secureMessagingInbox, googleFormFeedbackLink, queryNotificationMessage, commodities, tdrUnauthorisedMessage =
-    Value
+import javax.inject.{Inject, Singleton}
 
-  implicit object FeaturePathStringBinder
-      extends PathBindable.Parsing[Feature.Feature](
-        withName,
-        _.toString,
-        (k: String, e: Exception) => "Cannot parse %s as Feature: %s".format(k, e.getMessage)
-      )
+@Singleton
+class TdrUnauthorisedMsgConfig @Inject()(featureSwitchConfig: FeatureSwitchConfig, config: Configuration) {
 
+  val isTdrUnauthorisedMessageEnabled: Boolean = featureSwitchConfig.isFeatureOn(Feature.tdrUnauthorisedMessage)
 }

--- a/app/views/unauthorised.scala.html
+++ b/app/views/unauthorised.scala.html
@@ -17,6 +17,7 @@
 @import config.ExternalServicesConfig
 @import views.helpers.Title
 @import views.html.components.gds._
+@import config.featureFlags.TdrUnauthorisedMsgConfig
 
 @this(
     govukLayout: gdsMainTemplate,
@@ -24,37 +25,51 @@
     paragraphBody: paragraphBody,
     link: link,
     bulletList: bulletList,
-    config: ExternalServicesConfig
+    config: ExternalServicesConfig,
+    tdrUnauthorisedMsgConfig: TdrUnauthorisedMsgConfig
 )
 
 @()(implicit request: Request[_], messages: Messages)
 
-@howToSection = {
-    @paragraphBody(messages("unauthorised.paragraph.1"))
+@if(tdrUnauthorisedMsgConfig.isTdrUnauthorisedMessageEnabled) {
+    @govukLayout(title = Title("unauthorised.tdr.heading")) {
+        @pageTitle(messages("unauthorised.tdr.heading"))
 
-    @bulletList(List(
-      Html(messages("unauthorised.paragraph.1.bullet.1", link(
-        id = Some("get_eori_link"),
-        text = messages("unauthorised.paragraph.1.bullet.1.link"),
-        call = Call("GET", config.eoriService)
-      ))),
-      link(
-        id = Some("access_cds_link"),
-        text = messages("unauthorised.paragraph.1.bullet.2.link"),
-        call = Call("GET", config.cdsRegister)
-      )
-    ))
-}
+        @paragraphBody(messages("unauthorised.tdr.body",
+            link(
+                id = Some("contact_support_link"),
+                text = messages("unauthorised.tdr.body.link"),
+                call = Call("GET", s"mailto:${messages("unauthorised.tdr.body.link")}"),
+                target="_blank"
+            ))
+        )
+    }
+} else {
+    @govukLayout(title = Title("unauthorised.heading")) {
+        @pageTitle(messages("unauthorised.heading"))
 
-@govukLayout(title = Title("unauthorised.heading")) {
+        @paragraphBody(messages("unauthorised.paragraph.1"))
 
-    @pageTitle(messages("unauthorised.heading"))
+        @bulletList(List(
+            Html(
+                messages("unauthorised.paragraph.1.bullet.1",
+                    link(
+                        id = Some("get_eori_link"),
+                        text = messages("unauthorised.paragraph.1.bullet.1.link"),
+                        call = Call("GET", config.eoriService)
+                ))
+            ),
+            link(
+                id = Some("access_cds_link"),
+                text = messages("unauthorised.paragraph.1.bullet.2.link"),
+                call = Call("GET", config.cdsRegister)
+            )
+        ))
 
-    @howToSection
-
-    @paragraphBody(messages("unauthorised.paragraph.2", link(
-        id = Some("check_cds_application_status_link"),
-        text = messages("unauthorised.paragraph.2.link"),
-        call = Call("GET", config.cdsCheckStatus)
-    )))
+        @paragraphBody(messages("unauthorised.paragraph.2", link(
+            id = Some("check_cds_application_status_link"),
+            text = messages("unauthorised.paragraph.2.link"),
+            call = Call("GET", config.cdsCheckStatus)
+        )))
+    }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -114,6 +114,7 @@ microservice {
       use-improved-error-messages = true
       welsh-translation = false
       commodities = disabled
+      tdrUnauthorisedMessage = disabled
     }
   }
 }

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -63,6 +63,10 @@ unauthorised.paragraph.1.bullet.2.link = get access to the Customs Declaration S
 unauthorised.paragraph.2 = If you’ve already applied for an EORI number, you can {0}.
 unauthorised.paragraph.2.link = check the status of your application
 
+unauthorised.tdr.heading = The EORI you entered is not yet valid on the CDS test service
+unauthorised.tdr.body = Please contact {0} to ensure access has been set up for your EORI number.
+unauthorised.tdr.body.link = cdsexportsuiteam@hmrc.gov.uk
+
 dateTime.date.day.error.empty = The date must include a day
 dateTime.date.month.error.empty = The date must include a month
 dateTime.date.year.error.empty = The date must include a year

--- a/test/config/featureFlags/TdrUnauthorisedMsgConfigSpec.scala
+++ b/test/config/featureFlags/TdrUnauthorisedMsgConfigSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2021 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package config.featureFlags
+
+import base.UnitWithMocksSpec
+import com.typesafe.config.ConfigFactory
+import features.Feature
+import play.api.Configuration
+
+class TdrUnauthorisedMsgConfigSpec extends UnitWithMocksSpec {
+
+  private def buildTdrConfig(enabled: Boolean = false, key: Feature.Value = Feature.tdrUnauthorisedMessage) = {
+    val config = Configuration(ConfigFactory.parseString(s"""
+        |microservice.services.features.default=disabled
+        |microservice.services.features.${key}=${asConfigVal(enabled)}
+      """.stripMargin))
+
+    new TdrUnauthorisedMsgConfig(new FeatureSwitchConfig(config), config)
+  }
+
+  private def asConfigVal(bool: Boolean): String = if (bool) "enabled" else "disabled"
+
+  "TdrUnauthorisedMsgConfig on isTdrUnauthorisedMessageEnabled" should {
+
+    "return true" when {
+      "tdrUnauthorisedMsg feature is enabled" in {
+        buildTdrConfig(true).isTdrUnauthorisedMessageEnabled mustBe true
+      }
+    }
+
+    "return false" when {
+      "tdrUnauthorisedMsg feature is disabled" in {
+        buildTdrConfig().isTdrUnauthorisedMessageEnabled mustBe false
+      }
+
+      "tdrUnauthorisedMsg feature config key doesn't exist" in {
+        buildTdrConfig(true, Feature.betaBanner).isTdrUnauthorisedMessageEnabled mustBe false
+      }
+    }
+  }
+}

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -18,8 +18,8 @@ package controllers
 
 import base.ControllerWithoutFormSpec
 import base.ExportsTestData._
-import config.AppConfig
 import config.featureFlags.SecureMessagingInboxConfig
+import config.AppConfig
 import forms.Choice
 import forms.Choice.AllowedChoiceValues._
 import models.DeclarationType
@@ -39,8 +39,8 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues {
   import ChoiceControllerSpec._
 
   val choicePage = mock[choice_page]
-  val appConfig = mock[AppConfig]
   val secureMessagingInboxConfig = mock[SecureMessagingInboxConfig]
+  override val appConfig = mock[AppConfig]
 
   val controller =
     new ChoiceController(

--- a/test/controllers/declaration/SummaryControllerSpec.scala
+++ b/test/controllers/declaration/SummaryControllerSpec.scala
@@ -16,15 +16,12 @@
 
 package controllers.declaration
 
-import scala.concurrent.{ExecutionContext, Future}
-
 import base.ControllerWithoutFormSpec
-import config.AppConfig
 import forms.declaration.LegalDeclaration
 import mock.ErrorHandlerMocks
+import models.{ExportsDeclaration, Mode}
 import models.declaration.submissions.Submission
 import models.requests.ExportsSessionKeys
-import models.{ExportsDeclaration, Mode}
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, times, verify, when}
 import org.scalatest.OptionValues
@@ -34,6 +31,8 @@ import services.SubmissionService
 import uk.gov.hmrc.http.HeaderCarrier
 import views.html.declaration.summary._
 
+import scala.concurrent.{ExecutionContext, Future}
+
 class SummaryControllerSpec extends ControllerWithoutFormSpec with ErrorHandlerMocks with OptionValues {
 
   private val normalSummaryPage = mock[normal_summary_page]
@@ -41,7 +40,6 @@ class SummaryControllerSpec extends ControllerWithoutFormSpec with ErrorHandlerM
   private val amendSummaryPage = mock[amend_summary_page]
   private val mockSummaryPageNoData = mock[summary_page_no_data]
   private val mockSubmissionService = mock[SubmissionService]
-  private val appConfig = mock[AppConfig]
 
   private val controller = new SummaryController(
     mockAuthAction,

--- a/test/views/UnauthorisedViewSpec.scala
+++ b/test/views/UnauthorisedViewSpec.scala
@@ -16,7 +16,11 @@
 
 package views
 
-import base.Injector
+import base.{Injector, OverridableInjector}
+import config.featureFlags.TdrUnauthorisedMsgConfig
+import org.mockito.Mockito.{reset, when}
+import org.scalatest.BeforeAndAfterEach
+import play.api.inject.bind
 import play.twirl.api.Html
 import tools.Stubs
 import views.declaration.spec.UnitViewSpec
@@ -24,39 +28,71 @@ import views.html.unauthorised
 import views.tags.ViewTest
 
 @ViewTest
-class UnauthorisedViewSpec extends UnitViewSpec with Stubs with Injector {
+class UnauthorisedViewSpec extends UnitViewSpec with Stubs with Injector with BeforeAndAfterEach {
 
-  private val unauthorisedPage = instanceOf[unauthorised]
-  private def view: Html = unauthorisedPage()(request, messages)
+  val tdrUnauthorisedMsgConfig = mock[TdrUnauthorisedMsgConfig]
 
-  "Unauthorised Page view" should {
+  override def beforeEach(): Unit = {
+    super.beforeEach()
+    reset(tdrUnauthorisedMsgConfig)
+  }
 
-    "display page header" in {
-      view.getElementsByTag("h1").first() must containMessage("unauthorised.heading")
+  val injector = new OverridableInjector(bind[TdrUnauthorisedMsgConfig].toInstance(tdrUnauthorisedMsgConfig))
+  val unauthorisedPage = injector.instanceOf[unauthorised]
+
+  "Unauthorised Page view" when {
+    val view: Html = getUnauthorisedPageView(false)
+
+    "TdrUnauthorisedMessage is Disabled" should {
+      "display page header" in {
+        view.getElementsByTag("h1").first() must containMessage("unauthorised.heading")
+      }
+
+      "display get EORI link" in {
+        val link = view.getElementById("get_eori_link")
+
+        link must containMessage("unauthorised.paragraph.1.bullet.1.link")
+        link must haveHref("https://www.gov.uk/eori")
+        link.attr("target") mustBe "_self"
+      }
+
+      "display access CDS link" in {
+        val link = view.getElementById("access_cds_link")
+
+        link must containMessage("unauthorised.paragraph.1.bullet.2.link")
+        link must haveHref("https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service")
+        link.attr("target") mustBe "_self"
+      }
+
+      "display check CDS application status link" in {
+        val link = view.getElementById("check_cds_application_status_link")
+
+        link must containMessage("unauthorised.paragraph.2.link")
+        link must haveHref("https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk")
+        link.attr("target") mustBe "_self"
+      }
     }
 
-    "display get EORI link" in {
-      val link = view.getElementById("get_eori_link")
+    "TdrUnauthorisedMessage is Enabled" should {
+      "display page header" in {
+        val view: Html = getUnauthorisedPageView(true)
 
-      link must containMessage("unauthorised.paragraph.1.bullet.1.link")
-      link must haveHref("https://www.gov.uk/eori")
-      link.attr("target") mustBe "_self"
+        view.getElementsByTag("h1").first() must containMessage("unauthorised.tdr.heading")
+      }
+
+      "display contact email address link" in {
+        val view: Html = getUnauthorisedPageView(true)
+        val link = view.getElementById("contact_support_link")
+
+        link must containMessage("unauthorised.tdr.body.link")
+        link must haveHref(s"mailto:${messages("unauthorised.tdr.body.link")}")
+        link.attr("target") mustBe "_blank"
+      }
     }
+  }
 
-    "display access CDS link" in {
-      val link = view.getElementById("access_cds_link")
-
-      link must containMessage("unauthorised.paragraph.1.bullet.2.link")
-      link must haveHref("https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service")
-      link.attr("target") mustBe "_self"
-    }
-
-    "display check CDS application status link" in {
-      val link = view.getElementById("check_cds_application_status_link")
-
-      link must containMessage("unauthorised.paragraph.2.link")
-      link must haveHref("https://www.tax.service.gov.uk/customs/register-for-cds/are-you-based-in-uk")
-      link.attr("target") mustBe "_self"
-    }
+  private def getUnauthorisedPageView(tdrEnabled: Boolean) = {
+    when(tdrUnauthorisedMsgConfig.isTdrUnauthorisedMessageEnabled).thenReturn(tdrEnabled)
+    unauthorisedPage()(request, messages)
   }
 }

--- a/test/views/declaration/ExpressConsignmentViewSpec.scala
+++ b/test/views/declaration/ExpressConsignmentViewSpec.scala
@@ -20,7 +20,7 @@ import base.{Injector, MockAuthAction}
 import controllers.declaration.routes
 import controllers.helpers.SupervisingCustomsOfficeHelperSpec.skipDepartureTransportPageCodes
 import forms.common.YesNoAnswer
-import forms.declaration.ModeOfTransportCode.{meaningfulModeOfTransportCodes, FixedTransportInstallations, PostalConsignment}
+import forms.declaration.ModeOfTransportCode.meaningfulModeOfTransportCodes
 import models.DeclarationType._
 import models.Mode
 import models.declaration.{ExportItem, ProcedureCodesData}

--- a/test/views/declaration/confirmation/ConfirmationViewSpec.scala
+++ b/test/views/declaration/confirmation/ConfirmationViewSpec.scala
@@ -17,9 +17,7 @@
 package views.declaration.confirmation
 
 import java.time.ZonedDateTime
-
 import base.{Injector, MockAuthAction}
-import config.AppConfig
 import controllers.routes.{DeclarationDetailsController, SubmissionsController}
 import models.declaration.notifications.Notification
 import models.declaration.submissions.SubmissionStatus.{ACCEPTED, ADDITIONAL_DOCUMENTS_REQUIRED, QUERY_NOTIFICATION_MESSAGE, RECEIVED}
@@ -34,9 +32,7 @@ import views.tags.ViewTest
 @ViewTest
 class ConfirmationViewSpec extends UnitViewSpec with GivenWhenThen with Injector with MockAuthAction {
 
-  private val appConfig = instanceOf[AppConfig]
   private val page = instanceOf[confirmation_page]
-
   private val defaultDucr = "ducr"
   private val defaultLrn = "lrn"
   private val submissionId = "submissionId"


### PR DESCRIPTION
Also prevent users who are not logged in from hitting an Exports page
and causing an ERROR level log output (that triggers PagerDuty alerts).