### PR TITLE
Ceds 4022 correct links vulnerable to tabnabbing

### DIFF
--- a/app/views/choice_page.scala.html
+++ b/app/views/choice_page.scala.html
@@ -106,8 +106,8 @@
 
             @heading(messages("declaration.choice.link.sfus.description"), "govuk-heading-s", "h2")
 
-            @paragraph(link(id = Some("sfusUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = routes.FileUploadController.startFileUpload(""), target = "_blank"))
-            @paragraph(link(id = Some("sfusInboxLink"), text = messages("declaration.choice.link.sfusInbox.txt"), call = Call("GET", secureMessagingInboxConfig.sfusInboxLink), target = "_blank"))
+            @paragraph(link(id = Some("sfusUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = routes.FileUploadController.startFileUpload(""), target = Some("_blank")))
+            @paragraph(link(id = Some("sfusInboxLink"), text = messages("declaration.choice.link.sfusInbox.txt"), call = Call("GET", secureMessagingInboxConfig.sfusInboxLink), target = Some("_blank")))
 
             <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
         }
@@ -123,7 +123,7 @@
                 )
             )
 
-            @paragraph(link(id = Some("cdsUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = Call("GET", appConfig.cdsUploadDocs), target = "_blank"))
+            @paragraph(link(id = Some("cdsUploadLink"), text = messages("declaration.choice.link.sfusUpload.txt"), call = Call("GET", appConfig.cdsUploadDocs), target = Some("_blank")))
 
             <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible govuk-!-margin-bottom-6 govuk-!-margin-top-2" />
         }

--- a/app/views/components/gds/link.scala.html
+++ b/app/views/components/gds/link.scala.html
@@ -19,7 +19,7 @@
 @(
   text: String,
   call: Call,
-  target: String = "_self",
+  target: Option[String] = None,
   id: Option[String] = None,
   classes: String = "govuk-link govuk-link--no-visited-state",
   textHidden: Option[String] = None
@@ -28,5 +28,5 @@
 @hasHint = @{textHidden.exists(_.nonEmpty)}
 
 @* The <a> tag is split on purpose - to avoid inline-block whitespace problem *@
-<a class="@classes" href="@call" target=@target @id.map{id => id="@id" } @if(target == "_blank"){rel="noopener noreferrer"}
+<a class="@classes" href="@call" @target.map{t => target="@t"} @id.map{id => id="@id" } @if(target == Some("_blank")){rel="noopener noreferrer"}
   ><span @if(hasHint){aria-hidden="true"}>@text</span>@if(hasHint){<span class="govuk-visually-hidden">@{textHidden.getOrElse("")}</span>}</a>

--- a/app/views/components/gds/tariffLink.scala.html
+++ b/app/views/components/gds/tariffLink.scala.html
@@ -20,4 +20,4 @@
 
 @(linkText: String, linkUrl: String)
 
-@link(text = linkText, call = Call("GET", linkUrl), target = "_blank")
+@link(text = linkText, call = Call("GET", linkUrl), target = Some("_blank"))

--- a/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_document_edit.scala.html
@@ -67,7 +67,7 @@
             link(
                 text = messages("declaration.additionalDocument.measurementUnit.link.text"),
                 call = Call("GET", appConfig.additionalDocumentsUnitCodes),
-                target = "_blank"
+                target = Some("_blank")
             )
         ))
     </p>

--- a/app/views/declaration/additionalDocuments/additional_documents_required.scala.html
+++ b/app/views/declaration/additionalDocuments/additional_documents_required.scala.html
@@ -79,14 +79,14 @@
             id = Some("general-trade-tariff-inset-link"),
             text = messages("declaration.additionalDocumentsRequired.inset.link2Alt"),
             call = Call("GET", appConfig.tradeTariffUrl),
-            target = "_blank"
+            target = Some("_blank")
         )
     } { commodityCode =>
         @link(
             id = Some("commodity-code-inset-link"),
             text = messages("declaration.additionalDocumentsRequired.inset.link2", commodityCode.codeAsShown),
             call = Call("GET", appConfig.commodityCodeTariffPageUrl.replace(CommodityDetails.placeholder, commodityCode.codeAsRef)),
-            target = "_blank"
+            target = Some("_blank")
         )
     }
 }
@@ -96,7 +96,7 @@
         id = Some("licenses-and-certificates-inset-link"),
         call = Call("GET", appConfig.licensesForExportingGoods),
         text = messages("declaration.additionalDocumentsRequired.inset.link3"),
-        target = "_blank"
+        target = Some("_blank")
     )
 }
 

--- a/app/views/declaration/additionalInformation/additional_information_edit_content.scala.html
+++ b/app/views/declaration/additionalInformation/additional_information_edit_content.scala.html
@@ -70,7 +70,8 @@
 @paragraphBody(messages("declaration.additionalInformation.code.paragraph", link(
     id = Some("trade_tariff_link"),
     text = messages("declaration.additionalInformation.code.paragraph.link"),
-    call = Call("GET", appConfig.additionalInformationAppendix4)
+    call = Call("GET", appConfig.additionalInformationAppendix4),
+    target = Some("_blank")
 )))
 
 @govukFieldset(Fieldset(

--- a/app/views/declaration/additional_declaration_type.scala.html
+++ b/app/views/declaration/additional_declaration_type.scala.html
@@ -71,7 +71,7 @@
                 content = paragraphBody(messages("declaration.declarationType.notification.content", link(
                     text = messages("declaration.declarationType.notification.content.link"),
                     call = Call("GET", appConfig.guidance.january2022locations),
-                    target = "_blank"
+                    target = Some("_blank")
                 )))
             )
         }

--- a/app/views/declaration/authorisation_procedure_code_choice.scala.html
+++ b/app/views/declaration/authorisation_procedure_code_choice.scala.html
@@ -56,49 +56,49 @@
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.1.linkText"),
             call = Call("GET", appConfig.procedureCodesRemovalOfGoodsFromExciseWarehouse),
-            target = "_blank"
+            target = Some("_blank")
         )))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.2"))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.3",
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.3.linkText"),
             call = Call("GET", appConfig.procedureCodesRemovalOfGoodsFromExciseWarehouse),
-            target = "_blank"
+            target = Some("_blank")
         )))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.4",
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.4.linkText"),
             call = Call("GET", appConfig.procedureCodesOnwardSupplyRelief),
-            target = "_blank"
+            target = Some("_blank")
         )))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.5",
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.5.linkText"),
             call = Call("GET", appConfig.procedureCodesEndUseRelief),
-            target = "_blank"
+            target = Some("_blank")
         )))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.6",
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.6.linkText"),
             call = Call("GET", appConfig.permanentExportOrDispatch.section),
-            target = "_blank"
+            target = Some("_blank")
         )))
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.7"))
     <p>@link(
         text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.8.linkText"),
         call = Call("GET", appConfig.procedureCodesOutwardProcessing),
-        target = "_blank"
+        target = Some("_blank")
     )</p>
     <p>@link(
         text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.9.linkText"),
         call = Call("GET", appConfig.procedureCodesTemporaryExport),
-        target = "_blank"
+        target = Some("_blank")
     )</p>
     @paragraphBody(messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.10",
         link(
             text = messages("declaration.authorisations.procedureCodeChoice.readMoreExpander.paragraph.10.linkText"),
             call = Call("GET", appConfig.procedureCodesReExportFollowingSpecialProcedure),
-            target = "_blank"
+            target = Some("_blank")
         )))
 }
 

--- a/app/views/declaration/carrier_details.scala.html
+++ b/app/views/declaration/carrier_details.scala.html
@@ -50,7 +50,7 @@
     @link(
         text = messages("declaration.carrierAddress.body.2.link"),
         call = Call("GET", appConfig.companyInformationRegister),
-        target = "_blank"
+        target = Some("_blank")
     )
 }
 

--- a/app/views/declaration/commodityMeasure/supplementary_units_yes_no.scala.html
+++ b/app/views/declaration/commodityMeasure/supplementary_units_yes_no.scala.html
@@ -55,13 +55,13 @@
         @link(
             text = messages("declaration.supplementaryUnits.yesNo.body.link.2"),
             call = Call("GET", appConfig.tradeTariffSections),
-            target = "_blank"
+            target = Some("_blank")
         )
     } { commodityCode =>
         @link(
             text = messages("declaration.supplementaryUnits.yesNo.body.link.1", commodityCode.codeAsShown),
             call = Call("GET", appConfig.suppUnitsCommodityCodeTariffPageUrl.replace(CommodityDetails.placeholder, commodityCode.codeAsRef)),
-            target = "_blank"
+            target = Some("_blank")
         )
     }
 }

--- a/app/views/declaration/cus_code.scala.html
+++ b/app/views/declaration/cus_code.scala.html
@@ -61,7 +61,7 @@
             link(
                 messages("declaration.cusCode.paragraph.link"),
                 Call("GET", appConfig.ecicsToolUrl),
-                "_blank"
+                Some("_blank")
             )
         ))
 

--- a/app/views/declaration/declaration_choice.scala.html
+++ b/app/views/declaration/declaration_choice.scala.html
@@ -57,7 +57,7 @@
     link(
         text = messages("declaration.type.insetText.linkText"),
         call = Call("GET", appConfig.declareGoodsExported),
-        target = "_blank"
+        target = Some("_blank")
     )
 }
 
@@ -65,7 +65,7 @@
     link(
         text = messages("declaration.type.details.p1.linkText"),
         call = Call("GET", appConfig.additionalDeclarationType),
-        target = "_blank"
+        target = Some("_blank")
     )
 }
 
@@ -73,7 +73,7 @@
     link(
         text = messages("declaration.type.details.p2.linkText"),
         call = Call("GET", appConfig.simplifiedDeclarationOccasionalUse),
-        target = "_blank"
+        target = Some("_blank")
     )
 }
 

--- a/app/views/declaration/invoice_and_exchange_rate.scala.html
+++ b/app/views/declaration/invoice_and_exchange_rate.scala.html
@@ -136,7 +136,7 @@
             link(
                 text = messages("declaration.invoice.details.body.2.link.text"),
                 call = Call("GET", appConfig.exchangeRatesForCustoms),
-                target = "_blank"
+                target = Some("_blank")
             )
         ))
 

--- a/app/views/declaration/link_ducr_to_mucr.scala.html
+++ b/app/views/declaration/link_ducr_to_mucr.scala.html
@@ -53,7 +53,7 @@
         message = messages("declaration.linkDucrToMucr.details.hint1", link(
             text = messages("declaration.linkDucrToMucr.details.hint1.link"),
             call = Call("GET", appConfig.notesForMucrConsolidationUrl),
-            target = "_blank"
+            target = Some("_blank")
         ))
     )
 

--- a/app/views/declaration/location_of_goods.scala.html
+++ b/app/views/declaration/location_of_goods.scala.html
@@ -82,12 +82,12 @@
               paragraphBody(messages("declaration.locationOfGoods.inset.v3.body1", link(
                   messages("declaration.locationOfGoods.inset.v3.body1.link"),
                   Call("GET", appConfig.getGoodsMovementReference),
-                  "_blank"
+                  Some("_blank")
               ))),
               paragraphBody(messages("declaration.locationOfGoods.inset.v3.body2", link(
                   messages("declaration.locationOfGoods.inset.v3.body2.link"),
                   Call("GET", appConfig.guidance.january2022locations),
-                  "_blank"
+                  Some("_blank")
               )))
           ))))
         }

--- a/app/views/declaration/mucr_code.scala.html
+++ b/app/views/declaration/mucr_code.scala.html
@@ -54,7 +54,7 @@
 
         @heading(messages("declaration.mucr.title"))
 
-        @body(messages("declaration.mucr.paragraph", link(text = messages("declaration.mucr.paragraph.link"), call = Call("GET", appConfig.notesForMucrConsolidationUrl), target = "_blank")))
+        @body(messages("declaration.mucr.paragraph", link(text = messages("declaration.mucr.paragraph.link"), call = Call("GET", appConfig.notesForMucrConsolidationUrl), target = Some("_blank"))))
 
         @exportsInputText(
             field = form(Mucr.MUCR),

--- a/app/views/declaration/nact_code_add_first.scala.html
+++ b/app/views/declaration/nact_code_add_first.scala.html
@@ -67,7 +67,7 @@
             link(
                 messages("declaration.nationalAdditionalCode.addfirst.body.link"),
                 Call("GET", appConfig.nationalAdditionalCodes),
-                "_blank"
+                Some("_blank")
             )
         ))
 

--- a/app/views/declaration/not_declarant.scala.html
+++ b/app/views/declaration/not_declarant.scala.html
@@ -55,6 +55,6 @@
 </p>
 
 <p class="govuk-body">
-    @link(text = messages("general.inquiries.help.link"), call = Call("GET", appConfig.generalEnquiriesHelpUrl), target = "_blank")
+    @link(text = messages("general.inquiries.help.link"), call = Call("GET", appConfig.generalEnquiriesHelpUrl), target = Some("_blank"))
 </p>
 }

--- a/app/views/declaration/not_eligible.scala.html
+++ b/app/views/declaration/not_eligible.scala.html
@@ -32,7 +32,7 @@
 @descriptionLink = {<a href="https://www.gov.uk/guidance/dispatching-your-goods-within-the-eu" class="govuk-link">@messages("notEligible.descriptionLink")</a>}
 @supportPhone = {<b>0300 200 3700</b>}
 @enquiriesLink = {
-  @link(text = messages("general.inquiries.help.link"), call = Call("GET", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries"), target = "_blank")
+  @link(text = messages("general.inquiries.help.link"), call = Call("GET", "https://www.gov.uk/government/organisations/hm-revenue-customs/contact/customs-international-trade-and-excise-enquiries"), target = Some("_blank"))
 }
 
 @govukLayout(

--- a/app/views/declaration/packageInformation/package_information_edit_content.scala.html
+++ b/app/views/declaration/packageInformation/package_information_edit_content.scala.html
@@ -47,7 +47,7 @@
         message = messages("declaration.packageInformation.numberOfPackages.details.paragraph.3", link(
             text = messages("declaration.packageInformation.numberOfPackages.details.paragraph.3.link"),
             call = Call("GET", appConfig.combinedPackaging),
-            target = "_blank"))
+            target = Some("_blank")))
     )
 }
 

--- a/app/views/declaration/statistical_value.scala.html
+++ b/app/views/declaration/statistical_value.scala.html
@@ -61,7 +61,7 @@
 
     @paragraphBody(messages(
         "declaration.statisticalValue.inset.text.2",
-        link(messages("declaration.statisticalValue.inset.text.2.link"), Call("GET", appConfig.hmrcExchangeRatesFor2021), "_blank")
+        link(messages("declaration.statisticalValue.inset.text.2.link"), Call("GET", appConfig.hmrcExchangeRatesFor2021), Some("_blank"))
     ))
 }
 

--- a/app/views/declaration/taric_code_add_first.scala.html
+++ b/app/views/declaration/taric_code_add_first.scala.html
@@ -57,13 +57,13 @@
     @commodityCodeOfItem(itemId).fold {
         @link(
             text = messages("declaration.taricAdditionalCodes.addfirst.body.altlink"),
-            Call("GET", appConfig.tradeTariffUrl), "_blank"
+            Call("GET", appConfig.tradeTariffUrl), Some("_blank")
         )
     } { commodityCode =>
         @link(
             text = messages("declaration.taricAdditionalCodes.addfirst.body.link", commodityCode.codeAsShown),
           Call("GET", appConfig.commodityCodeTariffPageUrl.replace(CommodityDetails.placeholder, commodityCode.codeAsRef)),
-          "_blank"
+          Some("_blank")
         )
     }
 }
@@ -86,7 +86,7 @@
             paragraphBody(messages("declaration.taricAdditionalCodes.addfirst.inset.text", link(
                 messages("declaration.taricAdditionalCodes.addfirst.inset.text.link"),
                 Call("GET", appConfig.commodityCode9306909000),
-                "_blank"
+                Some("_blank")
             )))
         ))))
 

--- a/app/views/declaration/transport_leaving_the_border.scala.html
+++ b/app/views/declaration/transport_leaving_the_border.scala.html
@@ -56,7 +56,7 @@
             link(
                 call = Call("GET", GuidanceController.sendByRoro.url),
                 text = messages("declaration.transport.leavingTheBorder.inset.link"),
-                target = "_blank"
+                target = Some("_blank")
             )
         )))
     }

--- a/app/views/declaration/un_dangerous_goods_code.scala.html
+++ b/app/views/declaration/un_dangerous_goods_code.scala.html
@@ -57,7 +57,7 @@
 
         @heading(messages("declaration.unDangerousGoodsCode.header"))
 
-        @body(messages("declaration.unDangerousGoodsCode.paragraph", link(text = messages("declaration.unDangerousGoodsCode.paragraph.link"), call = Call("GET", appConfig.unDangerousGoodsUrl), target = "_blank")))
+        @body(messages("declaration.unDangerousGoodsCode.paragraph", link(text = messages("declaration.unDangerousGoodsCode.paragraph.link"), call = Call("GET", appConfig.unDangerousGoodsUrl), target = Some("_blank"))))
 
         @govukRadios(Radios(
             name = hasDangerousGoodsCodeKey,

--- a/app/views/declaration_details.scala.html
+++ b/app/views/declaration_details.scala.html
@@ -60,7 +60,7 @@
                 id = Some("uploading-documents-link"),
                 text = messages("submissions.uploading.documents"),
                 call = controllers.routes.FileUploadController.startFileUpload(mrn),
-                target = "_blank"
+                target = Some("_blank")
             )
         </p>
     }

--- a/app/views/guidance/error_explanation.scala.html
+++ b/app/views/guidance/error_explanation.scala.html
@@ -534,7 +534,7 @@
             <td class="govuk-table__cell">
             <p><strong>You declared 2 values that cannot be declared both together</strong></p>
 
-            <p>Check the @link(text = "CDS data element completion guide (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target = "_blank").</p>
+            <p>Check the @link(text = "CDS data element completion guide (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target = Some("_blank")).</p>
             </td>
         </tr>
 
@@ -550,13 +550,13 @@
             <td class="govuk-table__cell">
             <p><strong>The same data element has been completed twice</strong></p>
 
-            <p>Data elements @link(text = "may only be declared at header level where (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target="_blank") the information applies equally
+            <p>Data elements @link(text = "may only be declared at header level where (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target=Some("_blank")) the information applies equally
             to all goods items. Otherwise it should only be completed for each individual
             goods item. For example, previous document or container ID can be entered at
             header level or item level, but if you use both header and item level you may
             cause an invalidation.</p>
 
-            <p>Check the @link(text = "CDS data element completion guide (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target="_blank").</p>
+            <p>Check the @link(text = "CDS data element completion guide (opens in new tab)", call = Call("GET", "https://www.gov.uk/government/publications/uk-trade-tariff-cds-volume-3-export-declaration-completion-guide"), target=Some("_blank")).</p>
             </td>
         </tr>
 

--- a/app/views/helpers/AdditionalDocumentHelper.scala
+++ b/app/views/helpers/AdditionalDocumentHelper.scala
@@ -73,8 +73,8 @@ class AdditionalDocumentHelper @Inject() (
     s"$prefix.v${versionSelection(itemId)}.code.hint"
 
   def documentCodeExpander(implicit messages: Messages): Html = {
-    val link1 = link(messages(s"$prefix.code.expander.body.1.link"), Call("GET", appConfig.additionalDocumentsUnionCodes), "_blank")
-    val link2 = link(messages(s"$prefix.code.expander.body.2.link"), Call("GET", appConfig.additionalDocumentsReferenceCodes), "_blank")
+    val link1 = link(messages(s"$prefix.code.expander.body.1.link"), Call("GET", appConfig.additionalDocumentsUnionCodes), Some("_blank"))
+    val link2 = link(messages(s"$prefix.code.expander.body.2.link"), Call("GET", appConfig.additionalDocumentsReferenceCodes), Some("_blank"))
 
     val content = List(
       paragraph(messages(s"$prefix.code.expander.body.1", link1)),
@@ -158,7 +158,7 @@ class AdditionalDocumentHelper @Inject() (
             link(
               text = messages(s"$prefix.expander.body.1.withoutCommodityCode.link"),
               call = Call("GET", appConfig.tradeTariffSections),
-              target = "_blank"
+              target = Some("_blank")
             )
           )
         )
@@ -169,7 +169,7 @@ class AdditionalDocumentHelper @Inject() (
             link(
               text = messages(s"$prefix.expander.body.1.withCommodityCode.link", commodityCode.codeAsShown),
               call = Call("GET", appConfig.commodityCodeTariffPageUrl.replace(CommodityDetails.placeholder, commodityCode.codeAsRef)),
-              target = "_blank"
+              target = Some("_blank")
             )
           )
         )
@@ -178,7 +178,11 @@ class AdditionalDocumentHelper @Inject() (
       paragraph(
         messages(
           s"$prefix.expander.body.3",
-          link(text = messages(s"$prefix.expander.body.3.link"), call = Call("GET", appConfig.additionalDocumentsLicenceTypes), target = "_blank")
+          link(
+            text = messages(s"$prefix.expander.body.3.link"),
+            call = Call("GET", appConfig.additionalDocumentsLicenceTypes),
+            target = Some("_blank")
+          )
         )
       )
     )
@@ -187,7 +191,7 @@ class AdditionalDocumentHelper @Inject() (
     paragraph(
       messages(
         s"$prefix.expander.body.4",
-        link(messages(s"$prefix.expander.body.4.link"), Call("GET", appConfig.guidance.commodityCode0306310010), "_blank")
+        link(messages(s"$prefix.expander.body.4.link"), Call("GET", appConfig.guidance.commodityCode0306310010), Some("_blank"))
       )
     )
 }

--- a/app/views/helpers/AdditionalInformationRequiredHelper.scala
+++ b/app/views/helpers/AdditionalInformationRequiredHelper.scala
@@ -44,7 +44,7 @@ class AdditionalInformationRequiredHelper @Inject() (appConfig: AppConfig, parag
           id = Some("ai_containers_link"),
           text = messages("declaration.additionalInformationRequired.clearanceOr1040.para1.link"),
           call = Call("GET", appConfig.guidance.aiCodesForContainers),
-          target = "_blank"
+          target = Some("_blank")
         )
       )
     )
@@ -56,7 +56,7 @@ class AdditionalInformationRequiredHelper @Inject() (appConfig: AppConfig, parag
           id = Some("ai_codes_link"),
           text = messages("declaration.additionalInformationRequired.clearanceOr1040.para2.link"),
           call = Call("GET", appConfig.guidance.aiCodes),
-          target = "_blank"
+          target = Some("_blank")
         )
       )
     )
@@ -78,7 +78,7 @@ class AdditionalInformationRequiredHelper @Inject() (appConfig: AppConfig, parag
           id = Some("proc_codes_link"),
           text = messages("declaration.additionalInformationRequired.not1040.inset.para1.link"),
           call = Call("GET", appConfig.previousProcedureCodes),
-          target = "_blank"
+          target = Some("_blank")
         )
       )
     )
@@ -90,7 +90,7 @@ class AdditionalInformationRequiredHelper @Inject() (appConfig: AppConfig, parag
           id = Some("ai_codes_link"),
           text = messages("declaration.additionalInformationRequired.not1040.inset.para2.link"),
           call = Call("GET", appConfig.guidance.aiCodes),
-          target = "_blank"
+          target = Some("_blank")
         )
       )
     )

--- a/app/views/helpers/ConfirmationHelper.scala
+++ b/app/views/helpers/ConfirmationHelper.scala
@@ -183,7 +183,7 @@ class ConfirmationHelper @Inject() (
     val paragraph2 = paragraph(
       messages(
         "declaration.confirmation.whatYouCanDoNow.paragraph.2",
-        link(messages("declaration.confirmation.whatYouCanDoNow.paragraph.2.link"), FileUploadController.startFileUpload(mrn), "_blank")
+        link(messages("declaration.confirmation.whatYouCanDoNow.paragraph.2.link"), FileUploadController.startFileUpload(mrn), Some("_blank"))
       )
     )
 

--- a/app/views/helpers/DeclarationHolderEditHelper.scala
+++ b/app/views/helpers/DeclarationHolderEditHelper.scala
@@ -115,13 +115,13 @@ class DeclarationHolderEditHelper @Inject() (
 
   private def insetTextForExciseRemovals(appConfig: AppConfig)(implicit messages: Messages): Option[Html] = {
     val call1 = Call("GET", appConfig.permanentExportOrDispatch.authHolder)
-    val link1 = link(messages(s"$prefix.authCode.inset.excise.bullet1.link"), call1, "_blank")
+    val link1 = link(messages(s"$prefix.authCode.inset.excise.bullet1.link"), call1, Some("_blank"))
 
     val call2 = Call("GET", appConfig.permanentExportOrDispatch.conditions)
-    val link2 = link(messages(s"$prefix.authCode.inset.excise.bullet2.link"), call2, "_blank")
+    val link2 = link(messages(s"$prefix.authCode.inset.excise.bullet2.link"), call2, Some("_blank"))
 
     val call3 = Call("GET", appConfig.permanentExportOrDispatch.documents)
-    val link3 = link(messages(s"$prefix.authCode.inset.excise.bullet3.link"), call3, "_blank")
+    val link3 = link(messages(s"$prefix.authCode.inset.excise.bullet3.link"), call3, Some("_blank"))
 
     insetText(
       bulletList(
@@ -137,7 +137,7 @@ class DeclarationHolderEditHelper @Inject() (
 
   private def insetTextForNonStandardProcedures(appConfig: AppConfig)(implicit messages: Messages): Option[Html] = {
     val call1 = Call("GET", appConfig.previousProcedureCodes)
-    val link1 = link(messages(s"$prefix.authCode.inset.special.bullet1.link"), call1, "_blank")
+    val link1 = link(messages(s"$prefix.authCode.inset.special.bullet1.link"), call1, Some("_blank"))
 
     insetText(
       numberedList(
@@ -159,7 +159,7 @@ class DeclarationHolderEditHelper @Inject() (
     List(
       messages(
         s"$prefix.body.$key.1007",
-        link(messages(s"$prefix.body.1007.link"), Call("GET", appConfig.permanentExportOrDispatch.section), "_blank")
+        link(messages(s"$prefix.body.1007.link"), Call("GET", appConfig.permanentExportOrDispatch.section), Some("_blank"))
       )
     )
 

--- a/app/views/helpers/LocationOfGoodsHelper.scala
+++ b/app/views/helpers/LocationOfGoodsHelper.scala
@@ -54,7 +54,7 @@ class LocationOfGoodsHelper @Inject() (
 
         List(
           messages(s"$prefix.body.v2.1"),
-          messages(s"$prefix.body.v2.2", link(linkText2, Call("GET", appConfig.locationCodesForCsePremises), "_blank")),
+          messages(s"$prefix.body.v2.2", link(linkText2, Call("GET", appConfig.locationCodesForCsePremises), Some("_blank"))),
           messages(s"$prefix.body.v2.3", link(email, Call("GET", s"mailto:$email?subject=$subject")))
         ).map(body(_))
 
@@ -79,9 +79,9 @@ class LocationOfGoodsHelper @Inject() (
         List(
           body(messages(s"$prefix.body.v4.1")),
           body(messages(s"$prefix.body.v4.1.1")),
-          body(messages(s"$prefix.body.v4.2", link(linkText2, Call("GET", appConfig.previousProcedureCodes), "_blank"))),
+          body(messages(s"$prefix.body.v4.2", link(linkText2, Call("GET", appConfig.previousProcedureCodes), Some("_blank")))),
           body(messages(s"$prefix.body.v4.3.label"), "govuk-heading-s"),
-          body(messages(s"$prefix.body.v4.3", link(linkText3, Call("GET", appConfig.locationCodesForPortsUsingGVMS), "_blank")))
+          body(messages(s"$prefix.body.v4.3", link(linkText3, Call("GET", appConfig.locationCodesForPortsUsingGVMS), Some("_blank"))))
         )
 
       // version 1
@@ -138,10 +138,10 @@ class LocationOfGoodsHelper @Inject() (
     (1 to 10).flatMap { ix =>
       val title = if (ix <= 9) Some(heading(text(s"$ix.title"), titleClasses, "h2")) else None
       val hint =
-        if (ix <= 8) row(link(text(s"$ix.link1"), Call("GET", expanderLinks(ix)._1), "_blank"), classes = "")
+        if (ix <= 8) row(link(text(s"$ix.link1"), Call("GET", expanderLinks(ix)._1), Some("_blank")), classes = "")
         else {
-          val link1 = link(text(s"$ix.link1"), Call("GET", expanderLinks(ix)._1), "_blank")
-          val link2 = link(text(s"$ix.link2"), Call("GET", expanderLinks(ix)._2), "_blank")
+          val link1 = link(text(s"$ix.link1"), Call("GET", expanderLinks(ix)._1), Some("_blank"))
+          val link2 = link(text(s"$ix.link2"), Call("GET", expanderLinks(ix)._2), Some("_blank"))
           govukHint(Hint(content = HtmlContent(text(s"$ix.text", link1, link2))))
         }
 

--- a/app/views/helpers/PreviousDocumentsHelper.scala
+++ b/app/views/helpers/PreviousDocumentsHelper.scala
@@ -76,7 +76,7 @@ class PreviousDocumentsHelper @Inject() (
 
     val paragraphsForInsetText =
       if (versionSelection == 2) {
-        val linkForV2 = link(messages(s"$prefix.inset.text.3.link"), Call("GET", appConfig.simplifiedDeclPreviousDoc), "_blank")
+        val linkForV2 = link(messages(s"$prefix.inset.text.3.link"), Call("GET", appConfig.simplifiedDeclPreviousDoc), Some("_blank"))
         commonParagraphs :+ paragraph("inset.text.3", linkForV2)
       } else commonParagraphs
 

--- a/app/views/unauthorisedEori.scala.html
+++ b/app/views/unauthorisedEori.scala.html
@@ -37,7 +37,7 @@
             id = Some("contact_support_link"),
             text = messages("unauthorised.tdr.body.link"),
             call = Call("GET", s"mailto:${messages("unauthorised.tdr.body.link")}"),
-            target="_blank"
+            target = Some("_blank")
         ))
     )
 }

--- a/test/views/UnauthorisedViewSpec.scala
+++ b/test/views/UnauthorisedViewSpec.scala
@@ -54,18 +54,14 @@ class UnauthorisedViewSpec extends UnitViewSpec with Stubs with Injector with Be
 
         link.get(0) must containMessage("unauthorised.paragraph.1.linkText")
         link.get(0) must haveHref("https://www.gov.uk/guidance/get-access-to-the-customs-declaration-service")
-        link.get(0).attr("target") mustBe "_self"
 
         link.get(1) must containMessage("unauthorised.paragraph.2.linkText")
         link.get(1) must haveHref("https://www.gov.uk/log-in-register-hmrc-online-services/problems-signing-in")
-        link.get(1).attr("target") mustBe "_self"
 
         link.get(2) must containMessage("unauthorised.paragraph.3.linkText")
         link.get(2) must haveHref(
           "https://www.gov.uk/government/publications/use-hmrcs-business-tax-account/use-hmrcs-business-tax-account#adding-a-team-member"
         )
-        link.get(2).attr("target") mustBe "_self"
-
       }
 
       "display the expected sign out link" in {


### PR DESCRIPTION
Refactored link component so that `target="_self"` is no longer default behaviour in absence of a parameter.
This is because "_self" is default link behaviour anyway, and it just so happens to trigger the ZAP tests.
This is incorrect reporting on behalf of the ZAP test and I have mentioned this on the team-platsec channel.