### PR TITLE
CEDS-3577 Add error message for Y999 doc code

### DIFF
--- a/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
+++ b/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
@@ -73,6 +73,7 @@ object AdditionalDocument extends DeclarationPage {
     val documentTypeCodeRequired = optional(
       text()
         .verifying(keyWhenDocumentTypeCodeEmpty, nonEmpty)
+        .verifying("declaration.additionalDocument.documentTypeCode.Y999.error", f => isEmpty(f) or !documentCodesNotAcceptable.contains(f))
         .verifying("declaration.additionalDocument.documentTypeCode.error", isEmpty or (hasSpecificLength(4) and isAlphanumeric))
     ).verifying(keyWhenDocumentTypeCodeEmpty, isPresent)
 
@@ -233,7 +234,8 @@ object AdditionalDocument extends DeclarationPage {
     "Y968",
     "Y969",
     "Y970",
-    "Y971",
-    "Y999"
+    "Y971"
   )
+
+  val documentCodesNotAcceptable = Seq("Y999")
 }

--- a/app/views/components/gds/errorSummary.scala.html
+++ b/app/views/components/gds/errorSummary.scala.html
@@ -23,8 +23,8 @@
 @errorList = @{errors.map { error =>
     val errorKey = error.key.replace(".", "_").replace('[', '_').replace("]", "")
     ErrorLink(
-        href = Some(s"#${errorFieldName.getOrElse(errorKey)}"),
-        content = Text(messages(error.message, error.args: _*))
+      href = Some(s"#${errorFieldName.getOrElse(errorKey)}"),
+      content = HtmlContent(messages(error.message, error.args: _*))
     )
 }}
 

--- a/app/views/helpers/InputTextHelper.scala
+++ b/app/views/helpers/InputTextHelper.scala
@@ -20,7 +20,7 @@ import javax.inject.Singleton
 import play.api.data.Field
 import play.api.i18n.Messages
 import uk.gov.hmrc.govukfrontend.views.Aliases.ErrorMessage
-import uk.gov.hmrc.govukfrontend.views.viewmodels.content.Text
+import uk.gov.hmrc.govukfrontend.views.viewmodels.content.{HtmlContent, Text}
 import uk.gov.hmrc.govukfrontend.views.viewmodels.label.Label
 
 @Singleton
@@ -31,7 +31,7 @@ class InputTextHelper {
     else Label(content = Text(messages(labelKey, labelArg)), classes = labelClasses)
 
   def getAnyErrorMessages(field: Field)(implicit messages: Messages): Option[ErrorMessage] =
-    field.error.map(err => ErrorMessage(content = Text(messages(err.message))))
+    field.error.map(err => ErrorMessage(content = HtmlContent(messages(err.message))))
 
   def defineInputClasses(defaultInputClasses: String, inputClasses: Option[String]): String =
     inputClasses.map(clazz => s" $clazz").getOrElse(defaultInputClasses)

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -1088,6 +1088,7 @@ declaration.additionalDocument.documentTypeCode.expander.paragraph3.text = Colum
 declaration.additionalDocument.documentTypeCode.empty = Enter the document code required for your additional document
 declaration.additionalDocument.documentTypeCode.empty.fromAuthCode = Enter a document code and authorisation number to show the EORI you entered in section 3 is the holder of this authorisation
 declaration.additionalDocument.documentTypeCode.error = Document code must be in the correct format
+declaration.additionalDocument.documentTypeCode.Y999.error = Y999 is not currently accepted by CDS. Replace Y999 with the document code listed in the Trade Tariff for your commodity for the licence you are waiving. For example X002, 9106, 9104<br><br>Leave document identifier field blank, to indicate no licence is held<br><br>Enter XX in status code field, to indicate you are waiving the licence<br><br>Enter ‘Waiver claimed’ in the reason field
 declaration.additionalDocument.documentIdentifier = Document identifier
 declaration.additionalDocument.documentIdentifier.body = Document identifiers can be licence or certificate serial numbers. Details are in column 4 of the document code tables.
 declaration.additionalDocument.documentIdentifier.inset.fromAuthCode.paragraph1 = For authorisations, the identifier is the authorisation number given to you by HMRC to use for CDS declarations. It is in a prescribed format usually containing country code, authorisation code, EORI number and time-stamp.

--- a/test/views/declaration/AdditionalDocumentEditViewSpec.scala
+++ b/test/views/declaration/AdditionalDocumentEditViewSpec.scala
@@ -93,6 +93,7 @@ class AdditionalDocumentEditViewSpec extends UnitViewSpec with CommonMessages wi
       messages must haveTranslationFor("declaration.additionalDocument.documentTypeCode.empty")
       messages must haveTranslationFor("declaration.additionalDocument.documentTypeCode.empty.fromAuthCode")
       messages must haveTranslationFor("declaration.additionalDocument.documentTypeCode.error")
+      messages must haveTranslationFor("declaration.additionalDocument.documentTypeCode.Y999.error")
 
       messages must haveTranslationFor("declaration.additionalDocument.documentIdentifier")
       messages must haveTranslationFor("declaration.additionalDocument.documentIdentifier.body")
@@ -359,6 +360,15 @@ class AdditionalDocumentEditViewSpec extends UnitViewSpec with CommonMessages wi
         view must containErrorElementWithTagAndHref("a", s"#$documentTypeCodeKey")
 
         view must containErrorElementWithMessageKey("declaration.additionalDocument.documentTypeCode.empty")
+      }
+
+      "display error for Y999 Document type code" in {
+        val view = createView(Some(correctAdditionalDocument.copy(documentTypeCode = Some("Y999"))))
+
+        view must haveGovukGlobalErrorSummary
+        view must containErrorElementWithTagAndHref("a", s"#$documentTypeCodeKey")
+
+        view must containErrorElementWithMessageKey("declaration.additionalDocument.documentTypeCode.Y999.error")
       }
 
       "display error for empty Document type code when required after the entered authorisation code" in {

--- a/test/views/declaration/spec/ViewMatchers.scala
+++ b/test/views/declaration/spec/ViewMatchers.scala
@@ -178,7 +178,7 @@ trait ViewMatchers {
   class ContainErrorElementWithMessage(text: String) extends Matcher[Element] {
     override def apply(left: Element): MatchResult =
       MatchResult(
-        left != null && left.getElementsByClass("govuk-error-summary__list").text().contains(text),
+        left != null && left.getElementsByClass("govuk-error-summary__list").html().contains(text),
         s"Document did not contain error element with message {$text}\n${actualContentWas(left)}",
         s"Document contained an error element with message {$text}"
       )


### PR DESCRIPTION
Adding of temporary error message stopping use of code "Y999"

Had to enable escaping of HTML in a couple of places to allow for this multi-line error message.