### PR TITLE
CEDS-4812 Secure Exports FE login on TDR with additional secret value

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ We use the following codes:
  * [Package Type codes](https://www.gov.uk/government/publications/package-type-codes-for-data-element-69-of-the-customs-declaration-service) (6/9 in tariff) *Last published: 1 August 2018*
  * [Customs supervising office codes](https://www.gov.uk/government/publications/supervising-office-codes-for-data-element-527-of-the-customs-declaration-service) (5/27 in tariff) *Last updated 13 March 2023*
 
+## Generating TDRSecret values for a given EORI
+As this service deployed in ExternalTest as part of the CDS Trader Dress Rehearsal, an additional enrolment value of 'TDRSecret' is required for a user to successfully authenticate in this environment.
+
+To generate a valid 'TDRSecret' value for a user you can call the following program replacing the two `<???>` parameters with the appropriate values:
+
+```sbt "runMain utils.GenerateTdrSecret <tdrHashSalt> <eori>"```
+
 ## License
 
 This code is open source software licensed under the [Apache 2.0 License]("http://www.apache.org/licenses/LICENSE-2.0.html")

--- a/app/utils/GenerateTdrSecret.scala
+++ b/app/utils/GenerateTdrSecret.scala
@@ -14,11 +14,19 @@
  * limitations under the License.
  */
 
-package models
+package utils
 
-object AuthKey {
+import utils.HashingUtils.generateHashOfValue
 
-  val enrolment: String = "HMRC-CUS-ORG"
-  val identifierKey: String = "EORINumber"
-  val hashIdentifierKey: String = "TDRSecret"
+object GenerateTdrSecret {
+  def main(args: Array[String]): Unit =
+    if (args.length != 2) {
+      Console.err.println("Usage: GenerateTdrSecret <tdrHashSalt> <eori>")
+      sys.exit(1)
+    } else {
+      val tdrHashSalt = args(0)
+      val eori = args(1)
+
+      println(generateHashOfValue(eori, tdrHashSalt))
+    }
 }

--- a/app/utils/HashingUtils.scala
+++ b/app/utils/HashingUtils.scala
@@ -14,11 +14,24 @@
  * limitations under the License.
  */
 
-package models
+package utils
 
-object AuthKey {
+import org.apache.commons.codec.digest.HmacAlgorithms
 
-  val enrolment: String = "HMRC-CUS-ORG"
-  val identifierKey: String = "EORINumber"
-  val hashIdentifierKey: String = "TDRSecret"
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
+import javax.xml.bind.DatatypeConverter
+
+object HashingUtils {
+  private val algorithm = HmacAlgorithms.HMAC_SHA_256.toString
+
+  def generateHashOfValue(value: String, hiddenSalt: String): String = {
+    val secretSpec = new SecretKeySpec(hiddenSalt.getBytes(), algorithm)
+    val hmac = Mac.getInstance(algorithm)
+
+    hmac.init(secretSpec)
+
+    val sig = hmac.doFinal(value.getBytes("UTF-8"))
+    DatatypeConverter.printHexBinary(sig)
+  }
 }

--- a/conf/application.conf
+++ b/conf/application.conf
@@ -324,10 +324,6 @@ files.codelists.tagged-transport-codes = "/code-lists/tagged-transport-codes.jso
 accessibility-statement.service-path = "/customs-declare-exports"
 
 allowList {
-  ips = "MTI3LjAuMC4x"
-  excludedPaths = "L2hlYWx0aGNoZWNrLC9waW5nL3Bpbmc="
-  shutterPage = "https://www.tax.service.gov.uk/shutter/customs-declare-exports-shutter-page"
-  enabled = false
   eori = []
 }
 

--- a/conf/messages
+++ b/conf/messages
@@ -75,8 +75,8 @@ unauthorised.paragraph.3.linkText = add you as an administrator level team membe
 unauthorised.insetText = Check with the person who deals with VAT, for example, as they may have registered for CDS in order to claim back VAT.
 
 unauthorised.heading.eori.not.allowed = Your EORI number is not valid on this service
-unauthorised.tdr.heading = The CDS Trader Dress Rehearsal Service for Making an Export Declaration Online is temporarily unavailable whilst we carry out a system update
-unauthorised.tdr.body = We will advise as soon as the update is complete.
+unauthorised.tdr.heading = The EORI you entered is not valid on the customs declaration test service
+unauthorised.tdr.body = You need to contact {0} to ensure access has been set up for your EORI number.
 unauthorised.tdr.body.link = cdsexportsuiteam@hmrc.gov.uk
 
 unauthorisedAgent.heading = You cannot use this service

--- a/project/AppDependencies.scala
+++ b/project/AppDependencies.scala
@@ -15,7 +15,8 @@ object AppDependencies {
     "com.fasterxml.jackson.module" %% "jackson-module-scala"          % "2.14.2",
     "com.github.tototoshi"         %% "scala-csv"                     % "1.3.10",
     "net.sf.barcode4j"             %  "barcode4j"                     % "2.1",
-    "org.webjars.npm"              %  "accessible-autocomplete"       % "2.0.4"
+    "org.webjars.npm"              %  "accessible-autocomplete"       % "2.0.4",
+    "commons-codec"                %  "commons-codec"                 % "1.15"
   ).map(_.withSources)
 
   val test: Seq[ModuleID] = Seq(

--- a/test/base/MockAuthAction.scala
+++ b/test/base/MockAuthAction.scala
@@ -45,7 +45,7 @@ trait MockAuthAction extends MockitoSugar with Stubs with MetricsMocks with Inje
     new AuthActionImpl(mockAuthConnector, new EoriAllowList(Seq.empty), stubMessagesControllerComponents(), metricsMock, appConfig)
 
   val authEori = "12345"
-  val exampleUser = newUser(authEori, "external1")
+  val exampleUser = newUser(authEori, "external1", Some("9C7605A1AA5F58FE5E21F66CA413ACD0DD2F18EF341B33D9B059379B3214CDDF"))
 
   def unauthorizedUser(exceptionThrown: AuthorisationException): Unit =
     when(

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -54,6 +54,8 @@ class AppConfigSpec extends UnitWithMocksSpec {
         |microservice.services.customs-declare-exports-movements.port=9876
         |microservice.services.customs-declare-exports-movements.save-movement-uri=/save-movement-submission
         |play.frontend.host="self/base-url"
+        |
+        |secret.tdrHashSalt="SomeSuperSecret"
       """.stripMargin)
 
   private val validServicesConfiguration = Configuration(validConfig)
@@ -305,6 +307,18 @@ class AppConfigSpec extends UnitWithMocksSpec {
       validAppConfig.selfBaseUrl.get must be("self/base-url")
     }
 
+    "empty selfBaseUrl when the key is missing" in {
+      missingAppConfig.selfBaseUrl must be(None)
+    }
+
+    "have tdrHashSalt" in {
+      validAppConfig.maybeTdrHashSalt must be(Some("SomeSuperSecret"))
+    }
+
+    "empty tdrHashSalt when the key is missing" in {
+      missingAppConfig.maybeTdrHashSalt must be(None)
+    }
+
     "have additionalProcedureCodesOfCDs URL" in {
       validAppConfig.additionalProcedureCodesOfCDs must be("http://additionalProcedureCodesOfCDs")
     }
@@ -333,10 +347,6 @@ class AppConfigSpec extends UnitWithMocksSpec {
     "have single Declaration type options when list-of-available-declarations is not defined" in {
       missingAppConfig.availableDeclarations().size must be(1)
       missingAppConfig.availableDeclarations() must contain(DeclarationType.STANDARD.toString)
-    }
-
-    "empty selfBaseUrl when the key is missing" in {
-      missingAppConfig.selfBaseUrl must be(None)
     }
 
     "throw an exception" when {

--- a/test/controllers/ChoiceControllerSpec.scala
+++ b/test/controllers/ChoiceControllerSpec.scala
@@ -40,7 +40,7 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues w
   import ChoiceControllerSpec._
 
   val choicePage = mock[choice_page]
-  override val appConfig = mock[AppConfig]
+  val controllerAppConfig = mock[AppConfig]
   val externalServicesConfig = instanceOf[ExternalServicesConfig]
 
   val controller =
@@ -50,7 +50,7 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues w
       stubMessagesControllerComponents(),
       mockSecureMessagingInboxConfig,
       choicePage,
-      appConfig,
+      controllerAppConfig,
       externalServicesConfig
     )
 
@@ -58,11 +58,12 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues w
     super.beforeEach()
     authorizedUser()
     when(choicePage.apply(any(), any())(any(), any())).thenReturn(HtmlFormat.empty)
-    when(appConfig.availableJourneys()).thenReturn(allJourneys)
+    when(controllerAppConfig.availableJourneys()).thenReturn(allJourneys)
+    when(controllerAppConfig.maybeTdrHashSalt).thenReturn(None)
   }
 
   override protected def afterEach(): Unit = {
-    reset(choicePage, appConfig, mockSecureMessagingInboxConfig)
+    reset(choicePage, controllerAppConfig, mockSecureMessagingInboxConfig)
     super.afterEach()
   }
 
@@ -214,7 +215,7 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues w
         stubMessagesControllerComponents(),
         mockSecureMessagingInboxConfig,
         choicePage,
-        appConfig,
+        controllerAppConfig,
         externalServicesConfig
       )
       allJourneys.diff(choiceCtrl.availableJourneys).size mustBe 0
@@ -229,7 +230,7 @@ class ChoiceControllerSpec extends ControllerWithoutFormSpec with OptionValues w
         stubMessagesControllerComponents(),
         mockSecureMessagingInboxConfig,
         choicePage,
-        appConfig,
+        controllerAppConfig,
         externalServicesConfig
       )
       val missingJourneyTypes = allJourneys.diff(choiceCtrl.availableJourneys)

--- a/test/views/UnauthorisedEoriViewSpec.scala
+++ b/test/views/UnauthorisedEoriViewSpec.scala
@@ -32,5 +32,13 @@ class UnauthorisedEoriViewSpec extends UnitViewSpec with Injector {
     "display the expected page header" in {
       view.getElementsByTag("h1").first must containMessage("unauthorised.tdr.heading")
     }
+
+    "display the expected contact email address link" in {
+      val link = view.getElementById("contact_support_link")
+
+      link must containMessage("unauthorised.tdr.body.link")
+      link must haveHref(s"mailto:${messages("unauthorised.tdr.body.link")}")
+      link.attr("target") mustBe "_blank"
+    }
   }
 }


### PR DESCRIPTION
Adding new 'secret.tdrHashSalt' config value that will only be set in the TDR environment.

Adding additional authentication check that if the 'tdrHashSalt' value is present in config, then the user must specify an additional HMRC-CUS-ORG enrolment value of 'TDRSecret' who's value must be a valid hash of the supplied 'EORINumber' value.

Also removing redundant legacy appconfig values: "allowList.shutterPage", "allowList.ips","allowList.excludedPaths" & "allowList.enabled"