### PR TITLE
CEDS-3794 Amend STANDARD and SUPPLEMENTARY journeys

### DIFF
--- a/app/controllers/declaration/DepartureTransportController.scala
+++ b/app/controllers/declaration/DepartureTransportController.scala
@@ -17,11 +17,12 @@
 package controllers.declaration
 
 import controllers.actions.{AuthAction, JourneyAction}
-import controllers.declaration.routes.{BorderTransportController, ExpressConsignmentController}
+import controllers.declaration.routes.{BorderTransportController, ExpressConsignmentController, TransportCountryController}
 import controllers.helpers.TransportSectionHelper.isPostalOrFTIModeOfTransport
 import controllers.navigation.Navigator
 import controllers.routes.RootController
 import forms.declaration.DepartureTransport
+import forms.declaration.InlandOrBorder.Border
 import models.DeclarationType.{CLEARANCE, STANDARD, SUPPLEMENTARY}
 import models.requests.JourneyRequest
 import models.{ExportsDeclaration, Mode}
@@ -77,8 +78,10 @@ class DepartureTransportController @Inject()(
 
   private def nextPage(implicit request: JourneyRequest[AnyContent]): Mode => Call =
     request.declarationType match {
-      case STANDARD | SUPPLEMENTARY => BorderTransportController.displayPage
-      case CLEARANCE                => ExpressConsignmentController.displayPage
+      case CLEARANCE => ExpressConsignmentController.displayPage
+      case STANDARD | SUPPLEMENTARY =>
+        if (request.cacheModel.isInlandOrBorder(Border)) TransportCountryController.displayPage
+        else BorderTransportController.displayPage
     }
 
   private def updateCache(formData: DepartureTransport)(implicit r: JourneyRequest[AnyContent]): Future[ExportsDeclaration] =

--- a/app/controllers/navigation/Navigator.scala
+++ b/app/controllers/navigation/Navigator.scala
@@ -125,7 +125,6 @@ class Navigator @Inject()(
     case ExporterEoriNumber          => routes.DeclarantExporterController.displayPage
     case ExporterDetails             => routes.ExporterEoriNumberController.displayPage
     case BorderTransport             => routes.DepartureTransportController.displayPage
-    case TransportCountry            => routes.BorderTransportController.displayPage
     case ContainerAdd                => routes.TransportContainerController.displayContainerSummary
     case RoutingCountryQuestionPage  => routes.DestinationCountryController.displayPage
     case RemoveCountryPage           => routes.RoutingCountriesSummaryController.displayPage
@@ -157,6 +156,7 @@ class Navigator @Inject()(
     case InlandOrBorder            => inlandOrBorderPreviousPage
     case InlandModeOfTransportCode => inlandTransportDetailsPreviousPage
     case DepartureTransport        => departureTransportPreviousPageOnStandardOrSuppl
+    case TransportCountry          => transportCountryPreviousPage
     case ExpressConsignment        => expressConsignmentPreviousPageOnStandard
     case RepresentativeAgent       => representativeAgentPreviousPage
   }
@@ -221,7 +221,6 @@ class Navigator @Inject()(
     case ExporterEoriNumber          => routes.DeclarantExporterController.displayPage
     case ExporterDetails             => routes.ExporterEoriNumberController.displayPage
     case BorderTransport             => routes.DepartureTransportController.displayPage
-    case TransportCountry            => routes.BorderTransportController.displayPage
     case ContainerAdd                => routes.TransportContainerController.displayContainerSummary
     case LocationOfGoods             => routes.DestinationCountryController.displayPage
     case DocumentSummary             => routes.NatureOfTransactionController.displayPage
@@ -250,6 +249,7 @@ class Navigator @Inject()(
     case InlandOrBorder            => inlandOrBorderPreviousPage
     case InlandModeOfTransportCode => inlandTransportDetailsPreviousPage
     case DepartureTransport        => departureTransportPreviousPageOnStandardOrSuppl
+    case TransportCountry          => transportCountryPreviousPage
     case ContainerFirst            => containerFirstPreviousPageOnSupplementary
     case RepresentativeAgent       => representativeAgentPreviousPage
   }
@@ -592,6 +592,10 @@ class Navigator @Inject()(
     if (inAllowedFlow && cacheModel.isInlandOrBorder(Border)) routes.InlandOrBorderController.displayPage(mode)
     else routes.InlandTransportDetailsController.displayPage(mode)
   }
+
+  private def transportCountryPreviousPage(cacheModel: ExportsDeclaration, mode: Mode): Call =
+    if (cacheModel.isInlandOrBorder(Border)) routes.DepartureTransportController.displayPage(mode)
+    else routes.BorderTransportController.displayPage(mode)
 
   private def expressConsignmentPreviousPageOnStandard(cacheModel: ExportsDeclaration, mode: Mode): Call =
     if (isPostalOrFTIModeOfTransport(cacheModel.inlandModeOfTransportCode)) routes.InlandTransportDetailsController.displayPage(mode)

--- a/test/views/declaration/TransportCountryViewSpec.scala
+++ b/test/views/declaration/TransportCountryViewSpec.scala
@@ -18,9 +18,10 @@ package views.declaration
 
 import base.Injector
 import connectors.CodeListConnector
-import controllers.declaration.routes.BorderTransportController
+import controllers.declaration.routes.{BorderTransportController, DepartureTransportController}
 import controllers.helpers.TransportSectionHelper.nonPostalOrFTIModeOfTransportCodes
 import forms.common.YesNoAnswer.YesNoAnswers
+import forms.declaration.InlandOrBorder.Border
 import forms.declaration.ModeOfTransportCode.RoRo
 import forms.declaration.TransportCountry
 import forms.declaration.TransportCountry._
@@ -77,6 +78,22 @@ class TransportCountryViewSpec extends UnitViewSpec with ExportsTestData with St
             "contain the expected content" which {
               val view = createView(form(transportMode), transportMode)(journeyRequest(declarationType))
 
+              "display 'Back' button that links to the 'Border Transport' page" in {
+                val backButton = view.getElementById("back-link")
+                backButton must containMessage("site.back")
+                backButton.getElementById("back-link") must haveHref(BorderTransportController.displayPage(Normal))
+              }
+
+              "display 'Back' button that links to the 'Departure Transport' page" when {
+                "the user selects 'Border' on the /inland-or-border page" in {
+                  implicit val request = withRequestOfType(declarationType, withInlandOrBorder(Some(Border)))
+                  val view = createView(form(transportMode), transportMode)
+                  val backButton = view.getElementById("back-link")
+                  backButton must containMessage("site.back")
+                  backButton.getElementById("back-link") must haveHref(DepartureTransportController.displayPage(Normal))
+                }
+              }
+
               "display section header" in {
                 view.getElementById("section-header") must containMessage("declaration.section.6")
               }
@@ -111,12 +128,6 @@ class TransportCountryViewSpec extends UnitViewSpec with ExportsTestData with St
                 label.text mustBe messages(s"$prefix.country.label", transportMode)
                 label.tag.getName mustBe "label"
                 label.id mustBe s"${transportCountry}-label"
-              }
-
-              "display 'Back' button that links to the 'Border Transport' page" in {
-                val backButton = view.getElementById("back-link")
-                backButton must containMessage("site.back")
-                backButton.getElementById("back-link") must haveHref(BorderTransportController.displayPage(Normal))
               }
 
               "display 'Save and continue' button on page" in {


### PR DESCRIPTION
Amend STANDARD and SUPPLEMENTARY journeys skipping /border-transport when user selects 'Border' on /inland-or-border