### PR TITLE
CEDS-4834 amend cip preparing an audit event payload for amend functionality

### DIFF
--- a/app/handlers/ErrorHandler.scala
+++ b/app/handlers/ErrorHandler.scala
@@ -60,12 +60,12 @@ class ErrorHandler @Inject() (override val messagesApi: MessagesApi, errorPage: 
   def badRequest(implicit request: Request[_]): Result =
     BadRequest(globalErrorPage)
 
-  def internalServerError(message: String): Result = {
+  def internalServerError(message: String)(implicit request: Request[_]): Result = {
     logger.warn(message)
-    InternalServerError("")
+    InternalServerError(globalErrorPage)
   }
 
-  def internalError(message: String): Future[Result] =
+  def internalError(message: String)(implicit request: Request[_]): Future[Result] =
     Future.successful(internalServerError(message))
 
   def redirectToErrorPage(implicit request: Request[_]): Future[Result] =

--- a/test/controllers/DeclarationDetailsControllerSpec.scala
+++ b/test/controllers/DeclarationDetailsControllerSpec.scala
@@ -19,8 +19,8 @@ package controllers
 import base.ControllerWithoutFormSpec
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType.{AdditionalDeclarationType, STANDARD_FRONTIER}
 import mock.ErrorHandlerMocks
-import models.declaration.submissions.RequestType.{ExternalAmendmentRequest, SubmissionRequest}
 import models.declaration.submissions.{Action, Submission}
+import models.declaration.submissions.RequestType.{ExternalAmendmentRequest, SubmissionRequest}
 import models.requests.SessionHelper
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers._
@@ -136,7 +136,6 @@ class DeclarationDetailsControllerSpec extends ControllerWithoutFormSpec with Be
     }
 
     "return 500 (INTERNAL_SERVER-ERROR)" when {
-
       "there is no submission for the Declaration" in {
         when(mockCustomsDeclareExportsConnector.findSubmission(any())(any(), any())).thenReturn(Future.successful(None))
 
@@ -145,7 +144,7 @@ class DeclarationDetailsControllerSpec extends ControllerWithoutFormSpec with Be
         status(result) mustBe INTERNAL_SERVER_ERROR
 
         val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-        verify(mockErrorHandler).internalError(messageCaptor.capture())
+        verify(mockErrorHandler).internalError(messageCaptor.capture())(any())
         assert(messageCaptor.getValue.contains(s"Cannot found Submission(${submission.uuid})"))
       }
 
@@ -160,7 +159,7 @@ class DeclarationDetailsControllerSpec extends ControllerWithoutFormSpec with Be
           verify(mockCustomsDeclareExportsConnector, never).findDeclaration(any())(any(), any())
 
           val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-          verify(mockErrorHandler).internalServerError(messageCaptor.capture())
+          verify(mockErrorHandler).internalServerError(messageCaptor.capture())(any())
           assert(messageCaptor.getValue.contains("undefined latestDecId"))
         }
       }
@@ -177,7 +176,7 @@ class DeclarationDetailsControllerSpec extends ControllerWithoutFormSpec with Be
         status(result) mustBe INTERNAL_SERVER_ERROR
 
         val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-        verify(mockErrorHandler).internalServerError(messageCaptor.capture())
+        verify(mockErrorHandler).internalServerError(messageCaptor.capture())(any())
         assert(messageCaptor.getValue.contains("Cannot found latest declaration"))
       }
 
@@ -193,7 +192,7 @@ class DeclarationDetailsControllerSpec extends ControllerWithoutFormSpec with Be
         status(result) mustBe INTERNAL_SERVER_ERROR
 
         val messageCaptor: ArgumentCaptor[String] = ArgumentCaptor.forClass(classOf[String])
-        verify(mockErrorHandler).internalServerError(messageCaptor.capture())
+        verify(mockErrorHandler).internalServerError(messageCaptor.capture())(any())
         assert(messageCaptor.getValue.contains("has no additionalDeclarationType"))
       }
     }

--- a/test/mock/ErrorHandlerMocks.scala
+++ b/test/mock/ErrorHandlerMocks.scala
@@ -37,10 +37,10 @@ trait ErrorHandlerMocks extends BeforeAndAfterEach { self: MockitoSugar with Sui
 
     when(mockErrorHandler.badRequest(any())).thenReturn(BadRequest(HtmlFormat.empty))
 
-    when(mockErrorHandler.internalServerError(anyString()))
+    when(mockErrorHandler.internalServerError(anyString())(any()))
       .thenAnswer((ans: InvocationOnMock) => InternalServerError(ans.getArgument[String](0)))
 
-    when(mockErrorHandler.internalError(anyString()))
+    when(mockErrorHandler.internalError(anyString())(any()))
       .thenAnswer((ans: InvocationOnMock) => Future.successful(InternalServerError(ans.getArgument[String](0))))
 
     when(mockErrorHandler.redirectToErrorPage(any())).thenReturn(Future.successful(BadRequest(HtmlFormat.empty)))


### PR DESCRIPTION
Altering amend audit event to match format agreed with the CIP team.

Also fixing bug found that resulted in empty page being rendered to user on internal error scenario. Fix to show standard service 'sorry' page.