### PR TITLE
Revert "CEDS-4880: disable use-improved-error-messages feature"

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -116,7 +116,7 @@ microservice {
       sfus = enabled
       secureMessagingInbox = exports
       tdrUnauthorisedMessage = disabled
-      use-improved-error-messages = false
+      use-improved-error-messages = true
     }
   }
 }

--- a/test/config/AppConfigSpec.scala
+++ b/test/config/AppConfigSpec.scala
@@ -39,7 +39,7 @@ class AppConfigSpec extends UnitWithMocksSpec {
         |
         |list-of-available-journeys="CRT,CAN,SUB"
         |list-of-available-declarations="STANDARD,SUPPLEMENTARY"
-        |microservice.services.features.use-improved-error-messages=false
+        |microservice.services.features.use-improved-error-messages=true
         |microservice.services.customs-declare-exports.host=localhost
         |microservice.services.customs-declare-exports.port=9875
         |microservice.services.customs-declare-exports.submit-declaration=/declaration
@@ -263,7 +263,7 @@ class AppConfigSpec extends UnitWithMocksSpec {
     }
 
     "have improved error messages feature toggle set to true if defined" in {
-      validAppConfig.isUsingImprovedErrorMessages must be(false)
+      validAppConfig.isUsingImprovedErrorMessages must be(true)
     }
 
     "have language map with English" in {

--- a/test/config/featureFlags/FeatureSwitchConfigSpec.scala
+++ b/test/config/featureFlags/FeatureSwitchConfigSpec.scala
@@ -26,7 +26,7 @@ class FeatureSwitchConfigSpec extends UnitWithMocksSpec {
   private val validConfig: Config =
     ConfigFactory.parseString("""
         |microservice.services.features.default=disabled
-        |microservice.services.features.use-improved-error-messages=false
+        |microservice.services.features.use-improved-error-messages=true
       """.stripMargin)
   private val emptyConfig: Config = ConfigFactory.empty()
 


### PR DESCRIPTION
Reverts hmrc/customs-declare-exports-frontend#1846