### PR TITLE
CEDS-5089 GA4 Update the Content Security Policy

### DIFF
--- a/conf/application.conf
+++ b/conf/application.conf
@@ -27,7 +27,20 @@ appName = "customs-declare-exports-frontend"
 
 play.http.router = testOnlyDoNotUseInAppConf.Routes
 
-play.filters.headers.contentSecurityPolicy = "default-src 'self' 'unsafe-inline' localhost:9000 localhost:9032 localhost:9250 localhost:12345 www.google-analytics.com www.googletagmanager.com tagmanager.google.com data: ssl.gstatic.com www.gstatic.com fonts.gstatic.com fonts.googleapis.com"
+# CSP - see https://confluence.tools.tax.service.gov.uk/display/SEC/Content+Security+Policy+Guidance
+play.filters.enabled += play.filters.csp.CSPFilter
+play.filters.csp.directives {
+  default-src = "'self'"
+  font-src = "'self' https://ssl.gstatic.com www.gstatic.com https://fonts.gstatic.com https://fonts.googleapis.com;"
+  frame-src = "'self' https://www.googletagmanager.com;"
+  script-src = "'self' localhost:9032 localhost:12345 https://www.googletagmanager.com https://tagmanager.google.com;"
+  connect-src = "'self' localhost:9250 localhost:9570  https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
+  img-src = "'self' https://ssl.gstatic.com www.gstatic.com https://www.google-analytics.com data https//region1.google-analytics.com https://region1.analytics.google.com https://*.google-analytics.com https://*.analytics.google.com;"
+  style-src = "'self' localhost:9032 https://tagmanager.google.com https://fonts.googleapis.com;"
+  object-src = "'none'"
+  report-uri: ${csp-report-host}"/content-security-policy-reports/"${appName}
+}
+
 play.filters.csrf.contentType.whiteList = ["application/xml", "application/json"]
 
 play.http.errorHandler = "handlers.ErrorHandler"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,7 +1,7 @@
 resolvers += MavenRepository("HMRC-open-artefacts-maven2", "https://open.artefacts.tax.service.gov.uk/maven2")
 resolvers += Resolver.url("HMRC-open-artefacts-ivy", url("https://open.artefacts.tax.service.gov.uk/ivy2"))(Resolver.ivyStylePatterns)
 
-addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.13.0")
+addSbtPlugin("uk.gov.hmrc" % "sbt-auto-build" % "3.14.0")
 
 addSbtPlugin("uk.gov.hmrc" % "sbt-distributables" % "2.2.0")
 


### PR DESCRIPTION
Adding in settings for GA4 plus general review to comply with standards: https://confluence.tools.tax.service.gov.uk/display/SEC/Content+Security+Policy+Guidance