### PR TITLE
CEDS-4787 DEV: Fix issues with DiffTool producing incorrect pointers

### DIFF
--- a/app/forms/declaration/ConsigneeDetails.scala
+++ b/app/forms/declaration/ConsigneeDetails.scala
@@ -29,7 +29,7 @@ import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
 
 case class ConsigneeDetails(details: EntityDetails) extends DiffTools[ConsigneeDetails] {
   override def createDiff(original: ConsigneeDetails, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(details.createDiff(original.details, combinePointers(pointerString, ConsigneeDetails.pointer, sequenceId))).flatten
+    Seq(details.createDiff(original.details, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object ConsigneeDetails extends DeclarationPage with FieldMapping {

--- a/app/forms/declaration/NactCode.scala
+++ b/app/forms/declaration/NactCode.scala
@@ -33,7 +33,7 @@ case class NactCode(nactCode: String) extends Ordered[NactCode] {
 object NactCode extends DeclarationPage with FieldMapping {
   implicit val format = Json.format[NactCode]
 
-  val pointer: ExportsFieldPointer = CommodityDetails.combinedNomenclatureCodePointer
+  val pointer: ExportsFieldPointer = "nactCode"
 
   val nactCodeKey = "nactCode"
 

--- a/app/forms/declaration/TaricCode.scala
+++ b/app/forms/declaration/TaricCode.scala
@@ -32,7 +32,7 @@ case class TaricCode(taricCode: String) extends Ordered[TaricCode] {
 object TaricCode extends DeclarationPage with FieldMapping {
   implicit val format = Json.format[TaricCode]
 
-  val pointer: ExportsFieldPointer = CommodityDetails.combinedNomenclatureCodePointer
+  val pointer: ExportsFieldPointer = "taricCode"
 
   val taricCodeKey = "taricCode"
   val taricCodeLength = 4

--- a/app/forms/declaration/carrier/CarrierDetails.scala
+++ b/app/forms/declaration/carrier/CarrierDetails.scala
@@ -31,7 +31,7 @@ import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
 
 case class CarrierDetails(details: EntityDetails) extends DiffTools[CarrierDetails] {
   override def createDiff(original: CarrierDetails, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(details.createDiff(original.details, combinePointers(pointerString, CarrierDetails.pointer, sequenceId))).flatten
+    Seq(details.createDiff(original.details, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object CarrierDetails extends DeclarationPage with FieldMapping {

--- a/app/forms/declaration/consignor/ConsignorDetails.scala
+++ b/app/forms/declaration/consignor/ConsignorDetails.scala
@@ -31,7 +31,7 @@ import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
 
 case class ConsignorDetails(details: EntityDetails) extends DiffTools[ConsignorDetails] {
   override def createDiff(original: ConsignorDetails, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(details.createDiff(original.details, combinePointers(pointerString, ConsignorDetails.pointer, sequenceId))).flatten
+    Seq(details.createDiff(original.details, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object ConsignorDetails extends DeclarationPage with FieldMapping {


### PR DESCRIPTION
Fix Taric code pointer to point to 'taricCode'
Fix National Additional code pointer to point to 'nactCode' 
Fix CarrierDetails pointer to not repeat 'carrierDetails' part of pointer 
Fix ConsigneeDetails pointer to not repeat 'consigneeDetails' part of pointer 
Fix ConsignorDetails pointer to not repeat 'consignorDetails' part of pointer