### PR TITLE
CEDS-4772 Fix of incorrect display order on the Timeline page for rejected amendments

### DIFF
--- a/app/views/helpers/TimelineEvents.scala
+++ b/app/views/helpers/TimelineEvents.scala
@@ -29,6 +29,7 @@ import views.html.components.gds.{link, linkButton, paragraphBody}
 import views.html.components.upload_files_partial_for_timeline
 
 import java.time.ZonedDateTime
+import java.time.temporal.ChronoUnit.SECONDS
 import java.util.UUID
 import javax.inject.{Inject, Singleton}
 
@@ -126,7 +127,7 @@ class TimelineEvents @Inject() (
   }
 
   private def amendmentEvent(action: Action): NotificationEvent = {
-    val notificationSummary = NotificationSummary(UUID.randomUUID, action.requestTimestamp, AMENDED)
+    val notificationSummary = NotificationSummary(UUID.randomUUID, action.requestTimestamp.truncatedTo(SECONDS), AMENDED)
     NotificationEvent(action.id, action.requestType, notificationSummary)
   }
 


### PR DESCRIPTION
The problem was due to the fact that the `NotificationSummary.dateTimeIssued` value has no milliseconds defined, where as the `Action.requestTimestamp` does have milliseconds.

To correctly render events on the timeline page we create a 'fake' amendment request event, and set it's dateTime value to equal the `Action.requestTimestamp` value (that includes milliseconds).

However the amendment notification we receive back from DMS (the `NotificationSummary.dateTimeIssued` value) has no milliseconds value (so its effective value is '000'ms).

So when the 2 events are sorted the 'fake' request event (based on the `Action.requestTimestamp`) always appears chronologically later than the actual notification event (based on the `NotificationSummary.dateTimeIssued`). Obviously the request event should always appear before the notification event.

To resolve this issue, we now truncate the `Action.requestTimestamp` value to omit the miliseconds when creating the 'fake' request event, thus ensuring that the value is <= the `NotificationSummary.dateTimeIssued` value.