### PR TITLE
CEDS-3855 Ensure that Agents accessing service see agent-kick-out

### DIFF
--- a/app/controllers/declaration/DeclarationHolderSummaryController.scala
+++ b/app/controllers/declaration/DeclarationHolderSummaryController.scala
@@ -23,7 +23,7 @@ import controllers.navigation.Navigator
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.{formId, YesNoAnswers}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.isArrived
-import forms.declaration.declarationHolder.AuthorizationTypeCodes.{containAtLeastOneOfAuthCodes, isAuthCode, mutuallyExclusiveAuthCodes}
+import forms.declaration.declarationHolder.AuthorizationTypeCodes.{containAtLeastOneOfAuthCodes, isAuthCode}
 import models.Mode
 import models.requests.JourneyRequest
 import play.api.data.{Form, FormError}

--- a/app/forms/declaration/declarationHolder/AuthorizationTypeCodes.scala
+++ b/app/forms/declaration/declarationHolder/AuthorizationTypeCodes.scala
@@ -19,7 +19,6 @@ package forms.declaration.declarationHolder
 import config.featureFlags.MerchandiseInBagConfig
 import controllers.helpers.DeclarationHolderHelper.declarationHolders
 import models.ExportsDeclaration
-import models.codes.HolderOfAuthorisationCode
 import models.requests.JourneyRequest
 
 object AuthorizationTypeCodes {

--- a/app/services/view/HolderOfAuthorisationCodes.scala
+++ b/app/services/view/HolderOfAuthorisationCodes.scala
@@ -16,16 +16,14 @@
 
 package services.view
 
-import config.AppConfig
 import config.featureFlags.MerchandiseInBagConfig
-
-import java.util.Locale
 import connectors.CodeListConnector
 import forms.declaration.declarationHolder.AuthorizationTypeCodes.codesFilteredFromView
 import forms.declaration.declarationHolder.DeclarationHolder
-
-import javax.inject.{Inject, Singleton}
 import models.codes.HolderOfAuthorisationCode
+
+import java.util.Locale
+import javax.inject.{Inject, Singleton}
 
 @Singleton
 class HolderOfAuthorisationCodes @Inject()(codeListConnector: CodeListConnector, merchandiseInBagConfig: MerchandiseInBagConfig) {

--- a/test/base/ExportsTestData.scala
+++ b/test/base/ExportsTestData.scala
@@ -17,8 +17,8 @@
 package base
 
 import forms.Choice
-import forms.Choice._
 import forms.Choice.AllowedChoiceValues._
+import forms.Choice._
 import forms.declaration.LocationOfGoods
 import forms.declaration.ModeOfTransportCode.RoRo
 import models.AuthKey.{enrolment, identifierKey}
@@ -30,7 +30,7 @@ import org.joda.time.DateTimeZone.UTC
 import org.joda.time.{DateTime, LocalDate}
 import play.api.libs.json._
 import services.cache.{ExportsDeclarationBuilder, ExportsItemBuilder}
-import uk.gov.hmrc.auth.core.AffinityGroup.{Agent, Individual}
+import uk.gov.hmrc.auth.core.AffinityGroup.Individual
 import uk.gov.hmrc.auth.core.ConfidenceLevel.L50
 import uk.gov.hmrc.auth.core.retrieve._
 import uk.gov.hmrc.auth.core.{Enrolment, Enrolments, User}
@@ -49,7 +49,6 @@ object ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder
   val nrsItmpAddress =
     ItmpAddress(Some("line1"), Some("line2"), Some("line3"), Some("line4"), Some("line5"), Some("postCode"), Some("countryName"), Some("countryCode"))
   val nrsAffinityGroup = Some(Individual)
-  val nrsAgentAffinityGroup = Some(Agent)
   val nrsCredentialStrength = Some("STRONG")
   val nrsDateOfBirth = Some(LocalDate.now().minusYears(25))
   val eori = "GB123456789012000"
@@ -59,7 +58,6 @@ object ExportsTestData extends ExportsDeclarationBuilder with ExportsItemBuilder
   val mrn = "20GB46J8TMJ4RFGVA0"
   val mucr = "CZYX123A"
   val eidrDateStamp = "20001231"
-  val externalId = "0401"
 
   val pc1040 = Some(ProcedureCodesData(Some("1040"), List(NO_APC_APPLIES_CODE)))
 

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -16,18 +16,7 @@
 
 package base
 
-import base.ExportsTestData.{
-  newUser,
-  nrsAgentAffinityGroup,
-  nrsCredentialRole,
-  nrsCredentialStrength,
-  nrsDateOfBirth,
-  nrsGroupIdentifierValue,
-  nrsItmpAddress,
-  nrsItmpName,
-  nrsLoginTimes,
-  nrsMdtpInformation
-}
+import base.ExportsTestData._
 import config.AppConfig
 import controllers.actions.{AuthActionImpl, EoriAllowList}
 import models.SignedInUser
@@ -241,73 +230,6 @@ trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks with Inje
                                           user.identityData.internalId
                                         ),
                                         user.identityData.affinityGroup
-                                      ),
-                                      user.enrolments
-                                    ),
-                                    user.identityData.agentCode
-                                  ),
-                                  user.identityData.confidenceLevel.get
-                                ),
-                                user.identityData.nino
-                              ),
-                              user.identityData.saUtr
-                            ),
-                            user.identityData.dateOfBirth
-                          ),
-                          user.identityData.agentInformation.get
-                        ),
-                        nrsGroupIdentifierValue
-                      ),
-                      nrsCredentialRole
-                    ),
-                    Some(nrsMdtpInformation)
-                  ),
-                  Some(nrsItmpName)
-                ),
-                nrsDateOfBirth
-              ),
-              Some(nrsItmpAddress)
-            ),
-            nrsCredentialStrength
-          ),
-          nrsLoginTimes
-        )
-      )
-    )
-
-  def agentUser(user: SignedInUser = newUser("12345", "external1")): Unit =
-    when(
-      mockAuthConnector.authorise(
-        any(),
-        ArgumentMatchers.eq(
-          credentials and name and email and externalId and internalId and affinityGroup and allEnrolments
-            and agentCode and confidenceLevel and nino and saUtr and dateOfBirth and agentInformation and groupIdentifier and
-            credentialRole and mdtpInformation and itmpName and itmpDateOfBirth and itmpAddress and credentialStrength and loginTimes
-        )
-      )(any(), any())
-    ).thenReturn(
-      Future.successful(
-        new ~(
-          new ~(
-            new ~(
-              new ~(
-                new ~(
-                  new ~(
-                    new ~(
-                      new ~(
-                        new ~(
-                          new ~(
-                            new ~(
-                              new ~(
-                                new ~(
-                                  new ~(
-                                    new ~(
-                                      new ~(
-                                        new ~(
-                                          new ~(new ~(new ~(user.identityData.credentials, user.identityData.name), user.identityData.email), None),
-                                          user.identityData.internalId
-                                        ),
-                                        nrsAgentAffinityGroup
                                       ),
                                       user.enrolments
                                     ),

--- a/test/controllers/actions/AuthActionSpec.scala
+++ b/test/controllers/actions/AuthActionSpec.scala
@@ -23,7 +23,7 @@ import controllers.{routes, ChoiceController}
 import models.UnauthorisedReason.{UserEoriNotAllowed, UserIsAgent, UserIsNotEnrolled}
 import org.mockito.Mockito.{reset, when}
 import play.api.test.Helpers._
-import uk.gov.hmrc.auth.core.{BearerTokenExpired, FailedRelationship}
+import uk.gov.hmrc.auth.core.{BearerTokenExpired, FailedRelationship, UnsupportedAffinityGroup}
 import views.html.choice_page
 
 import java.net.URLEncoder
@@ -84,7 +84,7 @@ class AuthActionSpec extends ControllerWithoutFormSpec with Injector {
     }
 
     "redirect to /you-cannot-use-this-service when user is an Agent" in {
-      agentUser()
+      unauthorizedUser(UnsupportedAffinityGroup())
 
       val result = controller.displayPage(None)(getRequest())
 

--- a/test/controllers/declaration/DeclarationHolderSummaryControllerSpec.scala
+++ b/test/controllers/declaration/DeclarationHolderSummaryControllerSpec.scala
@@ -17,9 +17,8 @@
 package controllers.declaration
 
 import base.ControllerSpec
-import forms.common.{Eori, YesNoAnswer}
 import forms.common.YesNoAnswer.formId
-import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
+import forms.common.{Eori, YesNoAnswer}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.arrivedTypes
 import forms.declaration.declarationHolder.{AuthorizationTypeCodes, DeclarationHolder}
 import models.DeclarationType._


### PR DESCRIPTION
Previously there were instances where an Agent could potentially see another type of unauthorised page, not the one intended for them. This ensures Agents see the agent kick out regardless of any other auth data values.