### PR TITLE
CEDS-3696 Allow 8-digits Commodity codes, in addition to 10-digits ones

### DIFF
--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -43,7 +43,7 @@ class CommodityDetailsController @Inject()(
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors {
 
   def displayPage(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>
-    val frm = form(request.declarationType).withSubmissionErrors()
+    val frm = form(request.declarationType).withSubmissionErrors
     request.cacheModel.itemBy(itemId).flatMap(_.commodityDetails) match {
       case Some(commodityDetails) => Ok(commodityDetailsPage(mode, itemId, frm.fill(commodityDetails)))
       case _                      => Ok(commodityDetailsPage(mode, itemId, frm))
@@ -51,8 +51,7 @@ class CommodityDetailsController @Inject()(
   }
 
   def submitForm(mode: Mode, itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>
-    form(request.declarationType)
-      .bindFromRequest()
+    form(request.declarationType).bindFromRequest
       .fold(
         (formWithErrors: Form[CommodityDetails]) => Future.successful(BadRequest(commodityDetailsPage(mode, itemId, formWithErrors))),
         validForm => updateExportsCache(itemId, validForm).map(_ => redirectToNextPage(mode, itemId))
@@ -64,9 +63,9 @@ class CommodityDetailsController @Inject()(
       if (request.cacheModel.itemBy(itemId).exists(_.isExportInventoryCleansingRecord))
         navigator.continueTo(mode, controllers.declaration.routes.CommodityMeasureController.displayPage(_, itemId))
       else
-        navigator.continueTo(mode, controllers.declaration.routes.PackageInformationSummaryController.displayPage(_, itemId))
+        navigator.continueTo(mode, routes.PackageInformationSummaryController.displayPage(_, itemId))
     } else {
-      navigator.continueTo(mode, controllers.declaration.routes.UNDangerousGoodsCodeController.displayPage(_, itemId))
+      navigator.continueTo(mode, routes.UNDangerousGoodsCodeController.displayPage(_, itemId))
     }
 
   private def updateExportsCache(itemId: String, updatedItem: CommodityDetails)(

--- a/app/forms/declaration/CommodityDetails.scala
+++ b/app/forms/declaration/CommodityDetails.scala
@@ -37,7 +37,7 @@ object CommodityDetails extends DeclarationPage {
   val descriptionOfGoodsMaxLength = 280
   val commodityCodeChemicalPrefixes = Seq(28, 29, 38)
 
-  private val combinedNomenclatureCodeMaxLength = 10
+  private val combinedNomenclatureCodeAcceptedLengths = List(8, 10)
 
   private def mappingCombinedNomenclatureCodeRequired: Mapping[Option[String]] =
     mappingCombinedNomenclatureCodeOptional
@@ -50,7 +50,7 @@ object CommodityDetails extends DeclarationPage {
         .verifying("declaration.commodityDetails.combinedNomenclatureCode.error.invalid", isEmpty or isNumeric)
         .verifying(
           "declaration.commodityDetails.combinedNomenclatureCode.error.length",
-          isEmpty or hasSpecificLength(combinedNomenclatureCodeMaxLength)
+          isEmpty or hasSpecificLengths(combinedNomenclatureCodeAcceptedLengths)
         )
     )
 

--- a/app/utils/validators/forms/FieldValidator.scala
+++ b/app/utils/validators/forms/FieldValidator.scala
@@ -43,7 +43,7 @@ object FieldValidator {
   }
 
   private def noMoreDecimalPlacesThanRegexValue(decimalPlaces: Int): Pattern =
-    Pattern.compile(s"^([0-9]*)([\\.]{0,1}[0-9]{0,$decimalPlaces})$$")
+    Pattern.compile(s"^([0-9]*)([\\.]?[0-9]{0,$decimalPlaces})$$")
 
   private val allowedSpecialChars = Set(',', '.', '-', '\'', '/', ' ')
   private val allowedNewLineChars = Set('\r', '\n')
@@ -66,6 +66,8 @@ object FieldValidator {
   val noShorterThan: Int => String => Boolean = (length: Int) => (input: String) => input.length >= length
 
   val hasSpecificLength: Int => String => Boolean = (length: Int) => (input: String) => input.length == length
+
+  val hasSpecificLengths: Seq[Int] => String => Boolean = (lengths: Seq[Int]) => (input: String) => lengths.contains(input.length)
 
   val lengthInRange: Int => Int => String => Boolean = (min: Int) => (max: Int) => (input: String) => input.length >= min && input.length <= max
 

--- a/app/views/declaration/commodity_details.scala.html
+++ b/app/views/declaration/commodity_details.scala.html
@@ -47,9 +47,10 @@
 
 @commodityCodeBody = {
     @paragraphBody(messages(
-        "declaration.commodityDetails.combinedNomenclatureCode.body",
-        tariffLink(messages("declaration.commodityDetails.combinedNomenclatureCode.body.link"), appConfig.commodityCodeHelpUrl)
+        "declaration.commodityDetails.combinedNomenclatureCode.body.1",
+        tariffLink(messages("declaration.commodityDetails.combinedNomenclatureCode.body.1.link"), appConfig.commodityCodeHelpUrl)
     ))
+    @paragraphBody(messages("declaration.commodityDetails.combinedNomenclatureCode.body.2"))
 }
 
 @govukLayout(
@@ -60,6 +61,7 @@
         @errorSummary(form.errors)
 
         @sectionHeader(messages("declaration.section.5"))
+
         @pageTitle(messages("declaration.commodityDetails.title"))
 
         @inputText(

--- a/conf/messages.en
+++ b/conf/messages.en
@@ -661,7 +661,6 @@ declaration.additionalActors.remove.empty = Select yes if you need to remove thi
 declaration.additionalActors.remove.title = Are you sure you want to remove this party?
 declaration.additionalActors.error.duplicate = Additional party already added
 
-
 declaration.eori.empty = Enter an EORI number
 declaration.eori.error.format = EORI number must be in the correct format with no spaces. For example, GB123456789000
 
@@ -1375,11 +1374,12 @@ declaration.exchangeRate.hint = For example, if the contract states that a rate 
 
 declaration.commodityDetails.title = Commodity code and item details
 declaration.commodityDetails.combinedNomenclatureCode.label = What is the commodity code for this item?
-declaration.commodityDetails.combinedNomenclatureCode.body = The commodity code stems from the HS (Harmonized System) code that identifies goods for customs. Find out {0}.
-declaration.commodityDetails.combinedNomenclatureCode.body.link = how to get the right commodity code for your goods (opens in new tab)
-declaration.commodityDetails.combinedNomenclatureCode.hint = All commodity codes are 10 digits, for example 4203400090.
+declaration.commodityDetails.combinedNomenclatureCode.body.1 = The commodity code stems from the HS (Harmonized System) code that identifies goods for customs. Find out {0}.
+declaration.commodityDetails.combinedNomenclatureCode.body.1.link = how to get the right commodity code for your goods (opens in new tab)
+declaration.commodityDetails.combinedNomenclatureCode.body.2 = You only need to enter 8 digits for an export declaration. If you provide the full 10-digit code, then we can help you find the Tariff requirements for your goods.
+declaration.commodityDetails.combinedNomenclatureCode.hint = Enter all 10 digits, for example 4203400090. If you do not have the full code you may still enter 42034000.
 declaration.commodityDetails.combinedNomenclatureCode.error.empty = Enter a commodity code in the correct format
-declaration.commodityDetails.combinedNomenclatureCode.error.length = Enter a full 10-number commodity code
+declaration.commodityDetails.combinedNomenclatureCode.error.length = Enter 8 digits or 10 digits
 declaration.commodityDetails.combinedNomenclatureCode.error.invalid = Enter a commodity code in numbers only
 declaration.commodityDetails.description.label = Describe the goods
 declaration.commodityDetails.description.body = Enter a precise description that includes any branding, internal measurements or internal packaging.

--- a/test/forms/declaration/CommodityDetailsSpec.scala
+++ b/test/forms/declaration/CommodityDetailsSpec.scala
@@ -30,23 +30,32 @@ class CommodityDetailsSpec extends DeclarationPageBaseSpec {
 
     for (decType <- Set(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)) {
 
+      s"return form without errors for $decType" when {
+
+        "provided with a commodity code 8 digits long" in {
+          val form = CommodityDetails.form(decType).bind(formData("12345678", "description"), JsonBindMaxChars)
+          form.errors mustBe empty
+        }
+
+        "provided with a commodity code 10 digits long" in {
+          val form = CommodityDetails.form(decType).bind(formData("1234567890", "description"), JsonBindMaxChars)
+          form.errors mustBe empty
+        }
+      }
+
       s"return form with errors for $decType" when {
+
         "provided with invalid commodity code" in {
           val form = CommodityDetails.form(decType).bind(formData("A123456789", "description"), JsonBindMaxChars)
-
           form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.invalid"))
         }
 
-        "provided with commodity code too long" in {
-          val form = CommodityDetails.form(decType).bind(formData("12345678901", "description"), JsonBindMaxChars)
+        "provided with a commodity code not 8 or 10 digits long" in {
+          val form1 = CommodityDetails.form(decType).bind(formData("12345678901", "description"), JsonBindMaxChars)
+          form1.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
 
-          form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
-        }
-
-        "provided with commodity code too short" in {
-          val form = CommodityDetails.form(decType).bind(formData("1234", "description"), JsonBindMaxChars)
-
-          form.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
+          val form2 = CommodityDetails.form(decType).bind(formData("1234", "description"), JsonBindMaxChars)
+          form2.errors mustBe Seq(FormError(combinedNomenclatureCodeKey, "declaration.commodityDetails.combinedNomenclatureCode.error.length"))
         }
 
         "provided with invalid commodity code that is too long" in {

--- a/test/views/declaration/CommodityDetailsViewSpec.scala
+++ b/test/views/declaration/CommodityDetailsViewSpec.scala
@@ -50,13 +50,16 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
       view.getElementById("title").text mustBe messages("declaration.commodityDetails.title")
     }
 
-    "display a body text for the commodity code input field" in {
-      val element = view.getElementsByClass("govuk-body").get(0)
-      removeBlanksIfAnyBeforeDot(element.text) mustBe messages(
-        "declaration.commodityDetails.combinedNomenclatureCode.body",
-        messages("declaration.commodityDetails.combinedNomenclatureCode.body.link")
+    "display body texts for the commodity code input field" in {
+      val body1 = view.getElementsByClass("govuk-body").get(0)
+      removeBlanksIfAnyBeforeDot(body1.text) mustBe messages(
+        "declaration.commodityDetails.combinedNomenclatureCode.body.1",
+        messages("declaration.commodityDetails.combinedNomenclatureCode.body.1.link")
       )
-      element.child(0) must haveHref("https://www.gov.uk/guidance/using-the-trade-tariff-tool-to-find-a-commodity-code")
+      body1.child(0) must haveHref("https://www.gov.uk/guidance/using-the-trade-tariff-tool-to-find-a-commodity-code")
+
+      val body2 = view.getElementsByClass("govuk-body").get(1).text
+      body2 mustBe messages("declaration.commodityDetails.combinedNomenclatureCode.body.2")
     }
 
     "display a hint text for the commodity code input field" in {
@@ -70,7 +73,7 @@ class CommodityDetailsViewSpec extends UnitViewSpec with ExportsTestData with St
     }
 
     "display a body text for the description textarea field" in {
-      val element = view.getElementsByClass("govuk-body").get(1)
+      val element = view.getElementsByClass("govuk-body").get(2)
       element.text mustBe messages("declaration.commodityDetails.description.body")
     }
 


### PR DESCRIPTION
Also amend content of the /commodity-details page