### PR TITLE
CEDS-5205 Add new event on draft dec creation - fix bug

### DIFF
--- a/app/connectors/CustomsDeclareExportsConnector.scala
+++ b/app/connectors/CustomsDeclareExportsConnector.scala
@@ -180,7 +180,8 @@ class CustomsDeclareExportsConnector @Inject() (
         case Success(request) =>
           logPayload("Update Declaration Response", request)
           updateStopwatch.stop()
-          if (dec.declarationMeta.status == INITIAL) audit(eori, dec.id, dec.additionalDeclarationType, dec.ducr, DRAFT, None, auditService)
+          if (dec.declarationMeta.status == INITIAL && dec.ducr.isDefined)
+            audit(eori, dec.id, dec.additionalDeclarationType, dec.ducr, DRAFT, None, auditService)
 
         case Failure(_) =>
           updateStopwatch.stop()

--- a/app/services/AuditCreateDraftDec.scala
+++ b/app/services/AuditCreateDraftDec.scala
@@ -37,8 +37,6 @@ trait AuditCreateDraftDec {
   )(implicit hc: HeaderCarrier): Unit = {
     val auditData: Map[String, String] = Map(
       EventData.eori.toString -> eori,
-      EventData.decType.toString -> additionalDecType.map(_.toString).getOrElse(""),
-      EventData.ducr.toString -> ducr.map(_.ducr).getOrElse(""),
       EventData.declarationStatus.toString -> newDecStatus.toString,
       EventData.declarationId.toString -> newDecId
     )


### PR DESCRIPTION
Fix bug where the audit event was firing prematurely for new draft decs before the DUCR was set