### PR TITLE
CEDS-3771 When required, clear values cached from /inland-transport-details and /inland-or-border

### DIFF
--- a/app/controllers/declaration/InlandOrBorderController.scala
+++ b/app/controllers/declaration/InlandOrBorderController.scala
@@ -83,7 +83,14 @@ class InlandOrBorderController @Inject()(
     }
 
   private def updateExportsCache(mode: Mode, inlandOrBorder: InlandOrBorder)(implicit request: JourneyRequest[AnyContent]): Future[Result] =
-    updateDeclarationFromRequest(model => model.copy(locations = model.locations.copy(inlandOrBorder = Some(inlandOrBorder)))) map { _ =>
+    updateDeclarationFromRequest { declaration =>
+      declaration.copy(
+        locations = declaration.locations.copy(
+          inlandOrBorder = Some(inlandOrBorder),
+          inlandModeOfTransportCode = if (inlandOrBorder == Border) None else declaration.locations.inlandModeOfTransportCode
+        )
+      )
+    } map { _ =>
       navigator.continueTo(mode, nextPage(request.cacheModel, inlandOrBorder))
     }
 }

--- a/app/controllers/declaration/InlandTransportDetailsController.scala
+++ b/app/controllers/declaration/InlandTransportDetailsController.scala
@@ -76,8 +76,11 @@ class InlandTransportDetailsController @Inject()(
   }
 
   private def updateCacheAndGoNextPage(mode: Mode, code: InlandModeOfTransportCode)(implicit request: JourneyRequest[AnyContent]): Future[Result] =
-    updateDeclarationFromRequest(model => model.copy(locations = model.locations.copy(inlandModeOfTransportCode = Some(code))))
-      .map(_ => navigator.continueTo(mode, nextPage(request.declarationType, code)))
+    updateDeclarationFromRequest { declaration =>
+      declaration.copy(locations = declaration.locations.copy(inlandModeOfTransportCode = Some(code)))
+    } map { _ =>
+      navigator.continueTo(mode, nextPage(request.declarationType, code))
+    }
 
   private def validateAndUpdateCache(mode: Mode, code: InlandModeOfTransportCode)(implicit request: JourneyRequest[AnyContent]): Future[Result] =
     validateWithTransportLeavingBorderCode(code).fold(updateCacheAndGoNextPage(mode, code))(returnFormWithErrors(mode, code, _))

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -64,7 +64,7 @@ class SupervisingCustomsOfficeController @Inject()(
     updateDeclarationFromRequest { declaration =>
       declaration.copy(
         locations = declaration.locations
-          .copy(supervisingCustomsOffice = Some(formData), inlandOrBorder = inlandOrBorderHelper.inlandOrBorderValueIfOrNotToReset(declaration))
+          .copy(supervisingCustomsOffice = Some(formData), inlandOrBorder = inlandOrBorderHelper.resetInlandOrBorderIfRequired(declaration))
       )
     }
 }

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -17,7 +17,7 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.helpers.SupervisingCustomsOfficeHelper
+import controllers.helpers.{InlandOrBorderHelper, SupervisingCustomsOfficeHelper}
 import controllers.navigation.Navigator
 import forms.declaration.SupervisingCustomsOffice
 import forms.declaration.SupervisingCustomsOffice.form
@@ -39,6 +39,7 @@ class SupervisingCustomsOfficeController @Inject()(
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   supervisingCustomsOfficePage: supervising_customs_office,
+  inlandOrBorderHelper: InlandOrBorderHelper,
   supervisingCustomsOfficeHelper: SupervisingCustomsOfficeHelper
 )(implicit ec: ExecutionContext)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
@@ -59,6 +60,11 @@ class SupervisingCustomsOfficeController @Inject()(
       )
   }
 
-  private def updateCache(formData: SupervisingCustomsOffice)(implicit request: JourneyRequest[AnyContent]): Future[ExportsDeclaration] =
-    updateDeclarationFromRequest(model => model.copy(locations = model.locations.copy(supervisingCustomsOffice = Some(formData))))
+  private def updateCache(formData: SupervisingCustomsOffice)(implicit request: JourneyRequest[_]): Future[ExportsDeclaration] =
+    updateDeclarationFromRequest { declaration =>
+      declaration.copy(
+        locations = declaration.locations
+          .copy(supervisingCustomsOffice = Some(formData), inlandOrBorder = inlandOrBorderHelper.inlandOrBorderValueIfOrNotToReset(declaration))
+      )
+    }
 }

--- a/app/controllers/declaration/TransportLeavingTheBorderController.scala
+++ b/app/controllers/declaration/TransportLeavingTheBorderController.scala
@@ -74,7 +74,7 @@ class TransportLeavingTheBorderController @Inject()(
       declaration.copy(
         transport = declaration.transport.copy(borderModeOfTransportCode = Some(code)),
         locations = declaration.locations.copy(
-          inlandOrBorder = if (code.code == Some(RoRo)) None else inlandOrBorderHelper.inlandOrBorderValueIfOrNotToReset(declaration)
+          inlandOrBorder = if (code.code == Some(RoRo)) None else inlandOrBorderHelper.resetInlandOrBorderIfRequired(declaration)
         )
       )
     }

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -16,13 +16,10 @@
 
 package controllers.declaration
 
-import scala.concurrent.{ExecutionContext, Future}
-
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.navigation.Navigator
 import controllers.helpers.SupervisingCustomsOfficeHelper
+import controllers.navigation.Navigator
 import forms.declaration.WarehouseIdentification
-import javax.inject.Inject
 import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration, Mode}
 import play.api.data.Form
@@ -32,6 +29,9 @@ import play.twirl.api.HtmlFormat
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.{warehouse_identification, warehouse_identification_yesno}
+
+import javax.inject.Inject
+import scala.concurrent.{ExecutionContext, Future}
 
 class WarehouseIdentificationController @Inject()(
   authenticate: AuthAction,
@@ -74,6 +74,8 @@ class WarehouseIdentificationController @Inject()(
       case _                         => warehouseIdentificationPage(mode, form)
     }
 
-  private def updateCache(formData: WarehouseIdentification)(implicit request: JourneyRequest[AnyContent]): Future[ExportsDeclaration] =
-    updateDeclarationFromRequest(model => model.copy(locations = model.locations.copy(warehouseIdentification = Some(formData))))
+  private def updateCache(formData: WarehouseIdentification)(implicit request: JourneyRequest[_]): Future[ExportsDeclaration] =
+    updateDeclarationFromRequest { declaration =>
+      declaration.copy(locations = declaration.locations.copy(warehouseIdentification = Some(formData), inlandOrBorder = None))
+    }
 }

--- a/app/controllers/helpers/InlandOrBorderHelper.scala
+++ b/app/controllers/helpers/InlandOrBorderHelper.scala
@@ -29,7 +29,7 @@ class InlandOrBorderHelper @Inject()(depCodes: DepCodesHelper) {
 
   val notAllowedOnInlandOrBorder = List(CLEARANCE, OCCASIONAL, SIMPLIFIED)
 
-  def inlandOrBorderValueIfOrNotToReset(declaration: ExportsDeclaration): Option[InlandOrBorder] =
+  def resetInlandOrBorderIfRequired(declaration: ExportsDeclaration): Option[InlandOrBorder] =
     if (declaration.locations.inlandOrBorder.isEmpty) None
     else if (notAllowedOnInlandOrBorder.contains(declaration.`type`) || skipInlandOrBorder(declaration)) None
     else declaration.locations.inlandOrBorder

--- a/app/controllers/helpers/InlandOrBorderHelper.scala
+++ b/app/controllers/helpers/InlandOrBorderHelper.scala
@@ -16,14 +16,23 @@
 
 package controllers.helpers
 
+import forms.declaration.InlandOrBorder
 import forms.declaration.ModeOfTransportCode.RoRo
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.SUPPLEMENTARY_EIDR
+import models.DeclarationType._
 import models.ExportsDeclaration
 
 import javax.inject.{Inject, Singleton}
 
 @Singleton
 class InlandOrBorderHelper @Inject()(depCodes: DepCodesHelper) {
+
+  val notAllowedOnInlandOrBorder = List(CLEARANCE, OCCASIONAL, SIMPLIFIED)
+
+  def inlandOrBorderValueIfOrNotToReset(declaration: ExportsDeclaration): Option[InlandOrBorder] =
+    if (declaration.locations.inlandOrBorder.isEmpty) None
+    else if (notAllowedOnInlandOrBorder.contains(declaration.`type`) || skipInlandOrBorder(declaration)) None
+    else declaration.locations.inlandOrBorder
 
   def skipInlandOrBorder(declaration: ExportsDeclaration): Boolean =
     declaration.isAdditionalDeclarationType(SUPPLEMENTARY_EIDR) ||

--- a/app/models/ExportsDeclaration.scala
+++ b/app/models/ExportsDeclaration.scala
@@ -136,12 +136,6 @@ case class ExportsDeclaration(
   def removeSupervisingCustomsOffice: ExportsDeclaration =
     copy(locations = locations.copy(supervisingCustomsOffice = None))
 
-  def updateTransportLeavingBorder(code: ModeOfTransportCode): ExportsDeclaration =
-    copy(transport = transport.copy(borderModeOfTransportCode = Some(TransportLeavingTheBorder(Some(code)))))
-
-  def updateTransportLeavingBorder(transportLeavingTheBorder: TransportLeavingTheBorder): ExportsDeclaration =
-    copy(transport = transport.copy(borderModeOfTransportCode = Some(transportLeavingTheBorder)))
-
   def updateDepartureTransport(departure: DepartureTransport): ExportsDeclaration =
     copy(
       transport = transport.copy(
@@ -197,7 +191,7 @@ case class ExportsDeclaration(
   def updatePreviousDocuments(previousDocuments: Seq[Document]): ExportsDeclaration =
     copy(previousDocuments = Some(PreviousDocumentsData(previousDocuments)))
 
-  def updateReadyForSubmission(ready: Boolean) =
+  def updateReadyForSubmission(ready: Boolean): ExportsDeclaration =
     copy(readyForSubmission = Some(ready))
 
   def transform(function: ExportsDeclaration => ExportsDeclaration): ExportsDeclaration = function(this)

--- a/test/controllers/declaration/InlandOrBorderControllerSpec.scala
+++ b/test/controllers/declaration/InlandOrBorderControllerSpec.scala
@@ -29,6 +29,7 @@ import controllers.helpers.TransportSectionHelper._
 import controllers.routes.RootController
 import forms.declaration.InlandOrBorder
 import forms.declaration.InlandOrBorder.{fieldId, Border, Inland}
+import forms.declaration.ModeOfTransportCode.Maritime
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED}
 import models.Mode.Normal
@@ -176,6 +177,16 @@ class InlandOrBorderControllerSpec extends ControllerSpec with OptionValues {
             await(controller.submitPage(Normal)(postRequest(body)))
 
             theCacheModelUpdated.locations.inlandOrBorder.value mustBe Border
+          }
+
+          "reset the cached value from /inland-transport-details, if any, after a successful bind" in {
+            cacheRequest(additionalType, withInlandModeOfTransportCode(Maritime))
+
+            await(controller.submitPage(Normal)(postRequest(body)))
+
+            val locations = theCacheModelUpdated.locations
+            locations.inlandOrBorder.value mustBe Border
+            locations.inlandModeOfTransportCode mustBe None
           }
 
           s"redirect to ${expectedNextPage.url}" in {

--- a/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -279,7 +279,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
       }
     }
 
-    val inlandOrBorderIfOrNotToReset = List(
+    val resetInlandOrBorderConditions = List(
       (STANDARD_FRONTIER, Border, Some(Border)),
       (STANDARD_PRE_LODGED, Border, Some(Border)),
       (SUPPLEMENTARY_SIMPLIFIED, Inland, Some(Inland)),
@@ -292,7 +292,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
       (CLEARANCE_PRE_LODGED, Inland, None)
     )
 
-    inlandOrBorderIfOrNotToReset.foreach { data =>
+    resetInlandOrBorderConditions.foreach { data =>
       val additionalType = data._1
       val actualCachedInlandOrBorder = data._2
       val expectedCachedInlandOrBorder = data._3

--- a/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
+++ b/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
@@ -294,7 +294,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
       }
     }
 
-    val inlandOrBorderIfOrNotToReset = List(
+    val resetInlandOrBorderConditions = List(
       (STANDARD_FRONTIER, Maritime, Border, Some(Border)),
       (STANDARD_FRONTIER, RoRo, Border, None),
       (STANDARD_PRE_LODGED, Maritime, Border, Some(Border)),
@@ -304,7 +304,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
       (CLEARANCE_PRE_LODGED, Maritime, Inland, None)
     )
 
-    inlandOrBorderIfOrNotToReset.foreach { data =>
+    resetInlandOrBorderConditions.foreach { data =>
       val additionalType = data._1
       val modeOfTransportCode = data._2
       val actualCachedInlandOrBorder = data._3

--- a/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
+++ b/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
@@ -24,12 +24,13 @@ import controllers.declaration.routes.{
   SupervisingCustomsOfficeController,
   WarehouseIdentificationController
 }
-import controllers.helpers.SupervisingCustomsOfficeHelper
+import controllers.helpers.{InlandOrBorderHelper, SupervisingCustomsOfficeHelper}
 import controllers.helpers.TransportSectionHelper.additionalDeclTypesAllowedOnInlandOrBorder
 import controllers.routes.RootController
-import forms.declaration.ModeOfTransportCode.{meaningfulModeOfTransportCodes, RoRo}
+import forms.declaration.InlandOrBorder.{Border, Inland}
+import forms.declaration.ModeOfTransportCode.{meaningfulModeOfTransportCodes, Maritime, RoRo}
 import forms.declaration.TransportLeavingTheBorder.suffixForLocationOfGoods
-import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.SUPPLEMENTARY_EIDR
+import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
 import forms.declaration.{LocationOfGoods, ModeOfTransportCode, TransportLeavingTheBorder}
 import models.DeclarationType
 import models.DeclarationType._
@@ -49,6 +50,8 @@ import views.html.declaration.transport_leaving_the_border
 class TransportLeavingTheBorderControllerSpec extends ControllerSpec with OptionValues {
 
   private val transportLeavingTheBorder = mock[transport_leaving_the_border]
+
+  private val inlandOrBorderHelper = instanceOf[InlandOrBorderHelper]
   private val supervisingCustomsOfficeHelper = instanceOf[SupervisingCustomsOfficeHelper]
 
   val controller = new TransportLeavingTheBorderController(
@@ -58,6 +61,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
     navigator,
     stubMessagesControllerComponents(),
     transportLeavingTheBorder,
+    inlandOrBorderHelper = inlandOrBorderHelper,
     supervisingCustomsOfficeHelper
   )(ec)
 
@@ -287,6 +291,38 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
         val result = controller.submitForm(Normal)(postRequest(body))
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+      }
+    }
+
+    val inlandOrBorderIfOrNotToReset = List(
+      (STANDARD_FRONTIER, Maritime, Border, Some(Border)),
+      (STANDARD_FRONTIER, RoRo, Border, None),
+      (STANDARD_PRE_LODGED, Maritime, Border, Some(Border)),
+      (SUPPLEMENTARY_SIMPLIFIED, Maritime, Inland, Some(Inland)),
+      (SUPPLEMENTARY_EIDR, Maritime, Border, None),
+      (CLEARANCE_FRONTIER, Maritime, Border, None),
+      (CLEARANCE_PRE_LODGED, Maritime, Inland, None)
+    )
+
+    inlandOrBorderIfOrNotToReset.foreach { data =>
+      val additionalType = data._1
+      val modeOfTransportCode = data._2
+      val actualCachedInlandOrBorder = data._3
+      val expectedCachedInlandOrBorder = data._4
+
+      s"AdditionalDeclarationType is $additionalType and" when {
+        s"the value selected on /transport-leaving-the-border is $modeOfTransportCode and" when {
+          s"the cached InlandOrBorder is $actualCachedInlandOrBorder" should {
+            s"${if (expectedCachedInlandOrBorder.isEmpty) "" else "not "} reset InlandOrBorder after a successful bind" in {
+              withNewCaching(withRequest(additionalType, withInlandOrBorder(Some(actualCachedInlandOrBorder))).cacheModel)
+
+              val body = Json.obj("transportLeavingTheBorder" -> modeOfTransportCode.value)
+              await(controller.submitForm(Normal)(postRequest(body)))
+
+              theCacheModelUpdated.locations.inlandOrBorder mustBe expectedCachedInlandOrBorder
+            }
+          }
+        }
       }
     }
   }

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -20,10 +20,12 @@ import base.ControllerSpec
 import base.ExportsTestData.itemWithPC
 import controllers.helpers.SupervisingCustomsOfficeHelper
 import controllers.helpers.TransportSectionHelper.additionalDeclTypesAllowedOnInlandOrBorder
+import forms.declaration.InlandOrBorder.{Border, Inland}
 import forms.declaration.WarehouseIdentification
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
+import models.DeclarationType
 import models.DeclarationType._
-import models.{DeclarationType, Mode}
+import models.Mode.Normal
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{reset, verify, when}
@@ -38,6 +40,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
   private val pageYesNo = mock[warehouse_identification_yesno]
   private val pageIdentification = mock[warehouse_identification]
+
   private val supervisingCustomsOfficeHelper = instanceOf[SupervisingCustomsOfficeHelper]
 
   val controller = new WarehouseIdentificationController(
@@ -78,7 +81,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
   override def getFormForDisplayRequest(request: Request[AnyContentAsEmpty.type]): Form[_] = {
     withNewCaching(aDeclaration())
-    await(controller.displayPage(Mode.Normal)(request))
+    await(controller.displayPage(Normal)(request))
     theResponseForm
   }
 
@@ -90,7 +93,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
       "return 200 (OK)" when {
 
         "display page method is invoked and cache is empty" in {
-          val result = controller.displayPage(Mode.Normal)(getRequest())
+          val result = controller.displayPage(Normal)(getRequest())
 
           status(result) must be(OK)
         }
@@ -98,7 +101,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
         "display page method is invoked and cache is not empty" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withWarehouseIdentification(Some(identification))))
 
-          val result = controller.displayPage(Mode.Normal)(getRequest())
+          val result = controller.displayPage(Normal)(getRequest())
 
           status(result) must be(OK)
           theResponseForm.value mustBe Some(identification)
@@ -111,7 +114,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           val incorrectForm = Json.obj(WarehouseIdentification.warehouseIdKey -> "incorrect")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(incorrectForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
         }
@@ -122,7 +125,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           withNewCaching(request.cacheModel)
           val correctForm = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.SupervisingCustomsOfficeController.displayPage()
@@ -136,7 +139,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           withNewCaching(withRequest(SUPPLEMENTARY_EIDR, withItem(itemWithPC("1040"))).cacheModel)
           val correctForm = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
           status(result) mustBe SEE_OTHER
 
@@ -152,7 +155,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
             withNewCaching(withRequest(additionalType, withItem(itemWithPC("1040"))).cacheModel)
             val correctForm = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-            val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+            val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
             status(result) mustBe SEE_OTHER
             thePageNavigatedTo mustBe routes.InlandOrBorderController.displayPage()
@@ -167,7 +170,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           withNewCaching(request.cacheModel)
           val correctForm = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe routes.ExpressConsignmentController.displayPage()
@@ -179,7 +182,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
       "return 200 (OK)" when {
 
         "display page method is invoked and cache is empty" in {
-          val result = controller.displayPage(Mode.Normal)(getRequest())
+          val result = controller.displayPage(Normal)(getRequest())
 
           status(result) must be(OK)
         }
@@ -187,7 +190,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
         "display page method is invoked and cache is not empty" in {
           withNewCaching(aDeclarationAfter(request.cacheModel, withWarehouseIdentification(Some(identification))))
 
-          val result = controller.displayPage(Mode.Normal)(getRequest())
+          val result = controller.displayPage(Normal)(getRequest())
 
           status(result) must be(OK)
           theResponseFormYesNo.value mustBe Some(identification)
@@ -200,7 +203,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           val incorrectForm = Json.obj(WarehouseIdentification.inWarehouseKey -> "Yes", WarehouseIdentification.warehouseIdKey -> "incorrect")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(incorrectForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
         }
@@ -212,7 +215,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           val correctForm = Json.obj(WarehouseIdentification.inWarehouseKey -> "Yes", WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.SupervisingCustomsOfficeController.displayPage()
@@ -225,10 +228,45 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           val correctForm = Json.obj(WarehouseIdentification.inWarehouseKey -> "Yes", WarehouseIdentification.warehouseIdKey -> "R12341234")
 
-          val result = controller.saveIdentificationNumber(Mode.Normal)(postRequest(correctForm))
+          val result = controller.saveIdentificationNumber(Normal)(postRequest(correctForm))
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.DepartureTransportController.displayPage()
+        }
+      }
+    }
+
+    val bodyNonClearance = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
+    val bodyForClearance = Json.obj(WarehouseIdentification.inWarehouseKey -> "No", WarehouseIdentification.warehouseIdKey -> None)
+
+    val inlandOrBorderIfOrNotToReset = List(
+      (STANDARD_FRONTIER, Border, bodyNonClearance),
+      (STANDARD_PRE_LODGED, Border, bodyNonClearance),
+      (SUPPLEMENTARY_SIMPLIFIED, Inland, bodyNonClearance),
+      (SUPPLEMENTARY_EIDR, Border, bodyNonClearance),
+      (SIMPLIFIED_FRONTIER, Border, bodyNonClearance),
+      (SIMPLIFIED_PRE_LODGED, Border, bodyNonClearance),
+      (OCCASIONAL_FRONTIER, Border, bodyNonClearance),
+      (OCCASIONAL_PRE_LODGED, Border, bodyNonClearance),
+      (CLEARANCE_FRONTIER, Border, bodyForClearance),
+      (CLEARANCE_PRE_LODGED, Inland, bodyForClearance)
+    )
+
+    inlandOrBorderIfOrNotToReset.foreach { data =>
+      val additionalType = data._1
+      val actualCachedInlandOrBorder = data._2
+      val body = data._3
+
+      s"AdditionalDeclarationType is $additionalType and" when {
+        "the cached InlandOrBorder is NOT None" should {
+          "reset InlandOrBorder after a successful bind" in {
+            val inlandOrBorder = withInlandOrBorder(Some(actualCachedInlandOrBorder))
+            withNewCaching(withRequest(additionalType, inlandOrBorder).cacheModel)
+
+            await(controller.saveIdentificationNumber(Normal)(postRequest(body)))
+
+            theCacheModelUpdated.locations.inlandOrBorder mustBe None
+          }
         }
       }
     }

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -239,7 +239,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
     val bodyNonClearance = Json.obj(WarehouseIdentification.warehouseIdKey -> "R12341234")
     val bodyForClearance = Json.obj(WarehouseIdentification.inWarehouseKey -> "No", WarehouseIdentification.warehouseIdKey -> None)
 
-    val inlandOrBorderIfOrNotToReset = List(
+    val resetInlandOrBorderConditions = List(
       (STANDARD_FRONTIER, Border, bodyNonClearance),
       (STANDARD_PRE_LODGED, Border, bodyNonClearance),
       (SUPPLEMENTARY_SIMPLIFIED, Inland, bodyNonClearance),
@@ -252,7 +252,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
       (CLEARANCE_PRE_LODGED, Inland, bodyForClearance)
     )
 
-    inlandOrBorderIfOrNotToReset.foreach { data =>
+    resetInlandOrBorderConditions.foreach { data =>
       val additionalType = data._1
       val actualCachedInlandOrBorder = data._2
       val body = data._3


### PR DESCRIPTION
1. Clear out any cached value on /inland-transport-details when the user selects 'border' on /inland-or-border.
2. Clear out any cached value on /inland-or-border when the user submits (POST) /transport-leaving-the-border.
