### PR TITLE
CEDS-4881 Resolve ambiguity in DiffTool field pointers

### DIFF
--- a/app/forms/declaration/AdditionalInformation.scala
+++ b/app/forms/declaration/AdditionalInformation.scala
@@ -17,6 +17,7 @@
 package forms.declaration
 
 import forms.DeclarationPage
+import forms.declaration.AdditionalInformation.{codePointer, descriptionPointer}
 import models.viewmodels.TariffContentKey
 import models.DeclarationType.DeclarationType
 import models.ExportsFieldPointer.ExportsFieldPointer
@@ -32,16 +33,16 @@ import utils.validators.forms.FieldValidator._
 case class AdditionalInformation(code: String, description: String) extends DiffTools[AdditionalInformation] with ImplicitlySequencedObject {
   def createDiff(original: AdditionalInformation, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareStringDifference(original.code, code, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.description, description, combinePointers(pointerString, sequenceId))
+      compareStringDifference(original.code, code, combinePointers(pointerString, codePointer, sequenceId)),
+      compareStringDifference(original.description, description, combinePointers(pointerString, descriptionPointer, sequenceId))
     ).flatten
-
-  override def toString: String = s"${code}-${description}"
 }
 
 object AdditionalInformation extends DeclarationPage with FieldMapping {
 
   val pointer: ExportsFieldPointer = "items"
+  val codePointer: ExportsFieldPointer = "code"
+  val descriptionPointer: ExportsFieldPointer = "description"
 
   implicit val format = Json.format[AdditionalInformation]
 

--- a/app/forms/declaration/DeclarantDetails.scala
+++ b/app/forms/declaration/DeclarantDetails.scala
@@ -25,7 +25,7 @@ import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
 
 case class DeclarantDetails(details: EntityDetails) extends DiffTools[DeclarantDetails] {
   override def createDiff(original: DeclarantDetails, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(details.createDiff(original.details, combinePointers(pointerString, DeclarantDetails.pointer, sequenceId))).flatten
+    Seq(details.createDiff(original.details, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object DeclarantDetails extends DeclarationPage with FieldMapping {

--- a/app/forms/declaration/DeclarationAdditionalActors.scala
+++ b/app/forms/declaration/DeclarationAdditionalActors.scala
@@ -19,6 +19,7 @@ package forms.declaration
 import forms.DeclarationPage
 import forms.MappingHelper._
 import forms.common.Eori
+import forms.declaration.DeclarationAdditionalActors.{eoriPointer, partyTypePointer}
 import models.DeclarationType.DeclarationType
 import models.viewmodels.TariffContentKey
 import models.ExportsFieldPointer.ExportsFieldPointer
@@ -34,8 +35,8 @@ case class DeclarationAdditionalActors(eori: Option[Eori], partyType: Option[Str
     extends DiffTools[DeclarationAdditionalActors] with ImplicitlySequencedObject {
   def createDiff(original: DeclarationAdditionalActors, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareDifference(original.eori, eori, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.partyType, partyType, combinePointers(pointerString, sequenceId))
+      compareDifference(original.eori, eori, combinePointers(pointerString, eoriPointer, sequenceId)),
+      compareStringDifference(original.partyType, partyType, combinePointers(pointerString, partyTypePointer, sequenceId))
     ).flatten
 
   import DeclarationAdditionalActors._

--- a/app/forms/declaration/Document.scala
+++ b/app/forms/declaration/Document.scala
@@ -17,6 +17,7 @@
 package forms.declaration
 
 import forms.DeclarationPage
+import forms.declaration.Document.{documentReferencePointer, documentTypePointer, goodsItemIdentifierPointer}
 import models.DeclarationType.DeclarationType
 import models.viewmodels.TariffContentKey
 import models.ExportsFieldPointer.ExportsFieldPointer
@@ -34,9 +35,13 @@ case class Document(documentType: String, documentReference: String, goodsItemId
     extends DiffTools[Document] with ImplicitlySequencedObject {
   def createDiff(original: Document, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareStringDifference(original.documentType, documentType, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.documentReference, documentReference, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.goodsItemIdentifier, goodsItemIdentifier, combinePointers(pointerString, sequenceId))
+      compareStringDifference(original.documentType, documentType, combinePointers(pointerString, documentTypePointer, sequenceId)),
+      compareStringDifference(original.documentReference, documentReference, combinePointers(pointerString, documentReferencePointer, sequenceId)),
+      compareStringDifference(
+        original.goodsItemIdentifier,
+        goodsItemIdentifier,
+        combinePointers(pointerString, goodsItemIdentifierPointer, sequenceId)
+      )
     ).flatten
 }
 
@@ -44,6 +49,9 @@ object Document extends DeclarationPage with FieldMapping {
   implicit val format = Json.format[Document]
 
   val pointer: ExportsFieldPointer = "documents"
+  val documentTypePointer: ExportsFieldPointer = "documentType"
+  val documentReferencePointer: ExportsFieldPointer = "documentReference"
+  val goodsItemIdentifierPointer: ExportsFieldPointer = "goodsItemIdentifier"
 
   val formId = "PreviousDocuments"
 

--- a/app/forms/declaration/InlandModeOfTransportCode.scala
+++ b/app/forms/declaration/InlandModeOfTransportCode.scala
@@ -23,12 +23,15 @@ import models.ExportsFieldPointer.ExportsFieldPointer
 import models.FieldMapping
 import play.api.data.{Form, Forms}
 import play.api.libs.json.Json
-import services.DiffTools
-import services.DiffTools.{compareDifference, ExportsDeclarationDiff}
 
-case class InlandModeOfTransportCode(inlandModeOfTransportCode: Option[ModeOfTransportCode] = None) extends DiffTools[InlandModeOfTransportCode] {
-  def createDiff(original: InlandModeOfTransportCode, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(compareDifference(original.inlandModeOfTransportCode, inlandModeOfTransportCode, pointerString)).flatten
+case class InlandModeOfTransportCode(inlandModeOfTransportCode: Option[ModeOfTransportCode] = None) extends Ordered[InlandModeOfTransportCode] {
+  override def compare(that: InlandModeOfTransportCode): Int =
+    (inlandModeOfTransportCode, that.inlandModeOfTransportCode) match {
+      case (None, None)                    => 0
+      case (_, None)                       => 1
+      case (None, _)                       => -1
+      case (Some(current), Some(original)) => current.compare(original)
+    }
 }
 
 object InlandModeOfTransportCode extends DeclarationPage with FieldMapping {

--- a/app/forms/declaration/NactCode.scala
+++ b/app/forms/declaration/NactCode.scala
@@ -34,6 +34,7 @@ object NactCode extends DeclarationPage with FieldMapping {
   implicit val format = Json.format[NactCode]
 
   val pointer: ExportsFieldPointer = "nactCode"
+  val exemptionPointer: ExportsFieldPointer = "nactExemptionCode"
 
   val nactCodeKey = "nactCode"
 

--- a/app/forms/declaration/Seal.scala
+++ b/app/forms/declaration/Seal.scala
@@ -16,19 +16,24 @@
 
 package forms.declaration
 import forms.DeclarationPage
+import models.{DeclarationMeta, FieldMapping}
 import models.DeclarationMeta.sequenceIdPlaceholder
 import models.DeclarationType.DeclarationType
 import models.ExportsFieldPointer.ExportsFieldPointer
 import models.declaration.ExplicitlySequencedObject
 import models.viewmodels.TariffContentKey
-import models.{DeclarationMeta, FieldMapping}
-import play.api.data.Forms.text
 import play.api.data.{Form, Forms, Mapping}
+import play.api.data.Forms.text
 import play.api.libs.json.{Json, OFormat}
+import services.DiffTools
+import services.DiffTools.{combinePointers, compareStringDifference, ExportsDeclarationDiff}
 import utils.validators.forms.FieldValidator._
 
-case class Seal(sequenceId: Int = sequenceIdPlaceholder, id: String) extends ExplicitlySequencedObject[Seal] {
+case class Seal(sequenceId: Int = sequenceIdPlaceholder, id: String) extends DiffTools[Seal] with ExplicitlySequencedObject[Seal] {
   override def updateSequenceId(sequenceId: Int): Seal = copy(sequenceId = sequenceId)
+
+  override def createDiff(original: Seal, pointerString: ExportsFieldPointer, sequenceId: Option[Int]): ExportsDeclarationDiff =
+    Seq(compareStringDifference(original.id, id, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object Seal extends DeclarationPage with FieldMapping {

--- a/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
+++ b/app/forms/declaration/additionaldocuments/AdditionalDocument.scala
@@ -19,6 +19,15 @@ package forms.declaration.additionaldocuments
 import forms.common.Date
 import forms.declaration.additionaldocuments.DocumentWriteOff._
 import forms.{AdditionalConstraintsMapping, ConditionalConstraint, DeclarationPage}
+import forms.declaration.additionaldocuments.AdditionalDocument.{
+  dateOfValidityPointer,
+  documentIdentifierPointer,
+  documentStatusPointer,
+  documentStatusReasonPointer,
+  documentTypeCodePointer,
+  documentWriteOffPointer,
+  issuingAuthorityNamePointer
+}
 import models.DeclarationType.{CLEARANCE, DeclarationType}
 import models.ExportsFieldPointer.ExportsFieldPointer
 import models.declaration.ImplicitlySequencedObject
@@ -43,13 +52,21 @@ case class AdditionalDocument(
 ) extends DiffTools[AdditionalDocument] with ImplicitlySequencedObject {
   def createDiff(original: AdditionalDocument, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareStringDifference(original.documentTypeCode, documentTypeCode, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.documentIdentifier, documentIdentifier, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.documentStatus, documentStatus, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.documentStatusReason, documentStatusReason, combinePointers(pointerString, sequenceId)),
-      compareStringDifference(original.issuingAuthorityName, issuingAuthorityName, combinePointers(pointerString, sequenceId)),
-      createDiffOfOptions(original.dateOfValidity, dateOfValidity, combinePointers(pointerString, sequenceId)),
-      createDiffOfOptions(original.documentWriteOff, documentWriteOff, combinePointers(pointerString, sequenceId))
+      compareStringDifference(original.documentTypeCode, documentTypeCode, combinePointers(pointerString, documentTypeCodePointer, sequenceId)),
+      compareStringDifference(original.documentIdentifier, documentIdentifier, combinePointers(pointerString, documentIdentifierPointer, sequenceId)),
+      compareStringDifference(original.documentStatus, documentStatus, combinePointers(pointerString, documentStatusPointer, sequenceId)),
+      compareStringDifference(
+        original.documentStatusReason,
+        documentStatusReason,
+        combinePointers(pointerString, documentStatusReasonPointer, sequenceId)
+      ),
+      compareStringDifference(
+        original.issuingAuthorityName,
+        issuingAuthorityName,
+        combinePointers(pointerString, issuingAuthorityNamePointer, sequenceId)
+      ),
+      createDiffOfOptions(original.dateOfValidity, dateOfValidity, combinePointers(pointerString, dateOfValidityPointer, sequenceId)),
+      createDiffOfOptions(original.documentWriteOff, documentWriteOff, combinePointers(pointerString, documentWriteOffPointer, sequenceId))
     ).flatten
 
   def toJson: JsValue = Json.toJson(this)(AdditionalDocument.format)
@@ -65,6 +82,13 @@ case class AdditionalDocument(
 object AdditionalDocument extends DeclarationPage with FieldMapping {
 
   val pointer: ExportsFieldPointer = "documents"
+  val documentTypeCodePointer: ExportsFieldPointer = "documentTypeCode"
+  val documentIdentifierPointer: ExportsFieldPointer = "documentIdentifier"
+  val documentStatusPointer: ExportsFieldPointer = "documentStatus"
+  val documentStatusReasonPointer: ExportsFieldPointer = "documentStatusReason"
+  val issuingAuthorityNamePointer: ExportsFieldPointer = "issuingAuthorityName"
+  val dateOfValidityPointer: ExportsFieldPointer = "dateOfValidity"
+  val documentWriteOffPointer: ExportsFieldPointer = "documentWriteOff"
 
   def fromJsonString(value: String): Option[AdditionalDocument] = Json.fromJson(Json.parse(value)).asOpt
 

--- a/app/forms/declaration/additionaldocuments/DocumentWriteOff.scala
+++ b/app/forms/declaration/additionaldocuments/DocumentWriteOff.scala
@@ -16,20 +16,21 @@
 
 package forms.declaration.additionaldocuments
 
+import forms.declaration.additionaldocuments.DocumentWriteOff.{documentQuantityPointer, measurementUnitPointer}
 import models.ExportsFieldPointer.ExportsFieldPointer
 import models.FieldMapping
-import play.api.data.Forms.{optional, text}
 import play.api.data.{Form, FormError, Forms}
+import play.api.data.Forms.{optional, text}
 import play.api.libs.json.Json
 import services.DiffTools
-import services.DiffTools.{compareBigDecimalDifference, compareStringDifference, ExportsDeclarationDiff}
+import services.DiffTools.{combinePointers, compareBigDecimalDifference, compareStringDifference, ExportsDeclarationDiff}
 import utils.validators.forms.FieldValidator._
 
 case class DocumentWriteOff(measurementUnit: Option[String], documentQuantity: Option[BigDecimal]) extends DiffTools[DocumentWriteOff] {
   def createDiff(original: DocumentWriteOff, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareStringDifference(original.measurementUnit, measurementUnit, pointerString),
-      compareBigDecimalDifference(original.documentQuantity, documentQuantity, pointerString)
+      compareStringDifference(original.measurementUnit, measurementUnit, combinePointers(pointerString, measurementUnitPointer, sequenceId)),
+      compareBigDecimalDifference(original.documentQuantity, documentQuantity, combinePointers(pointerString, documentQuantityPointer, sequenceId))
     ).flatten
 
   def measurementUnitDisplay: String = measurementUnit.map(_.replace("#", " ")).getOrElse("")

--- a/app/forms/declaration/countries/Country.scala
+++ b/app/forms/declaration/countries/Country.scala
@@ -19,12 +19,15 @@ package forms.declaration.countries
 import models.ExportsFieldPointer.ExportsFieldPointer
 import models.FieldMapping
 import play.api.libs.json.Json
-import services.DiffTools
-import services.DiffTools.{combinePointers, compareStringDifference, ExportsDeclarationDiff}
 
-case class Country(code: Option[String]) extends DiffTools[Country] {
-  override def createDiff(original: Country, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(compareStringDifference(original.code, code, combinePointers(pointerString, Country.pointer, sequenceId))).flatten
+case class Country(code: Option[String]) extends Ordered[Country] {
+  override def compare(that: Country): Int =
+    (code, that.code) match {
+      case (None, None)                    => 0
+      case (_, None)                       => 1
+      case (None, _)                       => -1
+      case (Some(current), Some(original)) => current.compare(original)
+    }
 }
 
 object Country extends FieldMapping {

--- a/app/forms/declaration/declarationHolder/DeclarationHolder.scala
+++ b/app/forms/declaration/declarationHolder/DeclarationHolder.scala
@@ -40,8 +40,12 @@ case class DeclarationHolder(authorisationTypeCode: Option[String], eori: Option
   // eoriSource is not used to generate the WCO XML
   def createDiff(original: DeclarationHolder, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
     Seq(
-      compareStringDifference(original.authorisationTypeCode, authorisationTypeCode, combinePointers(pointerString, sequenceId)),
-      compareDifference(original.eori, eori, combinePointers(pointerString, sequenceId))
+      compareStringDifference(
+        original.authorisationTypeCode,
+        authorisationTypeCode,
+        combinePointers(pointerString, DeclarationHolder.authorisationTypeCodePointer, sequenceId)
+      ),
+      compareDifference(original.eori, eori, combinePointers(pointerString, DeclarationHolder.eoriPointer, sequenceId))
     ).flatten
 
   def id: String = s"${authorisationTypeCode.getOrElse("")}-${eori.getOrElse("")}"

--- a/app/forms/declaration/exporter/ExporterDetails.scala
+++ b/app/forms/declaration/exporter/ExporterDetails.scala
@@ -31,7 +31,7 @@ import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
 
 case class ExporterDetails(details: EntityDetails) extends DiffTools[ExporterDetails] {
   override def createDiff(original: ExporterDetails, pointerString: ExportsFieldPointer, sequenceId: Option[Int] = None): ExportsDeclarationDiff =
-    Seq(details.createDiff(original.details, combinePointers(pointerString, EntityDetails.pointer, sequenceId))).flatten
+    Seq(details.createDiff(original.details, combinePointers(pointerString, sequenceId))).flatten
 }
 
 object ExporterDetails extends DeclarationPage with FieldMapping {

--- a/app/models/declaration/Container.scala
+++ b/app/models/declaration/Container.scala
@@ -22,13 +22,14 @@ import models.ExportsFieldPointer.ExportsFieldPointer
 import models.FieldMapping
 import play.api.libs.json.{Json, OFormat}
 import services.DiffTools
-import services.DiffTools.{combinePointers, ExportsDeclarationDiff}
+import services.DiffTools.{combinePointers, compareStringDifference, ExportsDeclarationDiff}
 
 case class Container(sequenceId: Int = sequenceIdPlaceholder, id: String, seals: Seq[Seal])
     extends DiffTools[Container] with ExplicitlySequencedObject[Container] {
 
   override def createDiff(original: Container, pointerString: ExportsFieldPointer, sequenceId: Option[Int]): ExportsDeclarationDiff =
-    createDiff(original.seals, seals, combinePointers(pointerString, Seal.pointer, sequenceId))
+    Seq(compareStringDifference(original.id, id, combinePointers(pointerString, Container.idPointer, sequenceId))).flatten ++
+      createDiff(original.seals, seals, combinePointers(pointerString, Seal.pointer, sequenceId))
 
   override def updateSequenceId(sequenceId: Int): Container = copy(sequenceId = sequenceId)
 }

--- a/app/models/declaration/ExportItem.scala
+++ b/app/models/declaration/ExportItem.scala
@@ -68,7 +68,7 @@ case class ExportItem(
       compareDifference(original.cusCode, cusCode, combinePointers(pointerString, CusCode.pointer, maybeSequenceId)),
       compareDifference(original.taricCodes, taricCodes, combinePointers(pointerString, TaricCode.pointer, maybeSequenceId)),
       compareDifference(original.nactCodes, nactCodes, combinePointers(pointerString, NactCode.pointer, maybeSequenceId)),
-      compareDifference(original.nactExemptionCode, nactExemptionCode, combinePointers(pointerString, NactCode.pointer, maybeSequenceId)),
+      compareDifference(original.nactExemptionCode, nactExemptionCode, combinePointers(pointerString, NactCode.exemptionPointer, maybeSequenceId)),
       createDiff(original.packageInformation, packageInformation, combinePointers(pointerString, PackageInformation.pointer, maybeSequenceId)),
       createDiffOfOptions(original.commodityMeasure, commodityMeasure, combinePointers(pointerString, CommodityMeasure.pointer, maybeSequenceId)),
       createDiffOfOptionIsos(

--- a/app/models/declaration/RepresentativeDetails.scala
+++ b/app/models/declaration/RepresentativeDetails.scala
@@ -34,7 +34,7 @@ case class RepresentativeDetails(details: Option[EntityDetails], statusCode: Opt
     sequenceId: Option[Int] = None
   ): ExportsDeclarationDiff =
     Seq(
-      createDiffOfOptions(original.details, details, combinePointers(pointerString, RepresentativeDetails.detailsPointer, sequenceId)),
+      createDiffOfOptions(original.details, details, combinePointers(pointerString, sequenceId)),
       compareStringDifference(original.statusCode, statusCode, combinePointers(pointerString, RepresentativeDetails.statusCodePointer, sequenceId))
     ).flatten
 }
@@ -43,7 +43,6 @@ object RepresentativeDetails extends FieldMapping {
   implicit val format = Json.format[RepresentativeDetails]
 
   val pointer: ExportsFieldPointer = "representativeDetails"
-  val detailsPointer: ExportsFieldPointer = "details"
   val statusCodePointer: ExportsFieldPointer = "statusCode"
 
   def apply(): RepresentativeDetails = new RepresentativeDetails(None, None, None)

--- a/app/services/DiffTools.scala
+++ b/app/services/DiffTools.scala
@@ -78,35 +78,15 @@ trait DiffTools[T] {
     intersectingObjectDiffs.flatten ++ removedObjectsDiff ++ newObjectsDiff
   }
 
-  def createDiff[S <: ExplicitlySequencedObject[S]](original: Seq[S], current: Seq[S], pointerString: ExportsFieldPointer)(
-    implicit esoTag: DummyImplicit,
-    nonDiffEsoTag: DummyImplicit
-  ): ExportsDeclarationDiff = {
-    val originalObjectIds = original.map(_.sequenceId).toSet
-    val currentObjectIds = current.map(_.sequenceId).toSet
-    val newObjectsIds = currentObjectIds.diff(originalObjectIds)
-    val removedObjectsIds = originalObjectIds.diff(currentObjectIds)
-    val removedObjectsDiff =
-      removedObjectsIds.map(sequenceId =>
-        AlteredField(combinePointers(s"$pointerString", Some(sequenceId)), OriginalAndNewValues(original.find(_.sequenceId == sequenceId), None))
-      )
-    val newObjectsDiff =
-      newObjectsIds.map(sequenceId =>
-        AlteredField(combinePointers(s"$pointerString", Some(sequenceId)), OriginalAndNewValues(None, current.find(_.sequenceId == sequenceId)))
-      )
-
-    (removedObjectsDiff ++ newObjectsDiff).toSeq
-  }
-
   def createDiff[E <: DiffTools[E]](original: Option[Seq[E]], current: Option[Seq[E]], pointerString: ExportsFieldPointer): ExportsDeclarationDiff =
     createDiff(original.getOrElse(Seq.empty[E]), current.getOrElse(Seq.empty[E]), pointerString)
 
   def createDiff[S <: DiffTools[S] with ExplicitlySequencedObject[S]](
-    original: Option[Seq[S]],
-    current: Option[Seq[S]],
+    maybeOriginal: Option[Seq[S]],
+    maybeCurrent: Option[Seq[S]],
     pointerString: ExportsFieldPointer
   )(implicit esoTag: DummyImplicit): ExportsDeclarationDiff =
-    createDiff(original.getOrElse(Seq.empty[S]), current.getOrElse(Seq.empty[S]), pointerString)
+    createDiff(maybeOriginal.getOrElse(Seq.empty[S]), maybeCurrent.getOrElse(Seq.empty[S]), pointerString)
 
   def createDiffOfOptions[E <: DiffTools[E]](original: Option[E], current: Option[E], pointerString: ExportsFieldPointer): ExportsDeclarationDiff =
     (original, current) match {
@@ -244,6 +224,14 @@ object DiffTools {
 
   def compareOptionalString(optionOne: Option[String], optionTwo: Option[String]): Int =
     (optionOne, optionTwo) match {
+      case (None, None)                    => 0
+      case (_, None)                       => 1
+      case (None, _)                       => -1
+      case (Some(current), Some(original)) => current.compare(original)
+    }
+
+  def compareOptInt(orig: Option[Int], other: Option[Int]) =
+    (orig, other) match {
       case (None, None)                    => 0
       case (_, None)                       => 1
       case (None, _)                       => -1

--- a/test/forms/declaration/ContainerSpec.scala
+++ b/test/forms/declaration/ContainerSpec.scala
@@ -42,6 +42,14 @@ class ContainerSpec extends DeclarationPageBaseSpec {
         }
       }
 
+      "when the container Ids are not equal" in {
+        val fieldPointer = s"$baseFieldPointer.#1.${Container.idPointer}"
+        val container = Container(1, "latest", seals)
+        container.createDiff(container.copy(id = "original"), baseFieldPointer, Some(1)) mustBe Seq(
+          constructAlteredField(s"${fieldPointer}", "original", "latest")
+        )
+      }
+
       "when seals are present but not equal" in {
         val fieldPointer = s"$baseFieldPointer.#1.${Seal.pointer}"
         withClue("original container's seals are not present") {
@@ -75,6 +83,13 @@ class ContainerSpec extends DeclarationPageBaseSpec {
           container.createDiff(container.copy(seals = seals), baseFieldPointer, Some(1)) mustBe Seq(
             constructAlteredField(s"${fieldPointer}.#1", Some(seals(0)), None),
             constructAlteredField(s"${fieldPointer}.#4", None, Some(newSeal))
+          )
+        }
+
+        withClue("container seals contains same element with a different value") {
+          val container = Container(1, "latest", Seq(seals(0)))
+          container.createDiff(container.copy(seals = Seq(seals(0).copy(id = "one hundred"))), baseFieldPointer, Some(1)) mustBe Seq(
+            constructAlteredField(s"${fieldPointer}.#1", Some("one hundred"), Some("one"))
           )
         }
       }

--- a/test/forms/declaration/LocationsSpec.scala
+++ b/test/forms/declaration/LocationsSpec.scala
@@ -25,53 +25,6 @@ import services.AlteredField
 import services.AlteredField.constructAlteredField
 
 class LocationsSpec extends UnitSpec {
-  "Country.createDiff" should {
-    val baseFieldPointer = Locations.pointer
-    val someVal = Some("GB")
-
-    "produce the expected ExportsDeclarationDiff instance" when {
-      "no differences exist between the two versions" in {
-        withClue("both values are None") {
-          val country = Country(None)
-          country.createDiff(country, baseFieldPointer) mustBe Seq.empty[AlteredField]
-        }
-
-        withClue("both values are same Some value") {
-          val country = Country(someVal)
-          country.createDiff(country, baseFieldPointer) mustBe Seq.empty[AlteredField]
-        }
-      }
-
-      "differences exist between the two versions" in {
-        withClue("original is None but this has Some") {
-          val fieldPointer = s"${baseFieldPointer}.${Country.pointer}"
-          val country = Country(someVal)
-          val originalValue = None
-          country.createDiff(country.copy(code = originalValue), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue, country.code)
-          )
-        }
-
-        withClue("original is Some but this has None") {
-          val fieldPointer = s"${baseFieldPointer}.${Country.pointer}"
-          val country = Country(None)
-          val originalValue = someVal
-          country.createDiff(country.copy(code = originalValue), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue, country.code)
-          )
-        }
-
-        withClue("original is Some and this is Some but values are different") {
-          val fieldPointer = s"${baseFieldPointer}.${Country.pointer}"
-          val country = Country(Some("FR"))
-          val originalValue = someVal
-          country.createDiff(country.copy(code = originalValue), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue, country.code)
-          )
-        }
-      }
-    }
-  }
 
   "GoodsLocation.createDiff" should {
     val baseFieldPointer = GoodsLocation.pointer
@@ -86,44 +39,36 @@ class LocationsSpec extends UnitSpec {
       }
 
       "the original version's country field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${GoodsLocation.countryPointer}"
+        val fieldPointer = s"${baseFieldPointer}"
         val goodsLocation =
           GoodsLocation("latestCountry", "latestTypeOfLocation", "latestQualifierOfIdentification", "latestIdentificationOfLocation")
-        val originalValue = "original"
-        goodsLocation.createDiff(goodsLocation.copy(country = originalValue), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue, goodsLocation.country)
-        )
+        val originalValue = goodsLocation.copy(country = "original")
+        goodsLocation.createDiff(originalValue, baseFieldPointer) mustBe Seq(constructAlteredField(fieldPointer, originalValue, goodsLocation))
       }
 
       "the original version's typeOfLocation field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${GoodsLocation.typeOfLocationPointer}"
+        val fieldPointer = s"${baseFieldPointer}"
         val goodsLocation =
           GoodsLocation("latestCountry", "latestTypeOfLocation", "latestQualifierOfIdentification", "latestIdentificationOfLocation")
-        val originalValue = "original"
-        goodsLocation.createDiff(goodsLocation.copy(typeOfLocation = originalValue), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue, goodsLocation.typeOfLocation)
-        )
+        val originalValue = goodsLocation.copy(typeOfLocation = "original")
+        goodsLocation.createDiff(originalValue, baseFieldPointer) mustBe Seq(constructAlteredField(fieldPointer, originalValue, goodsLocation))
       }
 
       "the original version's qualifierOfIdentification field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${GoodsLocation.qualifierOfIdentificationPointer}"
+        val fieldPointer = s"${baseFieldPointer}"
         val goodsLocation =
           GoodsLocation("latestCountry", "latestTypeOfLocation", "latestQualifierOfIdentification", "latestIdentificationOfLocation")
-        val originalValue = "original"
-        goodsLocation.createDiff(goodsLocation.copy(qualifierOfIdentification = originalValue), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue, goodsLocation.qualifierOfIdentification)
-        )
+        val originalValue = goodsLocation.copy(qualifierOfIdentification = "original")
+        goodsLocation.createDiff(originalValue, baseFieldPointer) mustBe Seq(constructAlteredField(fieldPointer, originalValue, goodsLocation))
       }
 
       "the original version's identificationOfLocation field has a different value to this one" in {
         withClue("both version have Some value") {
-          val fieldPointer = s"${baseFieldPointer}.${GoodsLocation.identificationOfLocationPointer}"
+          val fieldPointer = s"${baseFieldPointer}"
           val goodsLocation =
             GoodsLocation("latestCountry", "latestTypeOfLocation", "latestQualifierOfIdentification", "latestIdentificationOfLocation")
-          val originalValue = "original"
-          goodsLocation.createDiff(goodsLocation.copy(identificationOfLocation = originalValue), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue, goodsLocation.identificationOfLocation)
-          )
+          val originalValue = goodsLocation.copy(qualifierOfIdentification = "original")
+          goodsLocation.createDiff(originalValue, baseFieldPointer) mustBe Seq(constructAlteredField(fieldPointer, originalValue, goodsLocation))
         }
       }
     }
@@ -144,20 +89,20 @@ class LocationsSpec extends UnitSpec {
         val latestCountry = Country(Some("GB"))
 
         "the original version's originationCountry field has a different value to this one" in {
-          val fieldPointer = s"${baseFieldPointer}.${Locations.originationCountryPointer}.${Country.pointer}"
+          val fieldPointer = s"${baseFieldPointer}.${Locations.originationCountryPointer}"
           val locations = Locations(originationCountry = Some(latestCountry))
-          val originalValue = Country(Some("FR"))
-          locations.createDiff(locations.copy(originationCountry = Some(originalValue)), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue.code, locations.originationCountry.get.code)
+          val originalValue = Some(Country(Some("FR")))
+          locations.createDiff(locations.copy(originationCountry = originalValue), baseFieldPointer) mustBe Seq(
+            constructAlteredField(fieldPointer, originalValue, locations.originationCountry)
           )
         }
 
         "the original version's destinationCountry field has a different value to this one" in {
-          val fieldPointer = s"${baseFieldPointer}.${Locations.destinationCountryPointer}.${Country.pointer}"
+          val fieldPointer = s"${baseFieldPointer}.${Locations.destinationCountryPointer}"
           val locations = Locations(destinationCountry = Some(latestCountry))
-          val originalValue = Country(Some("FR"))
-          locations.createDiff(locations.copy(destinationCountry = Some(originalValue)), baseFieldPointer) mustBe Seq(
-            constructAlteredField(fieldPointer, originalValue.code, locations.destinationCountry.get.code)
+          val originalValue = Some(Country(Some("FR")))
+          locations.createDiff(locations.copy(destinationCountry = originalValue), baseFieldPointer) mustBe Seq(
+            constructAlteredField(fieldPointer, originalValue, locations.destinationCountry)
           )
         }
 
@@ -202,6 +147,21 @@ class LocationsSpec extends UnitSpec {
               constructAlteredField(s"${fieldPointer}.#4", None, Some(RoutingCountry(4, Country(Some("other"))))),
               constructAlteredField(s"${fieldPointer}.#5", None, Some(RoutingCountry(5, Country(Some("other"))))),
               constructAlteredField(s"${fieldPointer}.#6", None, Some(RoutingCountry(6, Country(Some("other")))))
+            )
+          }
+
+          withClue("locations routingCountries contain elements with different values") {
+            val newRoutingCountries =
+              Seq(RoutingCountry(1, Country(Some("one"))), RoutingCountry(2, Country(Some("DIFF"))), RoutingCountry(4, Country(Some("four"))))
+            val locations = Locations(routingCountries = newRoutingCountries)
+
+            locations.createDiff(
+              locations.copy(routingCountries = routingCountries.dropRight(1)),
+              baseFieldPointer,
+              Some(1)
+            ) must contain theSameElementsAs Seq(
+              constructAlteredField(s"${fieldPointer}.#2", Some(routingCountries(1).country), Some(newRoutingCountries(1).country)),
+              constructAlteredField(s"${fieldPointer}.#4", None, Some(RoutingCountry(4, Country(Some("four")))))
             )
           }
         }
@@ -317,25 +277,17 @@ class LocationsSpec extends UnitSpec {
           val fieldPointer = s"${baseFieldPointer}.${InlandModeOfTransportCode.pointer}"
           withClue("both versions have Some(Some) values but values are different") {
             val locations = Locations(inlandModeOfTransportCode = Some(InlandModeOfTransportCode(Some(Maritime))))
-            val originalValue = InlandModeOfTransportCode(Some(Rail))
-            locations.createDiff(locations.copy(inlandModeOfTransportCode = Some(originalValue)), baseFieldPointer) mustBe Seq(
-              constructAlteredField(
-                fieldPointer,
-                originalValue.inlandModeOfTransportCode,
-                locations.inlandModeOfTransportCode.get.inlandModeOfTransportCode
-              )
+            val originalValue = Some(InlandModeOfTransportCode(Some(Rail)))
+            locations.createDiff(locations.copy(inlandModeOfTransportCode = originalValue), baseFieldPointer) mustBe Seq(
+              constructAlteredField(fieldPointer, originalValue, locations.inlandModeOfTransportCode)
             )
           }
 
           withClue("the original version's inlandModeOfTransportCode field is Some(None) but this one has Some(Some) value") {
             val locations = Locations(inlandModeOfTransportCode = Some(InlandModeOfTransportCode(Some(Maritime))))
-            val originalValue = InlandModeOfTransportCode(None)
-            locations.createDiff(locations.copy(inlandModeOfTransportCode = Some(originalValue)), baseFieldPointer) mustBe Seq(
-              constructAlteredField(
-                fieldPointer,
-                originalValue.inlandModeOfTransportCode,
-                locations.inlandModeOfTransportCode.get.inlandModeOfTransportCode
-              )
+            val originalValue = Some(InlandModeOfTransportCode(None))
+            locations.createDiff(locations.copy(inlandModeOfTransportCode = originalValue), baseFieldPointer) mustBe Seq(
+              constructAlteredField(fieldPointer, originalValue, locations.inlandModeOfTransportCode)
             )
           }
 

--- a/test/forms/declaration/PartiesSpec.scala
+++ b/test/forms/declaration/PartiesSpec.scala
@@ -79,7 +79,7 @@ class PartiesSpec extends UnitSpec {
   }
 
   "EntityDetails.createDiff" should {
-    val baseFieldPointer = EntityDetails.pointer
+    val baseFieldPointer = "details"
 
     "produce the expected ExportsDeclarationDiff instance" when {
       "no differences exist between the two versions" in {
@@ -302,7 +302,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's eori field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${EntityDetails.pointer}.${EntityDetails.eoriPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${EntityDetails.eoriPointer}"
         val exporterDetails = ExporterDetails(details)
         val originalValue = details.copy(eori = Some(Eori("original")))
         exporterDetails.createDiff(exporterDetails.copy(details = originalValue), baseFieldPointer) mustBe Seq(
@@ -323,7 +323,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's details field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${RepresentativeDetails.detailsPointer}"
+        val fieldPointer = s"${baseFieldPointer}"
         val representativeDetails = RepresentativeDetails(None, None, None)
         val originalValue = Some(details)
         representativeDetails.createDiff(representativeDetails.copy(details = originalValue), baseFieldPointer) mustBe Seq(
@@ -352,7 +352,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's eori field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DeclarationAdditionalActors.eoriPointer}"
         val declarationAdditionalActor = DeclarationAdditionalActors(Some(Eori("latestEori")), Some("latestPartyType"))
         val originalValue = Some(Eori("original"))
         declarationAdditionalActor.createDiff(declarationAdditionalActor.copy(eori = originalValue), baseFieldPointer) mustBe Seq(
@@ -361,7 +361,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's partyType field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DeclarationAdditionalActors.partyTypePointer}"
         val declarationAdditionalActor = DeclarationAdditionalActors(Some(Eori("latestEori")), Some("latestPartyType"))
         val originalValue = Some("original")
         declarationAdditionalActor.createDiff(declarationAdditionalActor.copy(partyType = originalValue), baseFieldPointer) mustBe Seq(
@@ -415,10 +415,10 @@ class PartiesSpec extends UnitSpec {
         withClue("both container seals contain different number of elements") {
           val decActors = DeclarationAdditionalActorsData(actors.drop(1))
           decActors.createDiff(decActors.copy(actors = actors), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).eori, actors(1).eori),
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).partyType, actors(1).partyType),
-            constructAlteredField(s"${fieldPointer}.#2", actors(1).eori, actors(2).eori),
-            constructAlteredField(s"${fieldPointer}.#2", actors(1).partyType, actors(2).partyType),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.eoriPointer}", actors(0).eori, actors(1).eori),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.partyTypePointer}", actors(0).partyType, actors(1).partyType),
+            constructAlteredField(s"${fieldPointer}.#2.${DeclarationAdditionalActors.eoriPointer}", actors(1).eori, actors(2).eori),
+            constructAlteredField(s"${fieldPointer}.#2.${DeclarationAdditionalActors.partyTypePointer}", actors(1).partyType, actors(2).partyType),
             constructAlteredField(s"${fieldPointer}.#3", Some(actors(2)), None)
           )
         }
@@ -426,10 +426,10 @@ class PartiesSpec extends UnitSpec {
         withClue("both container seals contain same elements but in different order") {
           val decActors = DeclarationAdditionalActorsData(actors.reverse)
           decActors.createDiff(decActors.copy(actors = actors), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).eori, actors(2).eori),
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).partyType, actors(2).partyType),
-            constructAlteredField(s"${fieldPointer}.#3", actors(2).eori, actors(0).eori),
-            constructAlteredField(s"${fieldPointer}.#3", actors(2).partyType, actors(0).partyType)
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.eoriPointer}", actors(0).eori, actors(2).eori),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.partyTypePointer}", actors(0).partyType, actors(2).partyType),
+            constructAlteredField(s"${fieldPointer}.#3.${DeclarationAdditionalActors.eoriPointer}", actors(2).eori, actors(0).eori),
+            constructAlteredField(s"${fieldPointer}.#3.${DeclarationAdditionalActors.partyTypePointer}", actors(2).partyType, actors(0).partyType)
           )
         }
 
@@ -437,8 +437,8 @@ class PartiesSpec extends UnitSpec {
           val otherVal = "other"
           val decActors = DeclarationAdditionalActorsData(Seq(DeclarationAdditionalActors(Some(Eori(otherVal)), Some(otherVal))) ++ actors.drop(1))
           decActors.createDiff(decActors.copy(actors = actors), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).eori, Some(Eori(otherVal))),
-            constructAlteredField(s"${fieldPointer}.#1", actors(0).partyType, Some(otherVal))
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.eoriPointer}", actors(0).eori, Some(Eori(otherVal))),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationAdditionalActors.partyTypePointer}", actors(0).partyType, Some(otherVal))
           )
         }
       }
@@ -456,7 +456,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's authorisationTypeCode field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DeclarationHolder.authorisationTypeCodePointer}"
         val declarationHolder = DeclarationHolder(Some("latestAuthorisationTypeCode"), Some(Eori("latestEori")), Some(EoriSource.UserEori))
         declarationHolder.createDiff(declarationHolder.copy(authorisationTypeCode = originalValue), baseFieldPointer) mustBe Seq(
           constructAlteredField(fieldPointer, originalValue, declarationHolder.authorisationTypeCode)
@@ -464,7 +464,7 @@ class PartiesSpec extends UnitSpec {
       }
 
       "the original version's eori field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DeclarationHolder.eoriPointer}"
         val declarationHolder = DeclarationHolder(Some("latestAuthorisationTypeCode"), Some(Eori("latestEori")), Some(EoriSource.UserEori))
         declarationHolder.createDiff(declarationHolder.copy(eori = originalValue.map(Eori(_))), baseFieldPointer) mustBe Seq(
           constructAlteredField(fieldPointer, originalValue.map(Eori(_)), declarationHolder.eori)
@@ -518,10 +518,18 @@ class PartiesSpec extends UnitSpec {
         withClue("both DeclarationHolder's holders contain different number of elements") {
           val declarationHolders = DeclarationHoldersData(holders.drop(1), YesNoAnswer.Yes)
           declarationHolders.createDiff(declarationHolders.copy(holders = holders), baseFieldPointer, Some(1)) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", holders(0).authorisationTypeCode, holders(1).authorisationTypeCode),
-            constructAlteredField(s"${fieldPointer}.#1", holders(0).eori, holders(1).eori),
-            constructAlteredField(s"${fieldPointer}.#2", holders(1).authorisationTypeCode, holders(2).authorisationTypeCode),
-            constructAlteredField(s"${fieldPointer}.#2", holders(1).eori, holders(2).eori),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${DeclarationHolder.authorisationTypeCodePointer}",
+              holders(0).authorisationTypeCode,
+              holders(1).authorisationTypeCode
+            ),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationHolder.eoriPointer}", holders(0).eori, holders(1).eori),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${DeclarationHolder.authorisationTypeCodePointer}",
+              holders(1).authorisationTypeCode,
+              holders(2).authorisationTypeCode
+            ),
+            constructAlteredField(s"${fieldPointer}.#2.${DeclarationHolder.eoriPointer}", holders(1).eori, holders(2).eori),
             constructAlteredField(s"${fieldPointer}.#3", Some(holders(2)), None)
           )
         }
@@ -529,10 +537,18 @@ class PartiesSpec extends UnitSpec {
         withClue("both DeclarationHolder's holders contain same elements but in different order") {
           val declarationHolders = DeclarationHoldersData(holders, YesNoAnswer.Yes)
           declarationHolders.createDiff(declarationHolders.copy(holders = holders.reverse), baseFieldPointer, Some(1)) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", holders(2).authorisationTypeCode, holders(0).authorisationTypeCode),
-            constructAlteredField(s"${fieldPointer}.#1", holders(2).eori, holders(0).eori),
-            constructAlteredField(s"${fieldPointer}.#3", holders(0).authorisationTypeCode, holders(2).authorisationTypeCode),
-            constructAlteredField(s"${fieldPointer}.#3", holders(0).eori, holders(2).eori)
+            constructAlteredField(
+              s"${fieldPointer}.#1.${DeclarationHolder.authorisationTypeCodePointer}",
+              holders(2).authorisationTypeCode,
+              holders(0).authorisationTypeCode
+            ),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationHolder.eoriPointer}", holders(2).eori, holders(0).eori),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${DeclarationHolder.authorisationTypeCodePointer}",
+              holders(0).authorisationTypeCode,
+              holders(2).authorisationTypeCode
+            ),
+            constructAlteredField(s"${fieldPointer}.#3.${DeclarationHolder.eoriPointer}", holders(0).eori, holders(2).eori)
           )
         }
 
@@ -540,8 +556,12 @@ class PartiesSpec extends UnitSpec {
           val otherHolder = DeclarationHolder(Some("authorisationTypeCodeOther"), Some(Eori("eoriOther")), Some(EoriSource.UserEori))
           val declarationHolders = DeclarationHoldersData(Seq(otherHolder) ++ holders.drop(1), YesNoAnswer.Yes)
           declarationHolders.createDiff(declarationHolders.copy(holders = holders), baseFieldPointer, Some(1)) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", holders(0).authorisationTypeCode, otherHolder.authorisationTypeCode),
-            constructAlteredField(s"${fieldPointer}.#1", holders(0).eori, otherHolder.eori)
+            constructAlteredField(
+              s"${fieldPointer}.#1.${DeclarationHolder.authorisationTypeCodePointer}",
+              holders(0).authorisationTypeCode,
+              otherHolder.authorisationTypeCode
+            ),
+            constructAlteredField(s"${fieldPointer}.#1.${DeclarationHolder.eoriPointer}", holders(0).eori, otherHolder.eori)
           )
         }
       }

--- a/test/forms/declaration/PreviousDocumentsSpec.scala
+++ b/test/forms/declaration/PreviousDocumentsSpec.scala
@@ -31,7 +31,7 @@ class PreviousDocumentsSpec extends DeclarationPageBaseSpec with OptionValues {
       }
 
       "the original version's documentType field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${Document.documentTypePointer}"
         val prevDocs = Document("latestType", "latestReference", None)
         val originalValue = "originalType"
         prevDocs.createDiff(prevDocs.copy(documentType = originalValue), baseFieldPointer) mustBe Seq(
@@ -40,7 +40,7 @@ class PreviousDocumentsSpec extends DeclarationPageBaseSpec with OptionValues {
       }
 
       "the original version's documentReference field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${Document.documentReferencePointer}"
         val prevDocs = Document("latestType", "latestReference", None)
         val originalValue = "originalReference"
         prevDocs.createDiff(prevDocs.copy(documentReference = originalValue), baseFieldPointer) mustBe Seq(
@@ -49,7 +49,7 @@ class PreviousDocumentsSpec extends DeclarationPageBaseSpec with OptionValues {
       }
 
       "the original version's goodsItemIdentifier field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${Document.goodsItemIdentifierPointer}"
         withClue("both versions have Some values but values are different") {
           val prevDocs = Document("latestType", "latestReference", Some("latestGoodsIdent"))
           val originalValue = "originalGoodsIdent"

--- a/test/services/SubmissionServiceSpec.scala
+++ b/test/services/SubmissionServiceSpec.scala
@@ -164,7 +164,7 @@ class SubmissionServiceSpec
 
       // Then
       val expectedFieldPointers = List(
-        "declaration.locations.destinationCountry.code",
+        "declaration.locations.destinationCountry",
         "declaration.totalNumberOfItems.totalAmountInvoiced",
         "declaration.totalNumberOfItems.exchangeRate"
       )

--- a/test/services/cache/ExportItemSpec.scala
+++ b/test/services/cache/ExportItemSpec.scala
@@ -375,7 +375,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's nactExemptionCode field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}.${NactCode.pointer}"
+        val fieldPointer = s"${baseFieldPointer}.${NactCode.exemptionPointer}"
         val item = ExportItem("latestId", nactExemptionCode = Some(NactCode("taricCodeFour")))
         val originalValue = NactCode("originalValue")
         item.createDiff(item.copy(nactExemptionCode = Some(originalValue)), baseFieldPointer) mustBe Seq(
@@ -581,18 +581,18 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       "the original version's country field has a different value to this one" in {
         val fieldPointer = s"${baseFieldPointer}"
         val additionalFiscalReference = AdditionalFiscalReference("latestCountry", "latestReference")
-        val originalValue = "originalCountry"
-        additionalFiscalReference.createDiff(additionalFiscalReference.copy(country = originalValue), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue, additionalFiscalReference.country)
+        val originalValue = additionalFiscalReference.copy(country = "originCountry")
+        additionalFiscalReference.createDiff(originalValue, baseFieldPointer) mustBe Seq(
+          constructAlteredField(fieldPointer, Some(originalValue), Some(additionalFiscalReference))
         )
       }
 
       "the original version's reference field has a different value to this one" in {
         val fieldPointer = s"${baseFieldPointer}"
         val additionalFiscalReference = AdditionalFiscalReference("latestCountry", "latestReference")
-        val originalValue = "originalReference"
-        additionalFiscalReference.createDiff(additionalFiscalReference.copy(reference = originalValue), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue, additionalFiscalReference.reference)
+        val originalValue = additionalFiscalReference.copy(reference = "originalReference")
+        additionalFiscalReference.createDiff(originalValue, baseFieldPointer) mustBe Seq(
+          constructAlteredField(fieldPointer, Some(originalValue), Some(additionalFiscalReference))
         )
       }
     }
@@ -636,10 +636,8 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalFiscalReferences references contain different number of elements") {
           val additionalFiscalReferences = AdditionalFiscalReferencesData(references.drop(1))
           additionalFiscalReferences.createDiff(additionalFiscalReferences.copy(references = references), fieldPointer, None) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0).country), Some(references(1).country)),
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0).reference), Some(references(1).reference)),
-            constructAlteredField(s"${fieldPointer}.references.#2", Some(references(1).country), Some(references(2).country)),
-            constructAlteredField(s"${fieldPointer}.references.#2", Some(references(1).reference), Some(references(2).reference)),
+            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0)), Some(references(1))),
+            constructAlteredField(s"${fieldPointer}.references.#2", Some(references(1)), Some(references(2))),
             constructAlteredField(s"${fieldPointer}.references.#3", Some(references(2)), None)
           )
         }
@@ -647,10 +645,8 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalFiscalReferences references contain same elements but in different order") {
           val additionalFiscalReferences = AdditionalFiscalReferencesData(references)
           additionalFiscalReferences.createDiff(additionalFiscalReferences.copy(references = references.reverse), fieldPointer, None) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(2).country), Some(references(0).country)),
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(2).reference), Some(references(0).reference)),
-            constructAlteredField(s"${fieldPointer}.references.#3", Some(references(0).country), Some(references(2).country)),
-            constructAlteredField(s"${fieldPointer}.references.#3", Some(references(0).reference), Some(references(2).reference))
+            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(2)), Some(references(0))),
+            constructAlteredField(s"${fieldPointer}.references.#3", Some(references(0)), Some(references(2)))
           )
         }
 
@@ -658,8 +654,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
           val newValue = AdditionalFiscalReference("countryFour", "referenceFour")
           val additionalFiscalReferences = AdditionalFiscalReferencesData(Seq(newValue) ++ references.drop(1))
           additionalFiscalReferences.createDiff(additionalFiscalReferences.copy(references = references), fieldPointer, None) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0).country), Some(newValue.country)),
-            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0).reference), Some(newValue.reference))
+            constructAlteredField(s"${fieldPointer}.references.#1", Some(references(0)), Some(newValue))
           )
         }
       }
@@ -824,7 +819,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's code field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalInformation.codePointer}"
         val additionalInformation = AdditionalInformation("latestCode", "latestDescription")
         val originalValue = "originalCountry"
         additionalInformation.createDiff(additionalInformation.copy(code = originalValue), baseFieldPointer) mustBe Seq(
@@ -833,7 +828,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's description field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalInformation.descriptionPointer}"
         val additionalInformation = AdditionalInformation("latestCode", "latestDescription")
         val originalValue = "originalCountry"
         additionalInformation.createDiff(additionalInformation.copy(description = originalValue), baseFieldPointer) mustBe Seq(
@@ -881,10 +876,18 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalInformations items contain different number of elements") {
           val additionalInformations = AdditionalInformationData(None, items.drop(1))
           additionalInformations.createDiff(additionalInformations.copy(items = items), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(0).code), Some(items(1).code)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(0).description), Some(items(1).description)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(items(1).code), Some(items(2).code)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(items(1).description), Some(items(2).description)),
+            constructAlteredField(s"${fieldPointer}.#1.${AdditionalInformation.codePointer}", Some(items(0).code), Some(items(1).code)),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalInformation.descriptionPointer}",
+              Some(items(0).description),
+              Some(items(1).description)
+            ),
+            constructAlteredField(s"${fieldPointer}.#2.${AdditionalInformation.codePointer}", Some(items(1).code), Some(items(2).code)),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalInformation.descriptionPointer}",
+              Some(items(1).description),
+              Some(items(2).description)
+            ),
             constructAlteredField(s"${fieldPointer}.#3", Some(items(2)), None)
           )
         }
@@ -892,10 +895,18 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalInformations items contain same elements but in different order") {
           val additionalInformations = AdditionalInformationData(None, items)
           additionalInformations.createDiff(additionalInformations.copy(items = items.reverse), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(2).code), Some(items(0).code)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(2).description), Some(items(0).description)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(items(0).code), Some(items(2).code)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(items(0).description), Some(items(2).description))
+            constructAlteredField(s"${fieldPointer}.#1.${AdditionalInformation.codePointer}", Some(items(2).code), Some(items(0).code)),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalInformation.descriptionPointer}",
+              Some(items(2).description),
+              Some(items(0).description)
+            ),
+            constructAlteredField(s"${fieldPointer}.#3.${AdditionalInformation.codePointer}", Some(items(0).code), Some(items(2).code)),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalInformation.descriptionPointer}",
+              Some(items(0).description),
+              Some(items(2).description)
+            )
           )
         }
 
@@ -903,8 +914,12 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
           val newValue = AdditionalInformation("codeFour", "descriptionFour")
           val additionalInformations = AdditionalInformationData(None, Seq(newValue) ++ items.drop(1))
           additionalInformations.createDiff(additionalInformations.copy(items = items), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(0).code), Some(newValue.code)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(items(0).description), Some(newValue.description))
+            constructAlteredField(s"${fieldPointer}.#1.${AdditionalInformation.codePointer}", Some(items(0).code), Some(newValue.code)),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalInformation.descriptionPointer}",
+              Some(items(0).description),
+              Some(newValue.description)
+            )
           )
         }
       }
@@ -921,7 +936,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's measurementUnit field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DocumentWriteOff.measurementUnitPointer}"
         val documentWriteOff = DocumentWriteOff(Some("latestMeasurementUnitPointer"), Some(BigDecimal(1)))
         val originalValue = "originalCountry"
         documentWriteOff.createDiff(documentWriteOff.copy(measurementUnit = Some(originalValue)), baseFieldPointer) mustBe Seq(
@@ -930,7 +945,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's documentQuantity field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${DocumentWriteOff.documentQuantityPointer}"
         val documentWriteOff = DocumentWriteOff(Some("latestMeasurementUnitPointer"), Some(BigDecimal(1)))
         val originalValue = BigDecimal(2)
         documentWriteOff.createDiff(documentWriteOff.copy(documentQuantity = Some(originalValue)), baseFieldPointer) mustBe Seq(
@@ -950,7 +965,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's documentTypeCode field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.documentTypeCodePointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -967,7 +982,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's documentIdentifier field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.documentIdentifierPointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -984,7 +999,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's documentStatus field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.documentStatusPointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -1001,7 +1016,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's documentStatusReason field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.documentStatusReasonPointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -1018,7 +1033,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's issuingAuthorityName field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.issuingAuthorityNamePointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -1035,7 +1050,7 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
       }
 
       "the original version's dateOfValidity field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.dateOfValidityPointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -1045,14 +1060,14 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
           Some(Date(None, None, None)),
           Some(DocumentWriteOff(None, None))
         )
-        val originalValue = Date(Some(1), None, None)
-        additionalDocument.createDiff(additionalDocument.copy(dateOfValidity = Some(originalValue)), baseFieldPointer) mustBe Seq(
-          constructAlteredField(fieldPointer, originalValue.day, additionalDocument.dateOfValidity.get.day)
+        val originalValue = Some(Date(Some(1), None, None))
+        additionalDocument.createDiff(additionalDocument.copy(dateOfValidity = originalValue), baseFieldPointer) mustBe Seq(
+          constructAlteredField(fieldPointer, originalValue, additionalDocument.dateOfValidity)
         )
       }
 
       "the original version's documentWriteOff field has a different value to this one" in {
-        val fieldPointer = s"${baseFieldPointer}"
+        val fieldPointer = s"${baseFieldPointer}.${AdditionalDocument.documentWriteOffPointer}.${DocumentWriteOff.measurementUnitPointer}"
         val additionalDocument = AdditionalDocument(
           Some("latestDocumentTypeCode"),
           Some("latestDocumentIdentifier"),
@@ -1132,16 +1147,56 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalDocuments documents contain different number of elements") {
           val additionalDocuments = AdditionalDocuments(None, documents.drop(1))
           additionalDocuments.createDiff(additionalDocuments.copy(documents = documents), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentTypeCode.get), Some(documents(1).documentTypeCode.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentIdentifier.get), Some(documents(1).documentIdentifier.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentStatus.get), Some(documents(1).documentStatus.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentStatusReason.get), Some(documents(1).documentStatusReason.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).issuingAuthorityName.get), Some(documents(1).issuingAuthorityName.get)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(documents(1).documentTypeCode.get), Some(documents(2).documentTypeCode.get)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(documents(1).documentIdentifier.get), Some(documents(2).documentIdentifier.get)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(documents(1).documentStatus.get), Some(documents(2).documentStatus.get)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(documents(1).documentStatusReason.get), Some(documents(2).documentStatusReason.get)),
-            constructAlteredField(s"${fieldPointer}.#2", Some(documents(1).issuingAuthorityName.get), Some(documents(2).issuingAuthorityName.get)),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentTypeCodePointer}",
+              Some(documents(0).documentTypeCode.get),
+              Some(documents(1).documentTypeCode.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentIdentifierPointer}",
+              Some(documents(0).documentIdentifier.get),
+              Some(documents(1).documentIdentifier.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusPointer}",
+              Some(documents(0).documentStatus.get),
+              Some(documents(1).documentStatus.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusReasonPointer}",
+              Some(documents(0).documentStatusReason.get),
+              Some(documents(1).documentStatusReason.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.issuingAuthorityNamePointer}",
+              Some(documents(0).issuingAuthorityName.get),
+              Some(documents(1).issuingAuthorityName.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalDocument.documentTypeCodePointer}",
+              Some(documents(1).documentTypeCode.get),
+              Some(documents(2).documentTypeCode.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalDocument.documentIdentifierPointer}",
+              Some(documents(1).documentIdentifier.get),
+              Some(documents(2).documentIdentifier.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalDocument.documentStatusPointer}",
+              Some(documents(1).documentStatus.get),
+              Some(documents(2).documentStatus.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalDocument.documentStatusReasonPointer}",
+              Some(documents(1).documentStatusReason.get),
+              Some(documents(2).documentStatusReason.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#2.${AdditionalDocument.issuingAuthorityNamePointer}",
+              Some(documents(1).issuingAuthorityName.get),
+              Some(documents(2).issuingAuthorityName.get)
+            ),
             constructAlteredField(s"${fieldPointer}.#3", Some(documents(2)), None)
           )
         }
@@ -1149,16 +1204,56 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
         withClue("both AdditionalDocuments documents contain same elements but in different order") {
           val additionalDocuments = AdditionalDocuments(None, documents)
           additionalDocuments.createDiff(additionalDocuments.copy(documents = documents.reverse), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(2).documentTypeCode.get), Some(documents(0).documentTypeCode.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(2).documentIdentifier.get), Some(documents(0).documentIdentifier.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(2).documentStatus.get), Some(documents(0).documentStatus.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(2).documentStatusReason.get), Some(documents(0).documentStatusReason.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(2).issuingAuthorityName.get), Some(documents(0).issuingAuthorityName.get)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(documents(0).documentTypeCode.get), Some(documents(2).documentTypeCode.get)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(documents(0).documentIdentifier.get), Some(documents(2).documentIdentifier.get)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(documents(0).documentStatus.get), Some(documents(2).documentStatus.get)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(documents(0).documentStatusReason.get), Some(documents(2).documentStatusReason.get)),
-            constructAlteredField(s"${fieldPointer}.#3", Some(documents(0).issuingAuthorityName.get), Some(documents(2).issuingAuthorityName.get))
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentTypeCodePointer}",
+              Some(documents(2).documentTypeCode.get),
+              Some(documents(0).documentTypeCode.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentIdentifierPointer}",
+              Some(documents(2).documentIdentifier.get),
+              Some(documents(0).documentIdentifier.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusPointer}",
+              Some(documents(2).documentStatus.get),
+              Some(documents(0).documentStatus.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusReasonPointer}",
+              Some(documents(2).documentStatusReason.get),
+              Some(documents(0).documentStatusReason.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.issuingAuthorityNamePointer}",
+              Some(documents(2).issuingAuthorityName.get),
+              Some(documents(0).issuingAuthorityName.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalDocument.documentTypeCodePointer}",
+              Some(documents(0).documentTypeCode.get),
+              Some(documents(2).documentTypeCode.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalDocument.documentIdentifierPointer}",
+              Some(documents(0).documentIdentifier.get),
+              Some(documents(2).documentIdentifier.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalDocument.documentStatusPointer}",
+              Some(documents(0).documentStatus.get),
+              Some(documents(2).documentStatus.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalDocument.documentStatusReasonPointer}",
+              Some(documents(0).documentStatusReason.get),
+              Some(documents(2).documentStatusReason.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#3.${AdditionalDocument.issuingAuthorityNamePointer}",
+              Some(documents(0).issuingAuthorityName.get),
+              Some(documents(2).issuingAuthorityName.get)
+            )
           )
         }
 
@@ -1174,11 +1269,31 @@ class ExportItemSpec extends UnitWithMocksSpec with ExportsItemBuilder {
           )
           val additionalDocuments = AdditionalDocuments(None, Seq(newValue) ++ documents.drop(1))
           additionalDocuments.createDiff(additionalDocuments.copy(documents = documents), baseFieldPointer) mustBe Seq(
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentTypeCode.get), Some(newValue.documentTypeCode.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentIdentifier.get), Some(newValue.documentIdentifier.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentStatus.get), Some(newValue.documentStatus.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).documentStatusReason.get), Some(newValue.documentStatusReason.get)),
-            constructAlteredField(s"${fieldPointer}.#1", Some(documents(0).issuingAuthorityName.get), Some(newValue.issuingAuthorityName.get))
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentTypeCodePointer}",
+              Some(documents(0).documentTypeCode.get),
+              Some(newValue.documentTypeCode.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentIdentifierPointer}",
+              Some(documents(0).documentIdentifier.get),
+              Some(newValue.documentIdentifier.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusPointer}",
+              Some(documents(0).documentStatus.get),
+              Some(newValue.documentStatus.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.documentStatusReasonPointer}",
+              Some(documents(0).documentStatusReason.get),
+              Some(newValue.documentStatusReason.get)
+            ),
+            constructAlteredField(
+              s"${fieldPointer}.#1.${AdditionalDocument.issuingAuthorityNamePointer}",
+              Some(documents(0).issuingAuthorityName.get),
+              Some(newValue.issuingAuthorityName.get)
+            )
           )
         }
       }

--- a/test/services/model/DiffToolsISpec.scala
+++ b/test/services/model/DiffToolsISpec.scala
@@ -18,8 +18,8 @@ package services.model
 
 import base.UnitSpec
 import forms.declaration.{PackageInformation, Seal}
-import forms.declaration.countries.Country
 import models.ExportsDeclaration
+import forms.declaration.countries.Country
 import models.declaration.{Container, ExportItem, Locations, ProcedureCodesData, RoutingCountry, Transport}
 import org.scalatest.GivenWhenThen
 import services.{AlteredField, OriginalAndNewValues}
@@ -29,7 +29,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
 
   private val baseFieldPointer = ExportsDeclaration.pointer
   private val goodsItemQuantityFieldPointer = s"$baseFieldPointer.${ExportsDeclaration.goodsItemQuantityPointer}"
-  private val destinationCountryPointer = s"$baseFieldPointer.${Locations.pointer}.${Locations.destinationCountryPointer}.${Country.pointer}"
+  private val destinationCountryPointer = s"$baseFieldPointer.${Locations.pointer}.${Locations.destinationCountryPointer}"
   private def itemFieldPointer(itemSeqId: Int) = s"$baseFieldPointer.${ExportItem.pointer}.#$itemSeqId"
   private def procedureCodePointer(itemSeqId: Int) =
     s"$baseFieldPointer.${ExportItem.pointer}.#$itemSeqId.${ProcedureCodesData.pointer}.${ProcedureCodesData.procedureCodesPointer}"
@@ -52,10 +52,10 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         val amendedDeclaration = aDeclaration(withItems(currentItem1), withDestinationCountry(Country(Some("DE"))))
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
+          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044"))),
           AlteredField(itemFieldPointer(2), OriginalAndNewValues(Some(originalItem2), None)),
           AlteredField(goodsItemQuantityFieldPointer, OriginalAndNewValues(Some(2), Some(1))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE"))),
-          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -70,10 +70,10 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         val amendedDeclaration = aDeclaration(withItems(currentItem1, currentItem2), withDestinationCountry(Country(Some("DE"))))
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
+          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044"))),
           AlteredField(itemFieldPointer(2), OriginalAndNewValues(None, Some(currentItem2))),
           AlteredField(goodsItemQuantityFieldPointer, OriginalAndNewValues(Some(1), Some(2))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE"))),
-          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -89,10 +89,10 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         val amendedDeclaration = aDeclaration(withItems(currentItem1, currentItem3), withDestinationCountry(Country(Some("DE"))))
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
+          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044"))),
           AlteredField(itemFieldPointer(2), OriginalAndNewValues(Some(originalItem2), None)),
           AlteredField(itemFieldPointer(3), OriginalAndNewValues(None, Some(currentItem3))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE"))),
-          AlteredField(procedureCodePointer(1), OriginalAndNewValues(Some("1042"), Some("1044")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
     }
@@ -116,7 +116,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(packageInfoPointer(2), OriginalAndNewValues(Some(originalPackageInfo2), None)),
           AlteredField(s"${packageInfoPointer(1)}.${PackageInformation.typesOfPackagesPointer}", OriginalAndNewValues(None, Some("box"))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -139,7 +139,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(packageInfoPointer(2), OriginalAndNewValues(None, Some(currentPackageInfo2))),
           AlteredField(s"${packageInfoPointer(1)}.${PackageInformation.typesOfPackagesPointer}", OriginalAndNewValues(None, Some("box"))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -164,7 +164,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
           AlteredField(packageInfoPointer(2), OriginalAndNewValues(Some(originalPackageInfo2), None)),
           AlteredField(packageInfoPointer(3), OriginalAndNewValues(None, Some(currentPackageInfo3))),
           AlteredField(s"${packageInfoPointer(1)}.${PackageInformation.typesOfPackagesPointer}", OriginalAndNewValues(None, Some("box"))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
     }
@@ -190,7 +190,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(sealPointer(1), OriginalAndNewValues(None, Some(currentSeal1))),
           AlteredField(containerPointer(2), OriginalAndNewValues(Some(originalContainer2), None)),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -213,7 +213,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(sealPointer(1), OriginalAndNewValues(None, Some(currentSeal1))),
           AlteredField(containerPointer(2), OriginalAndNewValues(None, Some(currentContainer2))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -241,7 +241,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
           AlteredField(sealPointer(1), OriginalAndNewValues(None, Some(currentSeal1))),
           AlteredField(containerPointer(2), OriginalAndNewValues(Some(originalContainer2), None)),
           AlteredField(containerPointer(3), OriginalAndNewValues(None, Some(currentContainer3))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
     }
@@ -261,7 +261,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(sealPointer(2), OriginalAndNewValues(Some(originalSeal2), None)),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -279,7 +279,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(sealPointer(2), OriginalAndNewValues(None, Some(currentSeal2))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -298,7 +298,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(sealPointer(2), OriginalAndNewValues(None, Some(currentSeal2))),
           AlteredField(sealPointer(1), OriginalAndNewValues(Some(originalSeal1), None)),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
     }
@@ -322,7 +322,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(routingCountryPointer(2), OriginalAndNewValues(Some(originalRoutingCountry2), None)),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -344,7 +344,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
 
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(routingCountryPointer(2), OriginalAndNewValues(None, Some(currentRoutingCountry2))),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
 
@@ -367,7 +367,7 @@ class DiffToolsISpec extends UnitSpec with ExportsDeclarationBuilder with Export
         amendedDeclaration.createDiff(originalDeclaration) must contain theSameElementsAs Seq(
           AlteredField(routingCountryPointer(2), OriginalAndNewValues(None, Some(currentRoutingCountry2))),
           AlteredField(routingCountryPointer(1), OriginalAndNewValues(Some(originalRoutingCountry1), None)),
-          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some("FR"), Some("DE")))
+          AlteredField(destinationCountryPointer, OriginalAndNewValues(Some(Country(Some("FR"))), Some(Country(Some("DE")))))
         )
       }
     }


### PR DESCRIPTION
To improve the accuracy of the field pointers returned by the diff tool for following entities:

* AdditionalFiscalReference
* AdditionalInformation
* Containers
* DeclarationAdditionalActors
* DeclarationHolder
* RoutingCountry