### PR TITLE
CEDS-5356 Reistate audit event when user updated draft declaration

### DIFF
--- a/app/controllers/declaration/AdditionalActorsAddController.scala
+++ b/app/controllers/declaration/AdditionalActorsAddController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -44,7 +45,7 @@ class AdditionalActorsAddController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   declarationAdditionalActorsPage: additional_actors_add
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validTypes = List(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL)

--- a/app/controllers/declaration/AdditionalActorsRemoveController.scala
+++ b/app/controllers/declaration/AdditionalActorsRemoveController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class AdditionalActorsRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   removePage: additional_actors_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalDeclarationTypeController.scala
+++ b/app/controllers/declaration/AdditionalDeclarationTypeController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class AdditionalDeclarationTypeController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalTypePage: additional_declaration_type
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/AdditionalDocumentAddController.scala
+++ b/app/controllers/declaration/AdditionalDocumentAddController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.{TaggedAdditionalDocumentCodes, TaggedAuthCodes}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
@@ -47,7 +48,7 @@ class AdditionalDocumentAddController @Inject() (
   taggedAuthCodes: TaggedAuthCodes,
   taggedAdditionalDocumentCodes: TaggedAdditionalDocumentCodes,
   additionalDocumentAddPage: additional_document_add
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   implicit val taggedAuthCodes2form = taggedAuthCodes

--- a/app/controllers/declaration/AdditionalDocumentChangeController.scala
+++ b/app/controllers/declaration/AdditionalDocumentChangeController.scala
@@ -28,6 +28,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.{TaggedAdditionalDocumentCodes, TaggedAuthCodes}
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
@@ -47,7 +48,7 @@ class AdditionalDocumentChangeController @Inject() (
   taggedAuthCodes: TaggedAuthCodes,
   taggedAdditionalDocumentCodes: TaggedAdditionalDocumentCodes,
   additionalDocumentChangePage: additional_document_change
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   implicit val taggedAuthCodes2form = taggedAuthCodes

--- a/app/controllers/declaration/AdditionalDocumentRemoveController.scala
+++ b/app/controllers/declaration/AdditionalDocumentRemoveController.scala
@@ -30,6 +30,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class AdditionalDocumentRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalDocumentRemovePage: additional_document_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, documentId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalDocumentsController.scala
+++ b/app/controllers/declaration/AdditionalDocumentsController.scala
@@ -70,8 +70,8 @@ class AdditionalDocumentsController @Inject() (
 
   private def nextPage(yesNoAnswer: YesNoAnswer, itemId: String)(implicit request: JourneyRequest[AnyContent]): Result =
     yesNoAnswer.answer match {
-      case YesNoAnswers.yes => navigator.continueTo(AdditionalDocumentAddController.displayPage(itemId))(request)
-      case _                => navigator.continueTo(ItemsSummaryController.displayItemsSummaryPage)(request)
+      case YesNoAnswers.yes => navigator.continueTo(AdditionalDocumentAddController.displayPage(itemId))
+      case _                => navigator.continueTo(ItemsSummaryController.displayItemsSummaryPage)
     }
 
   private def redirectIfNoDocuments(itemId: String)(implicit request: JourneyRequest[_]): Call =

--- a/app/controllers/declaration/AdditionalDocumentsRequiredController.scala
+++ b/app/controllers/declaration/AdditionalDocumentsRequiredController.scala
@@ -25,6 +25,7 @@ import models.declaration.AdditionalDocuments
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class AdditionalDocumentsRequiredController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalDocumentsRequired: additional_documents_required
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val emptyKey = "declaration.additionalDocumentsRequired.empty"

--- a/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesAddController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -44,7 +45,7 @@ class AdditionalFiscalReferencesAddController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalFiscalReferencesPage: additional_fiscal_references_add
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
+++ b/app/controllers/declaration/AdditionalFiscalReferencesRemoveController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class AdditionalFiscalReferencesRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   removePage: additional_fiscal_references_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalInformationAddController.scala
+++ b/app/controllers/declaration/AdditionalInformationAddController.scala
@@ -30,6 +30,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class AdditionalInformationAddController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalInformationPage: additional_information_add
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalInformationChangeController.scala
+++ b/app/controllers/declaration/AdditionalInformationChangeController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class AdditionalInformationChangeController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   changePage: additional_information_change
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalInformationController.scala
+++ b/app/controllers/declaration/AdditionalInformationController.scala
@@ -78,12 +78,12 @@ class AdditionalInformationController @Inject() (
 
     yesNoAnswer.answer match {
       case YesNoAnswers.yes =>
-        navigator.continueTo(routes.AdditionalInformationAddController.displayPage(itemId))(request)
+        navigator.continueTo(routes.AdditionalInformationAddController.displayPage(itemId))
 
       case YesNoAnswers.no if isClearanceJourney =>
-        navigator.continueTo(AdditionalDocumentsController.displayPage(itemId))(request)
+        navigator.continueTo(AdditionalDocumentsController.displayPage(itemId))
 
-      case _ => navigator.continueTo(IsLicenceRequiredController.displayPage(itemId))(request)
+      case _ => navigator.continueTo(IsLicenceRequiredController.displayPage(itemId))
     }
 
   }

--- a/app/controllers/declaration/AdditionalInformationRemoveController.scala
+++ b/app/controllers/declaration/AdditionalInformationRemoveController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class AdditionalInformationRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   removePage: additional_information_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AdditionalInformationRequiredController.scala
+++ b/app/controllers/declaration/AdditionalInformationRequiredController.scala
@@ -28,6 +28,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class AdditionalInformationRequiredController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   additionalInfoReq: additional_information_required
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/AdditionalProcedureCodesController.scala
+++ b/app/controllers/declaration/AdditionalProcedureCodesController.scala
@@ -32,6 +32,7 @@ import play.api.data.FormError
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.ProcedureCodeService
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
@@ -50,7 +51,7 @@ class AdditionalProcedureCodesController @Inject() (
   procedureCodeService: ProcedureCodeService,
   additionalProcedureCodesPage: additional_procedure_codes,
   supervisingCustomsOfficeHelper: SupervisingCustomsOfficeHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val emptyProcedureCodesData = ProcedureCodesData(None, Seq())

--- a/app/controllers/declaration/AuthorisationHolderAddController.scala
+++ b/app/controllers/declaration/AuthorisationHolderAddController.scala
@@ -30,6 +30,7 @@ import play.api.data.{Form, FormError}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.TaggedAuthCodes
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -46,7 +47,7 @@ class AuthorisationHolderAddController @Inject() (
   mcc: MessagesControllerComponents,
   taggedAuthCodes: TaggedAuthCodes,
   authorisationHolderPage: authorisation_holder_add
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AuthorisationHolderChangeController.scala
+++ b/app/controllers/declaration/AuthorisationHolderChangeController.scala
@@ -34,6 +34,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -47,7 +48,7 @@ class AuthorisationHolderChangeController @Inject() (
   errorHandler: ErrorHandler,
   mcc: MessagesControllerComponents,
   authorisationHolderChangePage: authorisation_holder_change
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/AuthorisationHolderRemoveController.scala
+++ b/app/controllers/declaration/AuthorisationHolderRemoveController.scala
@@ -30,6 +30,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -46,7 +47,7 @@ class AuthorisationHolderRemoveController @Inject() (
   errorHandler: ErrorHandler,
   mcc: MessagesControllerComponents,
   holderRemovePage: authorisation_holder_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/AuthorisationHolderRequiredController.scala
+++ b/app/controllers/declaration/AuthorisationHolderRequiredController.scala
@@ -28,6 +28,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class AuthorisationHolderRequiredController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   authorisationHolderRequired: authorisation_holder_required
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/AuthorisationProcedureCodeChoiceController.scala
+++ b/app/controllers/declaration/AuthorisationProcedureCodeChoiceController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class AuthorisationProcedureCodeChoiceController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   authorisationProcedureCodeChoice: authorisation_procedure_code_choice
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/BorderTransportController.scala
+++ b/app/controllers/declaration/BorderTransportController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.TransportCodeService
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class BorderTransportController @Inject() (
   mcc: MessagesControllerComponents,
   implicit val transportCodeService: TransportCodeService,
   borderTransport: border_transport
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = allDeclarationTypesExcluding(CLEARANCE)

--- a/app/controllers/declaration/CarrierDetailsController.scala
+++ b/app/controllers/declaration/CarrierDetailsController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class CarrierDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   carrierDetailsPage: carrier_details
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE)

--- a/app/controllers/declaration/CarrierEoriNumberController.scala
+++ b/app/controllers/declaration/CarrierEoriNumberController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class CarrierEoriNumberController @Inject() (
   mcc: MessagesControllerComponents,
   carrierEoriDetailsPage: carrier_eori_number,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validJourneys = Seq(STANDARD, SIMPLIFIED, OCCASIONAL, CLEARANCE)

--- a/app/controllers/declaration/CommodityDetailsController.scala
+++ b/app/controllers/declaration/CommodityDetailsController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration.isCodePrefixedWith
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class CommodityDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   commodityDetailsPage: commodity_details
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/CommodityMeasureController.scala
+++ b/app/controllers/declaration/CommodityMeasureController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class CommodityMeasureController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   commodityMeasurePage: commodity_measure
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(STANDARD, SUPPLEMENTARY, CLEARANCE)

--- a/app/controllers/declaration/ConfirmDucrController.scala
+++ b/app/controllers/declaration/ConfirmDucrController.scala
@@ -28,6 +28,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.i18n.Lang.logger
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class ConfirmDucrController @Inject() (
   mcc: MessagesControllerComponents,
   override val exportsCacheService: ExportsCacheService,
   confirmDucrPage: confirm_ducr
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/ConsigneeDetailsController.scala
+++ b/app/controllers/declaration/ConsigneeDetailsController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class ConsigneeDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   consigneeDetailsPage: consignee_details
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/ConsignmentReferencesController.scala
+++ b/app/controllers/declaration/ConsignmentReferencesController.scala
@@ -26,6 +26,7 @@ import models.DeclarationType.SUPPLEMENTARY
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class ConsignmentReferencesController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   consignmentReferencesPage: consignment_references
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/ConsignorDetailsController.scala
+++ b/app/controllers/declaration/ConsignorDetailsController.scala
@@ -25,6 +25,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class ConsignorDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   consignorDetailsPage: consignor_details
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)

--- a/app/controllers/declaration/ConsignorEoriNumberController.scala
+++ b/app/controllers/declaration/ConsignorEoriNumberController.scala
@@ -26,6 +26,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class ConsignorEoriNumberController @Inject() (
   mcc: MessagesControllerComponents,
   consignorEoriDetailsPage: consignor_eori_number,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validJourneys = Seq(DeclarationType.CLEARANCE)

--- a/app/controllers/declaration/CusCodeController.scala
+++ b/app/controllers/declaration/CusCodeController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class CusCodeController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   cusCodePage: cus_code
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validTypes = Seq(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL)

--- a/app/controllers/declaration/DeclarantDetailsController.scala
+++ b/app/controllers/declaration/DeclarantDetailsController.scala
@@ -28,6 +28,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class DeclarantDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   declarantDetailsPage: declarant_details
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/DeclarantExporterController.scala
+++ b/app/controllers/declaration/DeclarantExporterController.scala
@@ -24,6 +24,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -39,7 +40,7 @@ class DeclarantExporterController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   declarantExporterPage: declarant_exporter
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/DepartureTransportController.scala
+++ b/app/controllers/declaration/DepartureTransportController.scala
@@ -29,6 +29,7 @@ import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.TransportCodeService
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -48,7 +49,7 @@ class DepartureTransportController @Inject() (
   implicit val transportCodeService: TransportCodeService,
   departureTransportHelper: DepartureTransportHelper,
   departureTransportPage: departure_transport
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val displayPage: Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/DestinationCountryController.scala
+++ b/app/controllers/declaration/DestinationCountryController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
 import services.TaggedAuthCodes
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -44,7 +45,7 @@ class DestinationCountryController @Inject() (
   mcc: MessagesControllerComponents,
   taggedAuthCodes: TaggedAuthCodes,
   destinationCountryPage: destination_country
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/DucrChoiceController.scala
+++ b/app/controllers/declaration/DucrChoiceController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class DucrChoiceController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   ducrChoicePage: ducr_choice
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/DucrEntryController.scala
+++ b/app/controllers/declaration/DucrEntryController.scala
@@ -24,6 +24,7 @@ import forms.declaration.ConsignmentReferences
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -39,7 +40,7 @@ class DucrEntryController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   ducrEntryPage: ducr_entry
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
+++ b/app/controllers/declaration/EntryIntoDeclarantsRecordsController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class EntryIntoDeclarantsRecordsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   entryIntoDeclarantsRecordsPage: entry_into_declarants_records
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>

--- a/app/controllers/declaration/ExporterDetailsController.scala
+++ b/app/controllers/declaration/ExporterDetailsController.scala
@@ -25,6 +25,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class ExporterDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   exporterDetailsPage: exporter_address
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/ExporterEoriNumberController.scala
+++ b/app/controllers/declaration/ExporterEoriNumberController.scala
@@ -25,6 +25,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class ExporterEoriNumberController @Inject() (
   mcc: MessagesControllerComponents,
   exporterEoriDetailsPage: exporter_eori_number,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/ExpressConsignmentController.scala
+++ b/app/controllers/declaration/ExpressConsignmentController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class ExpressConsignmentController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   expressConsignmentPage: express_consignment
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private lazy val emptyKey = "declaration.transportInformation.expressConsignment.empty"

--- a/app/controllers/declaration/FiscalInformationController.scala
+++ b/app/controllers/declaration/FiscalInformationController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class FiscalInformationController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   fiscalInformationPage: fiscal_information
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, fastForward: Boolean): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/InlandOrBorderController.scala
+++ b/app/controllers/declaration/InlandOrBorderController.scala
@@ -34,6 +34,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -50,7 +51,7 @@ class InlandOrBorderController @Inject() (
   mcc: MessagesControllerComponents,
   inlandOrBorderPage: inland_border,
   inlandOrBorderHelper: InlandOrBorderHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val actionBuilder = authenticate andThen journeyAction.onAdditionalTypes(additionalDeclTypesAllowedOnInlandOrBorder)

--- a/app/controllers/declaration/InlandTransportDetailsController.scala
+++ b/app/controllers/declaration/InlandTransportDetailsController.scala
@@ -30,6 +30,7 @@ import models.requests.JourneyRequest
 import play.api.data.FormError
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -46,7 +47,7 @@ class InlandTransportDetailsController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   inlandTransportDetailsPage: inland_transport_details
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validJourneys = allDeclarationTypesExcluding(CLEARANCE)

--- a/app/controllers/declaration/InvoiceAndExchangeRateChoiceController.scala
+++ b/app/controllers/declaration/InvoiceAndExchangeRateChoiceController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class InvoiceAndExchangeRateChoiceController @Inject() (
   mcc: MessagesControllerComponents,
   invoiceAndExchangeRateChoicePage: invoice_and_exchange_rate_choice,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)

--- a/app/controllers/declaration/InvoiceAndExchangeRateController.scala
+++ b/app/controllers/declaration/InvoiceAndExchangeRateController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class InvoiceAndExchangeRateController @Inject() (
   mcc: MessagesControllerComponents,
   invoiceAndExchangeRatePage: invoice_and_exchange_rate,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)

--- a/app/controllers/declaration/IsExsController.scala
+++ b/app/controllers/declaration/IsExsController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class IsExsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   isExsPage: is_exs
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val allowedJourney: DeclarationType = CLEARANCE

--- a/app/controllers/declaration/IsLicenceRequiredController.scala
+++ b/app/controllers/declaration/IsLicenceRequiredController.scala
@@ -29,6 +29,7 @@ import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.TaggedAuthCodes
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class IsLicenceRequiredController @Inject() (
   mcc: MessagesControllerComponents,
   taggedAuthCodes: TaggedAuthCodes,
   is_licence_required: is_licence_required
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL)

--- a/app/controllers/declaration/LinkDucrToMucrController.scala
+++ b/app/controllers/declaration/LinkDucrToMucrController.scala
@@ -25,6 +25,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class LinkDucrToMucrController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   linkDucrToMucrPage: link_ducr_to_mucr
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/LocalReferenceNumberController.scala
+++ b/app/controllers/declaration/LocalReferenceNumberController.scala
@@ -25,6 +25,7 @@ import forms.{Lrn, LrnValidator}
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class LocalReferenceNumberController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   LrnPage: local_reference_number
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/LocationOfGoodsController.scala
+++ b/app/controllers/declaration/LocationOfGoodsController.scala
@@ -27,6 +27,7 @@ import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.TaggedAuthCodes
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -44,7 +45,7 @@ class LocationOfGoodsController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   navigator: Navigator,
   taggedAuthCodes: TaggedAuthCodes
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/MucrController.scala
+++ b/app/controllers/declaration/MucrController.scala
@@ -25,6 +25,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class MucrController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   mucrPage: mucr_code
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/NactCodeAddController.scala
+++ b/app/controllers/declaration/NactCodeAddController.scala
@@ -26,6 +26,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class NactCodeAddController @Inject() (
   mcc: MessagesControllerComponents,
   nactCodeAddFirstPage: nact_code_add_first,
   nactCodeAdd: nact_code_add
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   import NactCodeSummaryController._

--- a/app/controllers/declaration/NactCodeRemoveController.scala
+++ b/app/controllers/declaration/NactCodeRemoveController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class NactCodeRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   nactCodeRemove: nact_code_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validTypes = Seq(STANDARD, SUPPLEMENTARY, SIMPLIFIED, OCCASIONAL)

--- a/app/controllers/declaration/NatureOfTransactionController.scala
+++ b/app/controllers/declaration/NatureOfTransactionController.scala
@@ -25,6 +25,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class NatureOfTransactionController @Inject() (
   mcc: MessagesControllerComponents,
   natureOfTransactionPage: nature_of_transaction,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/OfficeOfExitController.scala
+++ b/app/controllers/declaration/OfficeOfExitController.scala
@@ -25,6 +25,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -40,7 +41,7 @@ class OfficeOfExitController @Inject() (
   mcc: MessagesControllerComponents,
   officeOfExitPage: office_of_exit,
   override val exportsCacheService: ExportsCacheService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/PackageInformationAddController.scala
+++ b/app/controllers/declaration/PackageInformationAddController.scala
@@ -30,6 +30,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import services.PackageTypesService
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class PackageInformationAddController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   packageInformationPage: package_information_add
-)(implicit ec: ExecutionContext, packageTypesService: PackageTypesService)
+)(implicit ec: ExecutionContext, packageTypesService: PackageTypesService, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/PackageInformationChangeController.scala
+++ b/app/controllers/declaration/PackageInformationChangeController.scala
@@ -31,6 +31,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.PackageTypesService
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -47,7 +48,7 @@ class PackageInformationChangeController @Inject() (
   errorHandler: ErrorHandler,
   mcc: MessagesControllerComponents,
   packageChangePage: package_information_change
-)(implicit ec: ExecutionContext, packageTypesService: PackageTypesService)
+)(implicit ec: ExecutionContext, packageTypesService: PackageTypesService, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, code: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/PackageInformationRemoveController.scala
+++ b/app/controllers/declaration/PackageInformationRemoveController.scala
@@ -29,6 +29,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class PackageInformationRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   packageTypeRemove: package_information_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String, id: String): Action[AnyContent] = (authenticate andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
+++ b/app/controllers/declaration/PersonPresentingGoodsDetailsController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class PersonPresentingGoodsDetailsController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   personPresentingGoodsDetailsPage: person_presenting_goods_details
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType(CLEARANCE)) { implicit request =>

--- a/app/controllers/declaration/PreviousDocumentsChangeController.scala
+++ b/app/controllers/declaration/PreviousDocumentsChangeController.scala
@@ -27,6 +27,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.cache.ExportsCacheService
 import services.DocumentTypeService
+import services.audit.AuditService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import utils.ListItem
@@ -43,7 +44,7 @@ class PreviousDocumentsChangeController @Inject() (
   mcc: MessagesControllerComponents,
   changePage: previous_documents_change,
   documentTypeService: DocumentTypeService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/PreviousDocumentsController.scala
+++ b/app/controllers/declaration/PreviousDocumentsController.scala
@@ -29,6 +29,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import services.cache.ExportsCacheService
 import services.DocumentTypeService
+import services.audit.AuditService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
 import views.html.declaration.previousDocuments.previous_documents
@@ -44,7 +45,7 @@ class PreviousDocumentsController @Inject() (
   previousDocumentsPage: previous_documents,
   override val exportsCacheService: ExportsCacheService,
   documentTypeService: DocumentTypeService
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/PreviousDocumentsRemoveController.scala
+++ b/app/controllers/declaration/PreviousDocumentsRemoveController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class PreviousDocumentsRemoveController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   removePage: previous_documents_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with WithUnsafeDefaultFormBinding {
 
   def displayPage(id: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/ProcedureCodesController.scala
+++ b/app/controllers/declaration/ProcedureCodesController.scala
@@ -27,6 +27,7 @@ import models.declaration.ProcedureCodesData
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class ProcedureCodesController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   procedureCodesPage: procedure_codes
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/RepresentativeAgentController.scala
+++ b/app/controllers/declaration/RepresentativeAgentController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class RepresentativeAgentController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   representativeAgentPage: representative_details_agent
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/RepresentativeEntityController.scala
+++ b/app/controllers/declaration/RepresentativeEntityController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class RepresentativeEntityController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   representativeEntityPage: representative_details_entity
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/RepresentativeStatusController.scala
+++ b/app/controllers/declaration/RepresentativeStatusController.scala
@@ -28,6 +28,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class RepresentativeStatusController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   representativeStatusPage: representative_details_status
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/RoutingCountriesController.scala
+++ b/app/controllers/declaration/RoutingCountriesController.scala
@@ -30,6 +30,7 @@ import models.declaration.RoutingCountry
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -46,7 +47,7 @@ class RoutingCountriesController @Inject() (
   mcc: MessagesControllerComponents,
   routingQuestionPage: routing_country_question,
   countryOfRoutingPage: country_of_routing
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayRoutingQuestion(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/SealController.scala
+++ b/app/controllers/declaration/SealController.scala
@@ -32,6 +32,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -50,7 +51,7 @@ class SealController @Inject() (
   addPage: seal_add,
   removePage: seal_remove,
   summaryPage: seal_summary
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayAddSeal(containerId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/StatisticalValueController.scala
+++ b/app/controllers/declaration/StatisticalValueController.scala
@@ -29,6 +29,7 @@ import models.requests.JourneyRequest
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -44,7 +45,7 @@ class StatisticalValueController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   itemTypePage: statistical_value
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validJourneys = List(STANDARD, SUPPLEMENTARY) ::: journeysOnLowValue

--- a/app/controllers/declaration/SummaryController.scala
+++ b/app/controllers/declaration/SummaryController.scala
@@ -29,6 +29,7 @@ import play.api.Logging
 import play.api.i18n.I18nSupport
 import play.api.mvc._
 import play.twirl.api.Html
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.http.HeaderCarrier
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -53,7 +54,7 @@ class SummaryController @Inject() (
   normalSummaryPage: normal_summary_page,
   summaryPageNoData: summary_page_no_data,
   lrnValidator: LrnValidator
-)(implicit ec: ExecutionContext, appConfig: AppConfig)
+)(implicit ec: ExecutionContext, appConfig: AppConfig, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with Logging with ModelCacheable {
 
   val displayPage: Action[AnyContent] = (authenticate andThen verifyEmail andThen journeyType).async { implicit request =>

--- a/app/controllers/declaration/SupervisingCustomsOfficeController.scala
+++ b/app/controllers/declaration/SupervisingCustomsOfficeController.scala
@@ -25,6 +25,7 @@ import models.requests.JourneyRequest
 import models.ExportsDeclaration
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class SupervisingCustomsOfficeController @Inject() (
   supervisingCustomsOfficePage: supervising_customs_office,
   inlandOrBorderHelper: InlandOrBorderHelper,
   supervisingCustomsOfficeHelper: SupervisingCustomsOfficeHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/SupplementaryUnitsController.scala
+++ b/app/controllers/declaration/SupplementaryUnitsController.scala
@@ -28,6 +28,7 @@ import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
 import services.TariffApiService
 import services.TariffApiService.{CommodityCodeNotFound, SupplementaryUnitsNotRequired}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -46,7 +47,7 @@ class SupplementaryUnitsController @Inject() (
   mcc: MessagesControllerComponents,
   supplementaryUnitsPage: supplementary_units,
   supplementaryUnitsYesNoPage: supplementary_units_yes_no
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(STANDARD, SUPPLEMENTARY)

--- a/app/controllers/declaration/TotalPackageQuantityController.scala
+++ b/app/controllers/declaration/TotalPackageQuantityController.scala
@@ -26,6 +26,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -41,7 +42,7 @@ class TotalPackageQuantityController @Inject() (
   navigator: Navigator,
   override val exportsCacheService: ExportsCacheService,
   totalPackageQuantity: total_package_quantity
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SUPPLEMENTARY)

--- a/app/controllers/declaration/TraderReferenceController.scala
+++ b/app/controllers/declaration/TraderReferenceController.scala
@@ -26,6 +26,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -42,7 +43,7 @@ class TraderReferenceController @Inject() (
   mcc: MessagesControllerComponents,
   override val exportsCacheService: ExportsCacheService,
   traderReferencePage: trader_reference
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with AmendmentDraftFilter with I18nSupport with ModelCacheable with SubmissionErrors
     with WithUnsafeDefaultFormBinding {
 

--- a/app/controllers/declaration/TransportContainerController.scala
+++ b/app/controllers/declaration/TransportContainerController.scala
@@ -33,6 +33,7 @@ import models.requests.JourneyRequest
 import play.api.data.{Form, FormError}
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -52,7 +53,7 @@ class TransportContainerController @Inject() (
   addPage: transport_container_add,
   summaryPage: transport_container_summary,
   removePage: transport_container_remove
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayAddContainer(): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/TransportCountryController.scala
+++ b/app/controllers/declaration/TransportCountryController.scala
@@ -27,6 +27,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class TransportCountryController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   transportCountry: transport_country
-)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector)
+)(implicit ec: ExecutionContext, codeListConnector: CodeListConnector, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = allDeclarationTypesExcluding(CLEARANCE)

--- a/app/controllers/declaration/TransportLeavingTheBorderController.scala
+++ b/app/controllers/declaration/TransportLeavingTheBorderController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -47,7 +48,7 @@ class TransportLeavingTheBorderController @Inject() (
   transportAtBorder: transport_leaving_the_border,
   inlandOrBorderHelper: InlandOrBorderHelper,
   supervisingCustomsOfficeHelper: SupervisingCustomsOfficeHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/TransportPaymentController.scala
+++ b/app/controllers/declaration/TransportPaymentController.scala
@@ -24,6 +24,7 @@ import models.requests.JourneyRequest
 import models.{DeclarationType, ExportsDeclaration}
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents, Result}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -39,7 +40,7 @@ class TransportPaymentController @Inject() (
   override val exportsCacheService: ExportsCacheService,
   mcc: MessagesControllerComponents,
   transportPayment: transport_payment
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   private val validTypes = Seq(DeclarationType.STANDARD, DeclarationType.SIMPLIFIED, DeclarationType.OCCASIONAL, DeclarationType.CLEARANCE)

--- a/app/controllers/declaration/UNDangerousGoodsCodeController.scala
+++ b/app/controllers/declaration/UNDangerousGoodsCodeController.scala
@@ -27,6 +27,7 @@ import models.{DeclarationType, ExportsDeclaration}
 import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, Call, MessagesControllerComponents}
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -43,7 +44,7 @@ class UNDangerousGoodsCodeController @Inject() (
   navigator: Navigator,
   mcc: MessagesControllerComponents,
   unDangerousGoodsCodePage: un_dangerous_goods_code
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage(itemId: String): Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/WarehouseIdentificationController.scala
+++ b/app/controllers/declaration/WarehouseIdentificationController.scala
@@ -28,6 +28,7 @@ import play.api.data.Form
 import play.api.i18n.I18nSupport
 import play.api.mvc.{Action, AnyContent, MessagesControllerComponents}
 import play.twirl.api.HtmlFormat
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class WarehouseIdentificationController @Inject() (
   warehouseIdentificationYesNoPage: warehouse_identification_yesno,
   warehouseIdentificationPage: warehouse_identification,
   supervisingCustomsOfficeHelper: SupervisingCustomsOfficeHelper
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   def displayPage: Action[AnyContent] = (authenticate andThen journeyType) { implicit request =>

--- a/app/controllers/declaration/ZeroRatedForVatController.scala
+++ b/app/controllers/declaration/ZeroRatedForVatController.scala
@@ -29,6 +29,7 @@ import models.ExportsDeclaration
 import models.requests.JourneyRequest
 import play.api.i18n.I18nSupport
 import play.api.mvc._
+import services.audit.AuditService
 import services.cache.ExportsCacheService
 import uk.gov.hmrc.play.bootstrap.controller.WithUnsafeDefaultFormBinding
 import uk.gov.hmrc.play.bootstrap.frontend.controller.FrontendController
@@ -45,7 +46,7 @@ class ZeroRatedForVatController @Inject() (
   mcc: MessagesControllerComponents,
   codeLinkConnector: CodeLinkConnector,
   zero_rated_for_vat: zero_rated_for_vat
-)(implicit ec: ExecutionContext)
+)(implicit ec: ExecutionContext, auditService: AuditService)
     extends FrontendController(mcc) with I18nSupport with ModelCacheable with SubmissionErrors with WithUnsafeDefaultFormBinding {
 
   val validJourneys = journeysOnLowValue :+ STANDARD

--- a/app/services/audit/AuditService.scala
+++ b/app/services/audit/AuditService.scala
@@ -140,8 +140,8 @@ class AuditService @Inject() (connector: AuditConnector, appConfig: AppConfig)(i
 
 object AuditTypes extends Enumeration {
   type Audit = Value
-  val Submission, SubmissionPayload, Cancellation, NavigateToMessages, Amendment, AmendmentPayload, AmendmentCancellation, UploadDocumentLink,
-    CreateDraftDeclatation = Value
+  val SaveDraftValue, Submission, SubmissionPayload, Cancellation, NavigateToMessages, Amendment, AmendmentPayload, AmendmentCancellation,
+    UploadDocumentLink, CreateDraftDeclatation = Value
 }
 
 object EventData extends Enumeration {

--- a/test/base/AuditedControllerSpec.scala
+++ b/test/base/AuditedControllerSpec.scala
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2024 HM Revenue & Customs
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package base
+
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{reset, times, verify, verifyNoInteractions, when}
+import org.scalatest.{BeforeAndAfterEach, Suite}
+import org.scalatestplus.mockito.MockitoSugar
+import services.audit.AuditService
+import uk.gov.hmrc.play.audit.http.connector.AuditResult.Success
+
+import scala.concurrent.Future
+
+trait AuditedControllerSpec extends MockitoSugar with BeforeAndAfterEach {
+  self: Suite =>
+
+  val auditService = mock[AuditService]
+
+  override protected def beforeEach(): Unit = {
+    super.beforeEach()
+
+    when(auditService.auditAllPagesUserInput(any(), any())(any())).thenReturn(Future.successful(Success))
+  }
+
+  def verifyAudit() = {
+    verify(auditService, times(1)).auditAllPagesUserInput(any(), any())(any())
+    reset(auditService)
+  }
+
+  def verifyNoAudit() = {
+    verifyNoInteractions(auditService)
+    reset(auditService)
+  }
+}

--- a/test/controllers/declaration/AdditionalActorsAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalActorsAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, Injector, TestHelper}
+import base.{AuditedControllerSpec, ControllerSpec, Injector, TestHelper}
 import forms.common.Eori
 import forms.declaration.AdditionalActor
 import mock.ErrorHandlerMocks
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.additionalActors.additional_actors_add
 
-class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandlerMocks with Injector {
+class AdditionalActorsAddControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with Injector {
 
   val declarationAdditionalActorsPage = mock[additional_actors_add]
 
@@ -42,7 +42,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
     navigator,
     stubMessagesControllerComponents(),
     declarationAdditionalActorsPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -115,6 +115,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
         val result = controller.saveForm()(postRequestAsFormUrlEncoded(wrongAction: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
 
       "user put duplicated item" in {
@@ -125,6 +126,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
         val result = controller.saveForm()(postRequestAsFormUrlEncoded(duplication: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
 
       "user reach maximum amount of items" in {
@@ -135,6 +137,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
         val result = controller.saveForm()(postRequestAsFormUrlEncoded(correctForm: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
     }
 
@@ -147,6 +150,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
+        verifyAudit()
       }
 
       "user add correct manufacturer" in {
@@ -156,6 +160,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
+        verifyAudit()
       }
 
       "user add correct freight forwarder" in {
@@ -165,6 +170,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
+        verifyAudit()
       }
 
       "user add correct warehouse keeper" in {
@@ -174,6 +180,7 @@ class AdditionalActorsAddControllerSpec extends ControllerSpec with ErrorHandler
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalActorsRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.{Eori, YesNoAnswer}
 import forms.declaration.AdditionalActor
 import models.declaration.AdditionalActors
@@ -31,7 +31,7 @@ import play.twirl.api.HtmlFormat
 import utils.ListItem
 import views.html.declaration.additionalActors.additional_actors_remove
 
-class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionValues {
+class AdditionalActorsRemoveControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[additional_actors_remove]
 
@@ -43,7 +43,7 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
       navigator,
       stubMessagesControllerComponents(),
       mockPage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -107,6 +107,7 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
 
           status(result) mustBe BAD_REQUEST
           verifyRemovePageInvoked()
+          verifyNoAudit()
         }
 
       }
@@ -121,6 +122,7 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
           thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
 
           theCacheModelUpdated.parties.declarationHoldersData mustBe None
+          verifyAudit()
         }
 
         "user submits 'No' answer" in {
@@ -133,6 +135,7 @@ class AdditionalActorsRemoveControllerSpec extends ControllerSpec with OptionVal
           thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalActorsSummaryController.displayPage
 
           verifyTheCacheIsUnchanged()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDeclarationTypeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.{DeclarantDetailsController, DucrChoiceController}
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.additional_declaration_type
 
-class AdditionalDeclarationTypeControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class AdditionalDeclarationTypeControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   val additionalDeclarationTypePage = mock[additional_declaration_type]
 
@@ -44,7 +44,7 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec with Amendm
     navigator,
     stubMessagesControllerComponents(),
     additionalDeclarationTypePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -113,12 +113,14 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec with Amendm
             withNewCaching(aDeclaration(withType(declarationType)))
             val result = controller.submitForm()(postRequest(JsString("")))
             status(result) must be(BAD_REQUEST)
+            verifyNoAudit()
           }
 
           s"the value selected is not a valid AdditionalDeclarationType" in {
             withNewCaching(aDeclaration(withType(declarationType)))
             val result = controller.submitForm()(postRequest(JsString("x")))
             status(result) must be(BAD_REQUEST)
+            verifyNoAudit()
           }
         }
       }
@@ -141,6 +143,7 @@ class AdditionalDeclarationTypeControllerSpec extends ControllerSpec with Amendm
               else DeclarantDetailsController.displayPage
 
             thePageNavigatedTo mustBe expectedPage
+            verifyAudit()
           }
         }
       }

--- a/test/controllers/declaration/AdditionalDocumentAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDocumentAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, MockTaggedCodes}
+import base.{AuditedControllerSpec, ControllerSpec, MockTaggedCodes}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.Yes
 import forms.declaration.additionaldocuments.AdditionalDocument
@@ -32,7 +32,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.additionalDocuments.additional_document_add
 
-class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandlerMocks with MockTaggedCodes {
+class AdditionalDocumentAddControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with MockTaggedCodes {
 
   val additionalDocumentAddPage = mock[additional_document_add]
 
@@ -45,7 +45,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
     taggedAuthCodes,
     taggedAdditionalDocumentCodes,
     additionalDocumentAddPage
-  )(ec)
+  )(ec, auditService)
 
   val itemId = "itemId"
 
@@ -93,6 +93,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
         val result = controller.submitForm(itemId)(postRequestAsFormUrlEncoded(incorrectForm: _*))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
         verifyPageInvoked()
       }
 
@@ -125,6 +126,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user reach maximum amount of items" in {
@@ -138,6 +140,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
     }
 
@@ -152,6 +155,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
 
         val savedDocuments = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalDocuments)
         savedDocuments mustBe Some(AdditionalDocuments(YesNoAnswer.Yes, Seq(additionalDocument)))
+        verifyAudit()
       }
     }
 
@@ -169,6 +173,7 @@ class AdditionalDocumentAddControllerSpec extends ControllerSpec with ErrorHandl
 
         val isRequired = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalDocuments.flatMap(_.isRequired))
         isRequired mustBe Yes
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/AdditionalDocumentRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDocumentRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.Yes
 import forms.declaration.additionaldocuments.AdditionalDocument
@@ -32,7 +32,7 @@ import play.twirl.api.HtmlFormat
 import utils.ListItem
 import views.html.declaration.additionalDocuments.additional_document_remove
 
-class AdditionalDocumentRemoveControllerSpec extends ControllerSpec with OptionValues {
+class AdditionalDocumentRemoveControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val additionalDocumentRemovePage = mock[additional_document_remove]
 
@@ -44,7 +44,7 @@ class AdditionalDocumentRemoveControllerSpec extends ControllerSpec with OptionV
       navigator,
       stubMessagesControllerComponents(),
       additionalDocumentRemovePage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -134,6 +134,7 @@ class AdditionalDocumentRemoveControllerSpec extends ControllerSpec with OptionV
           thePageNavigatedTo mustBe routes.AdditionalDocumentsController.displayPage(itemId)
 
           theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalDocuments) mustBe Some(AdditionalDocuments(None, Seq.empty))
+          verifyAudit()
         }
 
         "user submits 'No' answer" in {
@@ -146,6 +147,7 @@ class AdditionalDocumentRemoveControllerSpec extends ControllerSpec with OptionV
           thePageNavigatedTo mustBe routes.AdditionalDocumentsController.displayPage(itemId)
 
           verifyTheCacheIsUnchanged()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AdditionalDocumentsRequiredControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalDocumentsRequiredControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
 import org.mockito.ArgumentCaptor
@@ -30,7 +30,7 @@ import play.twirl.api.HtmlFormat
 import play.twirl.api.HtmlFormat.Appendable
 import views.html.declaration.additionalDocuments.additional_documents_required
 
-class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec {
+class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val page = mock[additional_documents_required]
 
@@ -41,7 +41,7 @@ class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     page
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -88,6 +88,7 @@ class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec {
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe routes.AdditionalDocumentAddController.displayPage(itemId)
+          verifyAudit()
         }
       }
 
@@ -99,6 +100,7 @@ class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec {
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe routes.ItemsSummaryController.displayItemsSummaryPage
+          verifyAudit()
         }
       }
 
@@ -111,6 +113,7 @@ class AdditionalDocumentsRequiredControllerSpec extends ControllerSpec {
           val result = controller.submitForm(itemId)(postRequest(incorrectForm))
           status(result) must be(BAD_REQUEST)
           verifyPageInvoked
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalFiscalReferencesAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import connectors.CodeListConnector
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
 import mock.{ErrorHandlerMocks, ItemActionMocks}
@@ -35,7 +35,7 @@ import views.html.declaration.fiscalInformation.additional_fiscal_references_add
 import scala.collection.immutable.ListMap
 import scala.concurrent.Future
 
-class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with ItemActionMocks with ErrorHandlerMocks {
+class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with AuditedControllerSpec with ItemActionMocks with ErrorHandlerMocks {
 
   val mockAddPage = mock[additional_fiscal_references_add]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -47,7 +47,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
     navigator,
     stubMessagesControllerComponents(),
     mockAddPage
-  )(ec, mockCodeListConnector)
+  )(ec, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -101,6 +101,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
         val result = controller.submitForm(item.id)(postRequestAsFormUrlEncoded(incorrectForm: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
 
       "user adds duplicated item" in {
@@ -115,6 +116,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
         val result = controller.submitForm(itemCacheData.id)(postRequestAsFormUrlEncoded(duplicatedForm: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
 
       "user reaches maximum amount of items" in {
@@ -130,6 +132,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
 
         val result = controller.submitForm(itemCacheData.id)(postRequestAsFormUrlEncoded(form: _*))
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
     }
 
@@ -146,6 +149,7 @@ class AdditionalFiscalReferencesAddControllerSpec extends ControllerSpec with It
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.AdditionalFiscalReferencesController.displayPage(item.id)
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalFiscalReferencesRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.YesNoAnswer
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData}
 import org.mockito.ArgumentCaptor
@@ -30,7 +30,7 @@ import play.twirl.api.HtmlFormat
 import utils.ListItem
 import views.html.declaration.fiscalInformation.additional_fiscal_references_remove
 
-class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with OptionValues {
+class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockRemovePage = mock[additional_fiscal_references_remove]
 
@@ -42,7 +42,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
       navigator,
       stubMessagesControllerComponents(),
       mockRemovePage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -112,6 +112,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
 
           status(result) mustBe BAD_REQUEST
           verifyRemovePageInvoked()
+          verifyNoAudit()
         }
 
       }
@@ -124,6 +125,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalFiscalReferencesController.displayPage(item.id)
+          verifyNoAudit()
         }
 
         "user submits 'Yes' answer when multiple additional information exists" in {
@@ -138,6 +140,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
           theCacheModelUpdated
             .itemBy(item.id)
             .flatMap(_.additionalFiscalReferencesData) mustBe Some(AdditionalFiscalReferencesData(Seq(additionalReferenceOther)))
+          verifyAudit()
         }
 
         "user submits 'Yes' answer when single additional information exists" in {
@@ -150,6 +153,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
           thePageNavigatedTo mustBe controllers.declaration.routes.FiscalInformationController.displayPage(item.id)
 
           theCacheModelUpdated.itemBy(item.id).flatMap(_.additionalFiscalReferencesData) mustBe Some(AdditionalFiscalReferencesData(Seq.empty))
+          verifyAudit()
         }
 
         "user submits 'No' answer" in {
@@ -162,6 +166,7 @@ class AdditionalFiscalReferencesRemoveControllerSpec extends ControllerSpec with
           thePageNavigatedTo mustBe controllers.declaration.routes.AdditionalFiscalReferencesController.displayPage(item.id)
 
           verifyTheCacheIsUnchanged()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AdditionalInformationAddControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.AdditionalInformationController
 import forms.common.YesNoAnswer.{No, Yes}
 import forms.declaration.AdditionalInformation
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.additionalInformation.additional_information_add
 
-class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHandlerMocks {
+class AdditionalInformationAddControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks {
 
   val mockAddPage = mock[additional_information_add]
 
@@ -45,7 +45,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
     navigator,
     stubMessagesControllerComponents(),
     mockAddPage
-  )(ec)
+  )(ec, auditService)
 
   val itemId = "itemId"
 
@@ -96,6 +96,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters 'RRS01' as code" in {
@@ -104,6 +105,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters 'LIC99' as code" in {
@@ -112,6 +114,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters duplicated item" in {
@@ -123,6 +126,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user reaches maximum amount of items" in {
@@ -135,6 +139,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
     }
 
@@ -152,6 +157,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
         val savedDocuments = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalInformation)
         savedDocuments mustBe Some(AdditionalInformationData(Seq(additionalInformation)))
+        verifyAudit()
       }
     }
   }
@@ -170,6 +176,7 @@ class AdditionalInformationAddControllerSpec extends ControllerSpec with ErrorHa
 
       val isRequired = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalInformation.flatMap(_.isRequired))
       isRequired mustBe Yes
+      verifyAudit()
     }
   }
 }

--- a/test/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationChangeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.AdditionalInformationController
 import forms.common.YesNoAnswer.Yes
 import forms.declaration.AdditionalInformation
@@ -34,7 +34,7 @@ import play.twirl.api.HtmlFormat
 import utils.ListItem
 import views.html.declaration.additionalInformation.additional_information_change
 
-class AdditionalInformationChangeControllerSpec extends ControllerSpec with ErrorHandlerMocks {
+class AdditionalInformationChangeControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks {
 
   val mockChangePage = mock[additional_information_change]
 
@@ -45,7 +45,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
     navigator,
     stubMessagesControllerComponents(),
     mockChangePage
-  )(ec)
+  )(ec, auditService)
 
   val itemId = "itemId"
   private val additionalInformation1 = AdditionalInformation("00400", "Some description")
@@ -97,6 +97,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters 'RRS01' as code" in {
@@ -105,6 +106,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters 'LIC99' as code" in {
@@ -113,6 +115,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
 
       "user enters duplicated item" in {
@@ -121,6 +124,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         status(result) mustBe BAD_REQUEST
         verifyPageInvoked()
+        verifyNoAudit()
       }
     }
 
@@ -136,6 +140,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         val savedData = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalInformation)
         savedData mustBe Some(AdditionalInformationData(Yes, Seq(AdditionalInformation("00000", "Change"), additionalInformation2)))
+        verifyAudit()
       }
 
       "user does not change document" in {
@@ -148,6 +153,7 @@ class AdditionalInformationChangeControllerSpec extends ControllerSpec with Erro
 
         val savedDocuments = theCacheModelUpdated.itemBy(itemId).flatMap(_.additionalInformation)
         savedDocuments mustBe Some(AdditionalInformationData(Yes, Seq(additionalInformation1, additionalInformation2)))
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalInformationRequiredControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.YesNoAnswer
 import models.DeclarationType._
 import org.mockito.ArgumentCaptor
@@ -31,7 +31,7 @@ import views.html.declaration.additionalInformation.additional_information_requi
 
 import scala.concurrent.Future
 
-class AdditionalInformationRequiredControllerSpec extends ControllerSpec with OptionValues {
+class AdditionalInformationRequiredControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   private val mockPage = mock[additional_information_required]
 
@@ -42,7 +42,7 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
     navigator,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   val itemId = "itemId"
 
@@ -99,8 +99,8 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
           status(result) mustBe BAD_REQUEST
           verifyPageInvoked()
+          verifyNoAudit()
         }
-
       }
 
       "return 303 (SEE_OTHER)" when {
@@ -124,8 +124,8 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.AdditionalInformationController.displayPage(itemId)
+          verifyAudit()
         }
-
       }
     }
 
@@ -138,8 +138,8 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.AdditionalDocumentsController.displayPage(itemId)
+        verifyAudit()
       }
-
     }
 
     onJourney(STANDARD, OCCASIONAL, SUPPLEMENTARY, SIMPLIFIED) { request =>
@@ -151,6 +151,7 @@ class AdditionalInformationRequiredControllerSpec extends ControllerSpec with Op
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.IsLicenceRequiredController.displayPage(itemId)
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/AdditionalProcedureCodesControllerSpec.scala
+++ b/test/controllers/declaration/AdditionalProcedureCodesControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.ExportsTestData.pc1040
 import controllers.helpers.{Remove, SupervisingCustomsOfficeHelper}
 import forms.declaration.SupervisingCustomsOffice
@@ -44,7 +44,8 @@ import views.html.declaration.procedureCodes.additional_procedure_codes
 
 import java.util.{Locale, UUID}
 
-class AdditionalProcedureCodesControllerSpec extends ControllerSpec with ErrorHandlerMocks with OptionValues with ScalaFutures {
+class AdditionalProcedureCodesControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with OptionValues with ScalaFutures {
 
   private val additionalProcedureCodesPage = mock[additional_procedure_codes]
   private val procedureCodeService = mock[ProcedureCodeService]
@@ -61,7 +62,7 @@ class AdditionalProcedureCodesControllerSpec extends ControllerSpec with ErrorHa
     procedureCodeService,
     additionalProcedureCodesPage,
     supervisingCustomsOfficeHelper
-  )(ec)
+  )(ec, auditService)
 
   private val itemId = "itemId12345"
   private val sampleProcedureCode = "1040"

--- a/test/controllers/declaration/AuthorisationHolderAddControllerSpec.scala
+++ b/test/controllers/declaration/AuthorisationHolderAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, ExportsTestData, MockTaggedCodes}
+import base.{AuditedControllerSpec, ControllerSpec, ExportsTestData, MockTaggedCodes}
 import controllers.declaration.routes.AuthorisationHolderSummaryController
 import forms.common.Eori
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
@@ -35,7 +35,8 @@ import play.api.test.Helpers._
 import play.twirl.api.{Html, HtmlFormat}
 import views.html.declaration.authorisationHolder.authorisation_holder_add
 
-class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhenThen with MockTaggedCodes with OptionValues {
+class AuthorisationHolderAddControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with GivenWhenThen with MockTaggedCodes with OptionValues {
 
   val mockAddPage = mock[authorisation_holder_add]
 
@@ -47,7 +48,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
     stubMessagesControllerComponents(),
     taggedAuthCodes,
     mockAddPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -102,6 +103,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user submits invalid data" in {
@@ -112,6 +114,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user submits duplicate data" in {
@@ -123,6 +126,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user adds too many codes" in {
@@ -135,6 +139,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user adds mutually exclusive data" when {
@@ -148,6 +153,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
             status(result) mustBe BAD_REQUEST
             verifyAddPageInvoked()
+            verifyNoAudit()
           }
 
           "attempted to add CSE when already having EXRR present" in {
@@ -159,6 +165,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
             status(result) mustBe BAD_REQUEST
             verifyAddPageInvoked()
+            verifyNoAudit()
           }
         }
       }
@@ -180,6 +187,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           val savedHolder = theCacheModelUpdated.parties.declarationHoldersData
           savedHolder mustBe Some(AuthorisationHolders(List(authorisationHolder)))
+          verifyAudit()
         }
       }
     }
@@ -202,6 +210,7 @@ class AuthorisationHolderAddControllerSpec extends ControllerSpec with GivenWhen
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AuthorisationHolderChangeControllerSpec.scala
+++ b/test/controllers/declaration/AuthorisationHolderChangeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.AuthorisationHolderSummaryController
 import forms.common.Eori
 import forms.declaration.additionaldeclarationtype.AdditionalDeclarationType._
@@ -35,7 +35,8 @@ import play.api.test.Helpers._
 import play.twirl.api.{Html, HtmlFormat}
 import views.html.declaration.authorisationHolder.authorisation_holder_change
 
-class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
+class AuthorisationHolderChangeControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
 
   val mockChangePage = mock[authorisation_holder_change]
 
@@ -47,7 +48,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
     mockErrorHandler,
     stubMessagesControllerComponents(),
     mockChangePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -119,6 +120,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyNoInteractions(mockChangePage)
+          verifyNoAudit()
         }
 
         "user edits with invalid data" in {
@@ -129,6 +131,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+          verifyNoAudit()
         }
 
         "user edit leads to duplicate data" in {
@@ -143,6 +146,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+          verifyNoAudit()
         }
       }
 
@@ -163,6 +167,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
 
           val savedHolder = theCacheModelUpdated.parties.declarationHoldersData
           savedHolder mustBe Some(AuthorisationHolders(List(authorisationHolder2)))
+          verifyAudit()
         }
       }
     }
@@ -190,6 +195,7 @@ class AuthorisationHolderChangeControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/AuthorisationHolderRemoveControllerSpec.scala
+++ b/test/controllers/declaration/AuthorisationHolderRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{AuthorisationHolderAddController, AuthorisationHolderRequiredController, AuthorisationHolderSummaryController}
 import forms.common.YesNoAnswer.Yes
 import forms.common.{Eori, YesNoAnswer}
@@ -38,7 +38,8 @@ import play.twirl.api.HtmlFormat
 import play.twirl.api.HtmlFormat.Appendable
 import views.html.declaration.authorisationHolder.authorisation_holder_remove
 
-class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
+class AuthorisationHolderRemoveControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
 
   val mockRemovePage = mock[authorisation_holder_remove]
 
@@ -50,7 +51,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
     mockErrorHandler,
     stubMessagesControllerComponents(),
     mockRemovePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -133,6 +134,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyNoInteractions(mockRemovePage)
+          verifyNoAudit()
         }
 
         "user submits an invalid answer" in {
@@ -143,6 +145,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
 
           status(result) mustBe BAD_REQUEST
           verifyRemovePageInvoked()
+          verifyNoAudit()
         }
       }
     }
@@ -170,6 +173,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
               case _                      => AuthorisationHolders(Seq(authorisationHolder_2), None)
             }
             theCacheModelUpdated.parties.declarationHoldersData mustBe Some(expectedHoldersData)
+            verifyAudit()
           }
         }
 
@@ -183,6 +187,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
           thePageNavigatedTo mustBe AuthorisationHolderSummaryController.displayPage
 
           verifyTheCacheIsUnchanged()
+          verifyNoAudit()
         }
       }
     }
@@ -207,6 +212,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
               await(result) mustBe aRedirectToTheNextPage
               thePageNavigatedTo mustBe AuthorisationHolderAddController.displayPage
               theCacheModelUpdated.parties.declarationHoldersData mustBe None
+              verifyAudit()
             }
           }
         }
@@ -224,6 +230,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
               thePageNavigatedTo mustBe AuthorisationHolderRequiredController.displayPage
 
               theCacheModelUpdated.parties.declarationHoldersData mustBe None
+              verifyAudit()
             }
           }
         }
@@ -242,6 +249,7 @@ class AuthorisationHolderRemoveControllerSpec extends ControllerSpec with ErrorH
                 thePageNavigatedTo mustBe AuthorisationHolderRequiredController.displayPage
 
                 theCacheModelUpdated.parties.declarationHoldersData mustBe None
+                verifyAudit()
               }
             }
           }

--- a/test/controllers/declaration/AuthorisationHolderRequiredControllerSpec.scala
+++ b/test/controllers/declaration/AuthorisationHolderRequiredControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{AuthorisationHolderAddController, AuthorisationHolderSummaryController, SectionSummaryController}
 import forms.common.{Eori, YesNoAnswer}
 import forms.declaration.AuthorisationProcedureCodeChoice.{Choice1007, Choice1040, ChoiceOthers}
@@ -36,7 +36,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.authorisationHolder.authorisation_holder_required
 
-class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with OptionValues {
+class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[authorisation_holder_required]
 
@@ -47,7 +47,7 @@ class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with Opti
     navigator,
     stubMessagesControllerComponents(),
     mockPage
-  )
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -190,6 +190,7 @@ class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with Opti
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe AuthorisationHolderAddController.displayPage
+          verifyAudit()
         }
       }
 
@@ -203,6 +204,7 @@ class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with Opti
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe SectionSummaryController.displayPage(2)
+          verifyAudit()
         }
       }
 
@@ -216,6 +218,7 @@ class AuthorisationHolderRequiredControllerSpec extends ControllerSpec with Opti
 
           status(result) mustBe BAD_REQUEST
           verifyPageInvoked()
+          verifyNoAudit()
         }
       }
   }

--- a/test/controllers/declaration/AuthorisationProcedureCodeChoiceControllerSpec.scala
+++ b/test/controllers/declaration/AuthorisationProcedureCodeChoiceControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.routes.RootController
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.AuthorisationProcedureCodeChoice
@@ -35,7 +35,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.authorisation_procedure_code_choice
 
-class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec {
+class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val authorisationProcedureCodeChoice = mock[authorisation_procedure_code_choice]
 
@@ -46,7 +46,7 @@ class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     authorisationProcedureCodeChoice
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -158,6 +158,7 @@ class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec {
 
             status(result) mustBe SEE_OTHER
             redirectLocation(result) mustBe Some(RootController.displayPage.url)
+            verifyNoAudit()
           }
         }
       }
@@ -178,6 +179,7 @@ class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec {
 
               verifyPageInvoked(0)
               theCacheModelUpdated.parties.authorisationProcedureCodeChoice mustBe choice
+              verifyAudit()
             }
           }
         }
@@ -191,6 +193,7 @@ class AuthorisationProcedureCodeChoiceControllerSpec extends ControllerSpec {
             status(result) must be(BAD_REQUEST)
             verifyPageInvoked()
             verifyTheCacheIsUnchanged()
+            verifyNoAudit()
           }
         }
       }

--- a/test/controllers/declaration/CarrierDetailsControllerSpec.scala
+++ b/test/controllers/declaration/CarrierDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import connectors.CodeListConnector
 import forms.common.Address
 import forms.declaration.EntityDetails
@@ -35,7 +35,7 @@ import views.html.declaration.carrier_details
 
 import scala.collection.immutable.ListMap
 
-class CarrierDetailsControllerSpec extends ControllerSpec {
+class CarrierDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val mockCarrierDetailsPage = mock[carrier_details]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -47,7 +47,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     mockCarrierDetailsPage
-  )(ec, mockCodeListConnector)
+  )(ec, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -118,6 +118,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
           val result = controller.saveAddress()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
     }
@@ -134,6 +135,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
           val result = controller.saveAddress()(postRequest(incorrectForm))
 
           status(result) must be(SEE_OTHER)
+          verifyAudit()
         }
       }
 
@@ -178,6 +180,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
         val result = controller.saveAddress()(postRequest(incorrectForm))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
     }
 
@@ -201,6 +204,7 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe controllers.declaration.routes.ConsigneeDetailsController.displayPage
+          verifyAudit()
         }
       }
 
@@ -222,9 +226,9 @@ class CarrierDetailsControllerSpec extends ControllerSpec {
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(controllers.routes.RootController.displayPage.url)
+          verifyNoAudit()
         }
       }
-
     }
   }
 }

--- a/test/controllers/declaration/CarrierEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/CarrierEoriNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.common.{Address, Eori}
 import forms.declaration.EntityDetails
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.carrier_eori_number
 
-class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
+class CarrierEoriNumberControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockCarrierEoriNumberPage = mock[carrier_eori_number]
 
@@ -45,7 +45,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
     stubMessagesControllerComponents(),
     mockCarrierEoriNumberPage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   def checkViewInteractions(noOfInvocations: Int = 1): Unit =
     verify(mockCarrierEoriNumberPage, times(noOfInvocations)).apply(any())(any(), any())
@@ -158,6 +158,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "EORI is not provided but trader selected that it has an EORI" in {
@@ -170,6 +171,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "no choice is selected and no cached CarrierDetails exist" in {
@@ -182,6 +184,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
     }
   }
@@ -200,6 +203,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe controllers.declaration.routes.CarrierDetailsController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.carrierDetails must be(Some(CarrierDetails(EntityDetails(None, None))))
+        verifyAudit()
       }
 
       "'Yes' is selected" in {
@@ -215,6 +219,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe controllers.declaration.routes.ConsigneeDetailsController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.carrierDetails must be(Some(CarrierDetails(EntityDetails(eoriInput, None))))
+        verifyAudit()
       }
     }
 
@@ -231,6 +236,7 @@ class CarrierEoriNumberControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) must be(SEE_OTHER)
         redirectLocation(result) mustBe Some(controllers.routes.RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/CommodityDetailsControllerSpec.scala
+++ b/test/controllers/declaration/CommodityDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{CommodityMeasureController, PackageInformationSummaryController, UNDangerousGoodsCodeController}
 import forms.declaration.{CommodityDetails, CusCode, IsExs}
 import models.DeclarationType._
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.commodity_details
 
-class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
+class CommodityDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockCommodityDetailsPage = mock[commodity_details]
 
@@ -42,7 +42,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
     navigator,
     stubMessagesControllerComponents(),
     mockCommodityDetailsPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -110,6 +110,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         verify(mockCommodityDetailsPage, times(1)).apply(any(), any())(any(), any())
+        verifyNoAudit()
       }
     }
 
@@ -122,6 +123,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe UNDangerousGoodsCodeController.displayPage(itemId)
+        verifyAudit()
       }
     }
 
@@ -134,6 +136,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe UNDangerousGoodsCodeController.displayPage(itemId)
+        verifyAudit()
       }
     }
 
@@ -151,6 +154,7 @@ class CommodityDetailsControllerSpec extends ControllerSpec with OptionValues {
         val result = controller.submitForm(itemId)(postRequest(correctForm))
 
         await(result) mustBe aRedirectToTheNextPage
+        verifyAudit()
         thePageNavigatedTo mustBe expectedCall
       }
 

--- a/test/controllers/declaration/CommodityMeasureControllerSpec.scala
+++ b/test/controllers/declaration/CommodityMeasureControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.routes.RootController
 import forms.declaration.commodityMeasure.CommodityMeasure
 import models.DeclarationType.{CLEARANCE, OCCASIONAL, SIMPLIFIED, STANDARD, SUPPLEMENTARY}
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.commodityMeasure.commodity_measure
 
-class CommodityMeasureControllerSpec extends ControllerSpec {
+class CommodityMeasureControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val format = Json.format[CommodityMeasure]
 
@@ -44,7 +44,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     commodityMeasurePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -105,6 +105,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
           status(result) must be(BAD_REQUEST)
           verify(commodityMeasurePage).apply(any(), any())(any(), any())
+          verifyNoAudit()
         }
       }
     }
@@ -121,6 +122,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.SupplementaryUnitsController.displayPage("itemId")
+          verifyAudit()
         }
       }
 
@@ -132,6 +134,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.AdditionalInformationRequiredController.displayPage("itemId")
+          verifyAudit()
         }
       }
     }
@@ -145,6 +148,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
           status(response) must be(SEE_OTHER)
           redirectLocation(response) mustBe Some(RootController.displayPage.url)
+          verifyNoAudit()
         }
 
         "the journey is not valid for submitPage" in {
@@ -154,6 +158,7 @@ class CommodityMeasureControllerSpec extends ControllerSpec {
 
           status(response) must be(SEE_OTHER)
           redirectLocation(response) mustBe Some(RootController.displayPage.url)
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/ConfirmDucrControllerSpec.scala
+++ b/test/controllers/declaration/ConfirmDucrControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.DucrEntryController
 import forms.Ducr
@@ -36,7 +36,7 @@ import play.api.test.Helpers.{await, redirectLocation, status}
 import play.twirl.api.HtmlFormat
 import views.html.declaration.confirm_ducr
 
-class ConfirmDucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec with ErrorHandlerMocks {
+class ConfirmDucrControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec with ErrorHandlerMocks {
 
   private val confirmDucrPage = mock[confirm_ducr]
 
@@ -47,7 +47,7 @@ class ConfirmDucrControllerSpec extends ControllerSpec with AmendmentDraftFilter
     stubMessagesControllerComponents(),
     mockExportsCacheService,
     confirmDucrPage
-  )
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -101,6 +101,7 @@ class ConfirmDucrControllerSpec extends ControllerSpec with AmendmentDraftFilter
         status(result) mustBe BAD_REQUEST
         verify(confirmDucrPage).apply(any(), meq(dummyConRefs.ducr.get))(any(), any())
         verifyTheCacheIsUnchanged()
+        verifyNoAudit()
       }
     }
 
@@ -116,6 +117,7 @@ class ConfirmDucrControllerSpec extends ControllerSpec with AmendmentDraftFilter
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.LocalReferenceNumberController.displayPage
         verifyTheCacheIsUnchanged()
+        verifyNoAudit()
       }
 
       "form was submitted with No answer" in {
@@ -127,6 +129,7 @@ class ConfirmDucrControllerSpec extends ControllerSpec with AmendmentDraftFilter
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.DucrEntryController.displayPage
         theCacheModelUpdated mustBe aDeclaration(withConsignmentReferences(ConsignmentReferences(None, None, None, None)))
+        verifyAudit()
       }
 
       "display page is invoked with no DUCR in cache" in {

--- a/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ConsigneeDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import connectors.CodeListConnector
 import controllers.declaration.routes.{AdditionalActorsSummaryController, AuthorisationProcedureCodeChoiceController}
 import forms.common.Address
@@ -36,7 +36,7 @@ import views.html.declaration.consignee_details
 
 import scala.collection.immutable.ListMap
 
-class ConsigneeDetailsControllerSpec extends ControllerSpec {
+class ConsigneeDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val consigneeDetailsPage = mock[consignee_details]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -48,7 +48,7 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     consigneeDetailsPage
-  )(ec, mockCodeListConnector)
+  )(ec, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -109,6 +109,7 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
           val result = controller.saveAddress()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
     }
@@ -145,5 +146,6 @@ class ConsigneeDetailsControllerSpec extends ControllerSpec {
 
     await(result) mustBe aRedirectToTheNextPage
     thePageNavigatedTo mustBe expectedRedirectionLocation
+    verifyAudit()
   }
 }

--- a/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
+++ b/test/controllers/declaration/ConsignmentReferencesControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.ExportsTestData.eidrDateStamp
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.{LinkDucrToMucrController, SectionSummaryController}
@@ -37,7 +37,7 @@ import views.html.declaration.consignment_references
 
 import scala.concurrent.Future
 
-class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec with GivenWhenThen {
+class ConsignmentReferencesControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec with GivenWhenThen {
 
   private val lrnValidator = mock[LrnValidator]
   private val consignmentReferencesPage = mock[consignment_references]
@@ -50,7 +50,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
     navigator,
     stubMessagesControllerComponents(),
     consignmentReferencesPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -115,6 +115,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
           val result = controller.submitForm()(postRequest(incorrectForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
 
         "LrnValidator returns false" in {
@@ -124,6 +125,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
           val result = controller.submitForm()(postRequest(correctForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -139,6 +141,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
         val declaration = theCacheModelUpdated
         declaration.consignmentReferences.head.ducr.get.ducr mustBe ducr.toUpperCase
+        verifyAudit()
       }
     }
 
@@ -152,6 +155,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.LinkDucrToMucrController.displayPage
+        verifyAudit()
       }
     }
 
@@ -167,6 +171,7 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.SectionSummaryController.displayPage(1)
+          verifyAudit()
         }
 
         "for SUPPLEMENTARY_EIDR" in {
@@ -178,8 +183,8 @@ class ConsignmentReferencesControllerSpec extends ControllerSpec with AmendmentD
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe routes.SectionSummaryController.displayPage(1)
+          verifyAudit()
         }
-
       }
     }
   }

--- a/test/controllers/declaration/ConsignorDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ConsignorDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import connectors.CodeListConnector
 import controllers.routes.RootController
 import forms.common.{Address, Eori}
@@ -37,7 +37,7 @@ import views.html.declaration.consignor_details
 
 import scala.collection.immutable.ListMap
 
-class ConsignorDetailsControllerSpec extends ControllerSpec {
+class ConsignorDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val consignorDetailsPage = mock[consignor_details]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -49,7 +49,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     consignorDetailsPage
-  )(ec, mockCodeListConnector)
+  )(ec, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -114,6 +114,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
           val result = controller.saveAddress()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
     }
@@ -137,6 +138,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe controllers.declaration.routes.RepresentativeAgentController.displayPage
+          verifyAudit()
         }
       }
 
@@ -165,6 +167,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe controllers.declaration.routes.CarrierEoriNumberController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -187,6 +190,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
         status(result) must be(SEE_OTHER)
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
 
@@ -199,6 +203,7 @@ class ConsignorDetailsControllerSpec extends ControllerSpec {
 
           status(result) must be(SEE_OTHER)
           redirectLocation(result) mustBe Some(RootController.displayPage.url)
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/ConsignorEoriNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{ConsignorDetailsController, RepresentativeAgentController}
 import controllers.routes.RootController
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -36,7 +36,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.consignor_eori_number
 
-class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues {
+class ConsignorEoriNumberControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockConsignorEoriNumberPage = mock[consignor_eori_number]
 
@@ -47,7 +47,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
     stubMessagesControllerComponents(),
     mockConsignorEoriNumberPage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   def checkViewInteractions(noOfInvocations: Int = 1): Unit =
     verify(mockConsignorEoriNumberPage, times(noOfInvocations)).apply(any())(any(), any())
@@ -155,6 +155,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "EORI is not provided but trader selected that it has an EORI" in {
@@ -166,6 +167,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "no choice is selected and no cached ConsignorDetails exist" in {
@@ -177,6 +179,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
     }
   }
@@ -194,6 +197,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
         thePageNavigatedTo mustBe ConsignorDetailsController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.consignorDetails must be(Some(ConsignorDetails(EntityDetails(None, None))))
+        verifyAudit()
       }
 
       "'Yes' is selected" in {
@@ -208,6 +212,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
         thePageNavigatedTo mustBe RepresentativeAgentController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.consignorDetails must be(Some(ConsignorDetails(EntityDetails(eoriInput, None))))
+        verifyAudit()
       }
     }
 
@@ -224,6 +229,7 @@ class ConsignorEoriNumberControllerSpec extends ControllerSpec with OptionValues
 
         status(result) must be(SEE_OTHER)
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/CusCodeControllerSpec.scala
+++ b/test/controllers/declaration/CusCodeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{NactCodeSummaryController, ZeroRatedForVatController}
 import controllers.helpers.ItemHelper.journeysOnLowValue
 import controllers.routes.RootController
@@ -36,12 +36,15 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.cus_code
 
-class CusCodeControllerSpec extends ControllerSpec {
+class CusCodeControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val mockPage = mock[cus_code]
 
   val controller =
-    new CusCodeController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)(ec)
+    new CusCodeController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mockPage)(
+      ec,
+      auditService
+    )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -112,6 +115,7 @@ class CusCodeControllerSpec extends ControllerSpec {
 
           status(result) mustBe BAD_REQUEST
           verify(mockPage, times(1)).apply(any(), any())(any(), any())
+          verifyNoAudit()
         }
       }
     }
@@ -126,6 +130,7 @@ class CusCodeControllerSpec extends ControllerSpec {
           val result = controller.submitForm(itemId)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe NactCodeSummaryController.displayPage(itemId)
+          verifyAudit()
         }
       }
     }
@@ -139,6 +144,7 @@ class CusCodeControllerSpec extends ControllerSpec {
           val result = controller.submitForm(itemId)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(itemId)
+          verifyAudit()
         }
 
         "NatureOfTransaction is 'Sale'" in {
@@ -146,6 +152,7 @@ class CusCodeControllerSpec extends ControllerSpec {
           val result = controller.submitForm(itemId)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(itemId)
+          verifyAudit()
         }
       }
 
@@ -158,6 +165,7 @@ class CusCodeControllerSpec extends ControllerSpec {
             val result = controller.submitForm(item.id)(postRequest(correctForm))
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(item.id)
+            verifyAudit()
           }
         }
       }
@@ -172,6 +180,7 @@ class CusCodeControllerSpec extends ControllerSpec {
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(RootController.displayPage.url)
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/DeclarantDetailsControllerSpec.scala
+++ b/test/controllers/declaration/DeclarantDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.{ConsignmentReferencesController, DeclarantExporterController, DucrChoiceController, NotEligibleController}
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.declarant_details
 
-class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class DeclarantDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   private val declarantDetailsPage = mock[declarant_details]
 
@@ -45,7 +45,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
     navigator,
     stubMessagesControllerComponents(),
     declarantDetailsPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -101,6 +101,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
 
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
     }
 
@@ -115,6 +116,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe DucrChoiceController.displayPage
+          verifyAudit()
         }
       }
 
@@ -127,6 +129,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe ConsignmentReferencesController.displayPage
+          verifyAudit()
         }
       }
 
@@ -139,6 +142,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe DeclarantExporterController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -154,6 +158,7 @@ class DeclarantDetailsControllerSpec extends ControllerSpec with AmendmentDraftF
           redirectLocation(result) mustBe Some(NotEligibleController.displayNotDeclarant.url)
 
           session(result).get(SessionHelper.declarationUuid) must be(None)
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/DeclarantExporterControllerSpec.scala
+++ b/test/controllers/declaration/DeclarantExporterControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{CarrierEoriNumberController, ConsigneeDetailsController, ExporterEoriNumberController, IsExsController}
 import forms.declaration.DeclarantIsExporter
 import models.DeclarationType
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.declarant_exporter
 
-class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
+class DeclarantExporterControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[declarant_exporter]
 
@@ -42,7 +42,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
     navigator,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   def theResponseForm: Form[DeclarantIsExporter] = {
     val formCaptor = ArgumentCaptor.forClass(classOf[Form[DeclarantIsExporter]])
@@ -109,6 +109,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
 
           status(result) mustBe BAD_REQUEST
           verifyPage(1)
+          verifyNoAudit()
         }
       }
     }
@@ -125,6 +126,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe ExporterEoriNumberController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
 
@@ -140,6 +142,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe CarrierEoriNumberController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
 
@@ -155,6 +158,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe IsExsController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
 
@@ -170,6 +174,7 @@ class DeclarantExporterControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe ConsigneeDetailsController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/DepartureTransportControllerSpec.scala
+++ b/test/controllers/declaration/DepartureTransportControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, MockTransportCodeService}
+import base.{AuditedControllerSpec, ControllerSpec, MockTransportCodeService}
 import controllers.declaration.routes.{BorderTransportController, ExpressConsignmentController, TransportCountryController}
 import controllers.helpers.TransportSectionHelper.{postalOrFTIModeOfTransportCodes, Guernsey, Jersey}
 import forms.declaration.DepartureTransport
@@ -37,7 +37,7 @@ import play.twirl.api.HtmlFormat
 import views.helpers.DepartureTransportHelper
 import views.html.declaration.departure_transport
 
-class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerMocks {
+class DepartureTransportControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks {
 
   val transportCodeService = MockTransportCodeService.transportCodeService
 
@@ -53,7 +53,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
     transportCodeService,
     departureTransportHelper,
     departureTransportPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -64,7 +64,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
   }
 
   override protected def afterEach(): Unit = {
-    reset(departureTransportHelper, departureTransportPage)
+    reset(departureTransportHelper, departureTransportPage, auditService)
     super.afterEach()
   }
 
@@ -125,6 +125,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
               val transport = theCacheModelUpdated.transport
               transport.meansOfTransportOnDepartureType mustBe None
               transport.meansOfTransportOnDepartureIDNumber mustBe None
+              verifyAudit()
             }
           }
         }
@@ -158,6 +159,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
           val result = controller.submitForm()(postRequest(correctForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
 
         "form is incorrect" in {
@@ -167,6 +169,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
           val result = controller.submitForm()(postRequest(incorrectForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
     }
@@ -186,6 +189,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
             val transport = theCacheModelUpdated.transport
             transport.meansOfTransportOnDepartureType mustBe None
             transport.meansOfTransportOnDepartureIDNumber mustBe None
+            verifyAudit()
           }
 
           s"the 'submitForm' method is invoked and Destination country is '$country'" in {
@@ -201,6 +205,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
             val transport = theCacheModelUpdated.transport
             transport.meansOfTransportOnDepartureType mustBe None
             transport.meansOfTransportOnDepartureIDNumber mustBe None
+            verifyAudit()
           }
         }
       }
@@ -214,6 +219,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
           status(result) must be(SEE_OTHER)
           thePageNavigatedTo mustBe BorderTransportController.displayPage
+          verifyAudit()
         }
       }
 
@@ -227,6 +233,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
           status(result) must be(SEE_OTHER)
           thePageNavigatedTo mustBe TransportCountryController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -261,6 +268,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
           val transport = theCacheModelUpdated.transport
           transport.meansOfTransportOnDepartureType mustBe None
           transport.meansOfTransportOnDepartureIDNumber mustBe None
+          verifyAudit()
         }
       }
     }
@@ -277,6 +285,7 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
           status(result) must be(SEE_OTHER)
           thePageNavigatedTo mustBe ExpressConsignmentController.displayPage
+          verifyAudit()
         }
 
         "'0019' has been entered as Procedure Code and" when {
@@ -290,10 +299,10 @@ class DepartureTransportControllerSpec extends ControllerSpec with ErrorHandlerM
 
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe ExpressConsignmentController.displayPage
+            verifyAudit()
           }
         }
       }
     }
-
   }
 }

--- a/test/controllers/declaration/DestinationCountryControllerSpec.scala
+++ b/test/controllers/declaration/DestinationCountryControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, MockTaggedCodes}
+import base.{AuditedControllerSpec, ControllerSpec, MockTaggedCodes}
 import connectors.CodeListConnector
 import controllers.declaration.routes.{LocationOfGoodsController, OfficeOfExitController, RoutingCountriesController}
 import controllers.helpers.TransportSectionHelper.{Guernsey, Jersey}
@@ -39,7 +39,7 @@ import views.html.declaration.destinationCountries.destination_country
 import scala.collection.immutable.ListMap
 import scala.concurrent.ExecutionContext.global
 
-class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCodes {
+class DestinationCountryControllerSpec extends ControllerSpec with AuditedControllerSpec with MockTaggedCodes {
 
   val destinationCountryPage = mock[destination_country]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -52,7 +52,7 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
     stubMessagesControllerComponents(),
     taggedAuthCodes,
     destinationCountryPage
-  )(global, mockCodeListConnector)
+  )(global, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -63,7 +63,7 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
   }
 
   override protected def afterEach(): Unit = {
-    reset(destinationCountryPage, mockCodeListConnector)
+    reset(destinationCountryPage, mockCodeListConnector, auditService)
     super.afterEach()
   }
 
@@ -111,6 +111,7 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
         val result = controller.submit(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 
@@ -125,6 +126,7 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
           val result = controller.submit(postRequest(formData))
 
           status(result) mustBe SEE_OTHER
+          verifyAudit()
           thePageNavigatedTo mustBe redirect
         }
 
@@ -138,6 +140,7 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
           val result = controller.submit(postRequest(formData))
 
           status(result) mustBe SEE_OTHER
+          verifyAudit()
           thePageNavigatedTo mustBe OfficeOfExitController.displayPage
         }
 
@@ -189,6 +192,8 @@ class DestinationCountryControllerSpec extends ControllerSpec with MockTaggedCod
             transport.meansOfTransportCrossingTheBorderType mustBe None
             transport.meansOfTransportCrossingTheBorderIDNumber mustBe None
             transport.transportCrossingTheBorderNationality mustBe None
+
+            verifyAudit()
           }
       }
     }

--- a/test/controllers/declaration/DucrChoiceControllerSpec.scala
+++ b/test/controllers/declaration/DucrChoiceControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.{DucrEntryController, TraderReferenceController}
 import controllers.routes.RootController
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.ducr_choice
 
-class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class DucrChoiceControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   private val ducrChoicePage = mock[ducr_choice]
 
@@ -44,7 +44,7 @@ class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterS
     navigator,
     stubMessagesControllerComponents(),
     ducrChoicePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -109,6 +109,7 @@ class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterS
             val result = controller.submitForm(postRequest(body))
 
             status(result) must be(BAD_REQUEST)
+            verifyNoAudit()
           }
         }
       }
@@ -123,6 +124,7 @@ class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterS
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }
@@ -140,6 +142,7 @@ class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterS
 
             status(result) mustBe SEE_OTHER
             thePageNavigatedTo mustBe TraderReferenceController.displayPage
+            verifyNoAudit()
           }
         }
       }
@@ -162,6 +165,7 @@ class DucrChoiceControllerSpec extends ControllerSpec with AmendmentDraftFilterS
               consignmentReferences.lrn.get.lrn mustBe LRN.lrn
 
               thePageNavigatedTo mustBe DucrEntryController.displayPage
+              verifyAudit()
             }
           }
         }

--- a/test/controllers/declaration/ExporterDetailsControllerSpec.scala
+++ b/test/controllers/declaration/ExporterDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import connectors.CodeListConnector
 import controllers.declaration.routes.{IsExsController, RepresentativeAgentController}
 import forms.common.{Address, Eori}
@@ -38,7 +38,7 @@ import views.html.declaration.exporter_address
 import scala.collection.immutable.ListMap
 import scala.concurrent.ExecutionContext
 
-class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
+class ExporterDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val exporter_address = mock[exporter_address]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -50,7 +50,7 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
     navigator,
     stubMessagesControllerComponents(),
     exporter_address
-  )(ExecutionContext.global, mockCodeListConnector)
+  )(ExecutionContext.global, mockCodeListConnector, auditService)
 
   val address = Some(Address("CaptainAmerica", "Test Street", "Leeds", "LS18BN", "United Kingdom, Great Britain, Northern Ireland"))
   val eori = Some(Eori("GB213472539481923"))
@@ -106,6 +106,7 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
           val body = Json.obj("details" -> Json.obj("eori" -> "!nva!id"))
           val response = controller.saveAddress()(postRequest(body))
           status(response) mustBe BAD_REQUEST
+          verifyNoAudit()
         }
       }
 
@@ -118,6 +119,7 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
 
           response mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe RepresentativeAgentController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -131,6 +133,7 @@ class ExporterDetailsControllerSpec extends ControllerSpec with OptionValues {
 
           response mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe IsExsController.displayPage
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/ExporterEoriNumberControllerSpec.scala
+++ b/test/controllers/declaration/ExporterEoriNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{ExporterDetailsController, IsExsController, RepresentativeAgentController}
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.common.{Address, Eori}
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.exporter_eori_number
 
-class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues {
+class ExporterEoriNumberControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockExporterEoriNumberPage = mock[exporter_eori_number]
 
@@ -45,7 +45,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
     stubMessagesControllerComponents(),
     mockExporterEoriNumberPage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   def checkViewInteractions(noOfInvocations: Int = 1): Unit =
     verify(mockExporterEoriNumberPage, times(noOfInvocations)).apply(any())(any(), any())
@@ -141,6 +141,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "EORI is not provided but trader selected that it has an EORI" in {
@@ -152,6 +153,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
 
       "no choice is selected and no cached ExporterDetails exist" in {
@@ -163,6 +165,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
     }
 
@@ -178,6 +181,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
         thePageNavigatedTo mustBe ExporterDetailsController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.exporterDetails must be(Some(ExporterDetails(EntityDetails(None, None))))
+        verifyAudit()
       }
     }
   }
@@ -196,6 +200,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
         thePageNavigatedTo mustBe RepresentativeAgentController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.exporterDetails must be(Some(ExporterDetails(EntityDetails(eoriInput, None))))
+        verifyAudit()
       }
     }
   }
@@ -214,6 +219,7 @@ class ExporterEoriNumberControllerSpec extends ControllerSpec with OptionValues 
         thePageNavigatedTo mustBe IsExsController.displayPage
         checkViewInteractions(0)
         theCacheModelUpdated.parties.exporterDetails must be(Some(ExporterDetails(EntityDetails(eoriInput, None))))
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/ExpressConsignmentControllerSpec.scala
+++ b/test/controllers/declaration/ExpressConsignmentControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.routes.RootController
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -36,7 +36,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.express_consignment
 
-class ExpressConsignmentControllerSpec extends ControllerSpec {
+class ExpressConsignmentControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val expressConsignmentPage = mock[express_consignment]
 
@@ -47,7 +47,7 @@ class ExpressConsignmentControllerSpec extends ControllerSpec {
     navigator,
     stubMessagesControllerComponents(),
     expressConsignmentPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -57,7 +57,7 @@ class ExpressConsignmentControllerSpec extends ControllerSpec {
   }
 
   override protected def afterEach(): Unit = {
-    reset(expressConsignmentPage)
+    reset(expressConsignmentPage, auditService)
     super.afterEach()
   }
 
@@ -112,6 +112,7 @@ class ExpressConsignmentControllerSpec extends ControllerSpec {
           val result = controller.submitForm()(postRequest(incorrectForm))
           status(result) must be(BAD_REQUEST)
           verifyPageInvoked
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/FiscalInformationControllerSpec.scala
+++ b/test/controllers/declaration/FiscalInformationControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{AdditionalFiscalReferencesController, AdditionalProcedureCodesController, CommodityDetailsController}
 import forms.declaration.FiscalInformation.AllowedFiscalInformationAnswers._
 import forms.declaration.{AdditionalFiscalReference, AdditionalFiscalReferencesData, FiscalInformation}
@@ -32,7 +32,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.fiscalInformation.fiscal_information
 
-class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
+class FiscalInformationControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   private val mockFiscalInformationPage = mock[fiscal_information]
 
@@ -43,7 +43,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
     navigator,
     stubMessagesControllerComponents(),
     mockFiscalInformationPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -120,6 +120,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         verifyPageAccessed(1)
+        verifyNoAudit()
       }
     }
 
@@ -133,6 +134,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.AdditionalFiscalReferencesAddController.displayPage(itemId)
         verifyPageAccessed(0)
+        verifyAudit()
       }
 
       "user answer no" in {
@@ -143,6 +145,7 @@ class FiscalInformationControllerSpec extends ControllerSpec with OptionValues {
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe CommodityDetailsController.displayPage(itemId)
         verifyPageAccessed(0)
+        verifyAudit()
       }
 
       "user comes back from Commodity details and is 'fast-forwarded' to see existing additional fiscal references page" in {

--- a/test/controllers/declaration/InlandTransportDetailsControllerSpec.scala
+++ b/test/controllers/declaration/InlandTransportDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes._
 import controllers.helpers.TransportSectionHelper.{nonPostalOrFTIModeOfTransportCodes, postalOrFTIModeOfTransportCodes}
 import controllers.routes.RootController
@@ -35,7 +35,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.inland_transport_details
 
-class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhenThen with OptionValues {
+class InlandTransportDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec with GivenWhenThen with OptionValues {
 
   private val inlandTransportDetails = mock[inland_transport_details]
 
@@ -46,7 +46,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
     exportsCacheService = mockExportsCacheService,
     mcc = stubMessagesControllerComponents(),
     inlandTransportDetailsPage = inlandTransportDetails
-  )
+  )(ec, auditService)
 
   private val exampleTransportMode = Maritime
 
@@ -57,7 +57,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
   }
 
   override protected def afterEach(): Unit = {
-    reset(inlandTransportDetails)
+    reset(inlandTransportDetails, auditService)
     super.afterEach()
   }
 
@@ -117,6 +117,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
         await(controller.submit().apply(postRequest(body)))
 
         theCacheModelUpdated.locations.inlandModeOfTransportCode.value.inlandModeOfTransportCode.value mustBe exampleTransportMode
+        verifyAudit()
       }
 
       "return Bad Request if payload is not compatible with model" in {
@@ -126,6 +127,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
         val result = controller.submit()(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
 
       "return an error" when {
@@ -138,6 +140,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
 
             val result = controller.submit()(postRequest(body))
             status(result) mustBe BAD_REQUEST
+            verifyNoAudit()
           }
         }
       }
@@ -159,6 +162,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
             transport.meansOfTransportCrossingTheBorderType mustBe None
             transport.meansOfTransportCrossingTheBorderIDNumber mustBe None
             transport.transportCrossingTheBorderNationality mustBe None
+            verifyAudit()
           }
         }
       }
@@ -180,6 +184,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
 
             result mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe expectedRedirect
+            verifyAudit()
           }
         }
       }
@@ -198,6 +203,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
 
             result mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe expectedRedirect
+            verifyAudit()
           }
         }
       }
@@ -220,6 +226,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
 
             result mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe borderTransportUrl
+            verifyAudit()
           }
         }
 
@@ -233,6 +240,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
 
               result mustBe aRedirectToTheNextPage
               thePageNavigatedTo mustBe transportCountryUrl
+              verifyAudit()
             }
           }
         }
@@ -252,9 +260,7 @@ class InlandTransportDetailsControllerSpec extends ControllerSpec with GivenWhen
             thePageNavigatedTo mustBe expectedRedirect
           }
         }
-
       }
-
     }
   }
 

--- a/test/controllers/declaration/InvoiceAndExchangeRateChoiceControllerSpec.scala
+++ b/test/controllers/declaration/InvoiceAndExchangeRateChoiceControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.routes.RootController
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.invoice_and_exchange_rate_choice
 
-class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
+class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val invoiceAndExchangeRateChoicePage = mock[invoice_and_exchange_rate_choice]
 
@@ -45,7 +45,7 @@ class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
     stubMessagesControllerComponents(),
     invoiceAndExchangeRateChoicePage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -105,12 +105,14 @@ class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
       "return 303 (SEE_OTHER) and redirect to the /total-package-quantity page" when {
         "the answer is 'yes'" in {
           verifyRedirect(YesNoAnswers.yes, routes.TotalPackageQuantityController.displayPage)
+          verifyAudit()
         }
       }
 
       "return 303 (SEE_OTHER) and redirect to the /invoices-and-exchange-rate page" when {
         "the answer is 'no'" in {
           verifyRedirect(YesNoAnswers.no, routes.InvoiceAndExchangeRateController.displayPage)
+          verifyNoAudit()
         }
       }
     }
@@ -121,6 +123,7 @@ class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
 
         val result = controller.submitForm()(postRequest(JsString("")))
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
 
@@ -132,6 +135,7 @@ class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
 
       "neither Yes or No have been selected on the page" in {
@@ -140,6 +144,7 @@ class InvoiceAndExchangeRateChoiceControllerSpec extends ControllerSpec {
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/IsLicenceRequiredControllerSpec.scala
+++ b/test/controllers/declaration/IsLicenceRequiredControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, MockTaggedCodes}
+import base.{AuditedControllerSpec, ControllerSpec, MockTaggedCodes}
 import controllers.declaration.routes.{AdditionalDocumentAddController, AdditionalDocumentsController, AdditionalDocumentsRequiredController}
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.Yes
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.is_licence_required
 
-class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCodes with OptionValues {
+class IsLicenceRequiredControllerSpec extends ControllerSpec with AuditedControllerSpec with MockTaggedCodes with OptionValues {
 
   private val itemId = "itemId"
   private val commodityDetails = CommodityDetails(Some("1234567890"), Some("description"))
@@ -50,7 +50,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
     stubMessagesControllerComponents(),
     taggedAuthCodes,
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   override def getFormForDisplayRequest(request: Request[AnyContentAsEmpty.type]): Form[_] = {
     withNewCaching(declaration)
@@ -121,6 +121,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
             val result = controller.submitForm(itemId)(postRequestAsFormUrlEncoded(Seq("yesNo" -> "Yes"): _*))
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe AdditionalDocumentsController.displayPage(itemId)
+            verifyAudit()
           }
 
           "user submits valid No answer" in {
@@ -129,6 +130,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
             val result = controller.submitForm(itemId)(postRequestAsFormUrlEncoded(Seq("yesNo" -> "No"): _*))
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe AdditionalDocumentsController.displayPage(itemId)
+            verifyAudit()
           }
         }
 
@@ -139,6 +141,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
             val result = controller.submitForm(itemId)(postRequestAsFormUrlEncoded(Seq("yesNo" -> "Yes"): _*))
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe AdditionalDocumentAddController.displayPage(itemId)
+            verifyAudit()
           }
 
           "user submits valid No answer" when {
@@ -154,6 +157,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
 
               await(result) mustBe aRedirectToTheNextPage
               thePageNavigatedTo mustBe AdditionalDocumentAddController.displayPage(itemId)
+              verifyAudit()
             }
 
             "NO authorisation from List" in {
@@ -162,6 +166,7 @@ class IsLicenceRequiredControllerSpec extends ControllerSpec with MockTaggedCode
               val result = controller.submitForm(itemId)(postRequestAsFormUrlEncoded(Seq("yesNo" -> "No"): _*))
               await(result) mustBe aRedirectToTheNextPage
               thePageNavigatedTo mustBe AdditionalDocumentsRequiredController.displayPage(itemId)
+              verifyAudit()
             }
           }
         }

--- a/test/controllers/declaration/LinkDucrToMucrControllerSpec.scala
+++ b/test/controllers/declaration/LinkDucrToMucrControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import forms.common.YesNoAnswer
 import forms.common.YesNoAnswer.YesNoAnswers
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.link_ducr_to_mucr
 
-class LinkDucrToMucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class LinkDucrToMucrControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   private val linkDucrToMucrPage = mock[link_ducr_to_mucr]
 
@@ -44,7 +44,7 @@ class LinkDucrToMucrControllerSpec extends ControllerSpec with AmendmentDraftFil
     navigator,
     stubMessagesControllerComponents(),
     linkDucrToMucrPage
-  )(ec)
+  )(ec, auditService)
 
   def nextPageOnTypes: Seq[NextPageOnType] =
     allDeclarationTypes.map(NextPageOnType(_, routes.SectionSummaryController.displayPage(1)))
@@ -118,6 +118,7 @@ class LinkDucrToMucrControllerSpec extends ControllerSpec with AmendmentDraftFil
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
 
       "neither Yes or No have been selected on the page" in {
@@ -126,6 +127,7 @@ class LinkDucrToMucrControllerSpec extends ControllerSpec with AmendmentDraftFil
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
     }
   }
@@ -140,6 +142,7 @@ class LinkDucrToMucrControllerSpec extends ControllerSpec with AmendmentDraftFil
     val result = controller.submitForm()(postRequest(correctForm))
 
     status(result) mustBe SEE_OTHER
+    verifyAudit()
     thePageNavigatedTo mustBe call
   }
 }

--- a/test/controllers/declaration/LocalReferenceNumberControllerSpec.scala
+++ b/test/controllers/declaration/LocalReferenceNumberControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.LinkDucrToMucrController
 import forms.{Lrn, LrnValidator}
@@ -34,7 +34,7 @@ import views.html.declaration.local_reference_number
 
 import scala.concurrent.Future
 
-class LocalReferenceNumberControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec with GivenWhenThen {
+class LocalReferenceNumberControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec with GivenWhenThen {
 
   private val lrnValidator = mock[LrnValidator]
   private val lrnPage = mock[local_reference_number]
@@ -47,7 +47,7 @@ class LocalReferenceNumberControllerSpec extends ControllerSpec with AmendmentDr
     navigator,
     stubMessagesControllerComponents(),
     lrnPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -104,6 +104,7 @@ class LocalReferenceNumberControllerSpec extends ControllerSpec with AmendmentDr
 
           val result = controller.submitForm()(postRequest(incorrectForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
 
         "LrnValidator returns false" in {
@@ -113,6 +114,7 @@ class LocalReferenceNumberControllerSpec extends ControllerSpec with AmendmentDr
 
           val result = controller.submitForm()(postRequest(correctForm))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -125,6 +127,7 @@ class LocalReferenceNumberControllerSpec extends ControllerSpec with AmendmentDr
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.LinkDucrToMucrController.displayPage
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/LocationOfGoodsControllerSpec.scala
+++ b/test/controllers/declaration/LocationOfGoodsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, MockTaggedCodes}
+import base.{AuditedControllerSpec, ControllerSpec, MockTaggedCodes}
 import connectors.CodeListConnector
 import controllers.declaration.routes.OfficeOfExitController
 import controllers.routes.RootController
@@ -39,7 +39,7 @@ import views.html.declaration.location_of_goods
 
 import scala.collection.immutable.ListMap
 
-class LocationOfGoodsControllerSpec extends ControllerSpec with MockTaggedCodes with OptionValues {
+class LocationOfGoodsControllerSpec extends ControllerSpec with AuditedControllerSpec with MockTaggedCodes with OptionValues {
 
   val mockLocationOfGoods = mock[location_of_goods]
   val mockCodeListConnector = mock[CodeListConnector]
@@ -52,7 +52,7 @@ class LocationOfGoodsControllerSpec extends ControllerSpec with MockTaggedCodes 
     mockExportsCacheService,
     navigator,
     taggedAuthCodes
-  )(ec, mockCodeListConnector)
+  )(ec, mockCodeListConnector, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -164,6 +164,7 @@ class LocationOfGoodsControllerSpec extends ControllerSpec with MockTaggedCodes 
         verify(mockLocationOfGoods, times(0)).apply(any())(any(), any())
 
         theCacheModelUpdated.locations.goodsLocation.value mustBe GoodsLocation("PL", "A", "U", "EMAEMAEMA")
+        verifyAudit()
       }
     }
 
@@ -175,6 +176,7 @@ class LocationOfGoodsControllerSpec extends ControllerSpec with MockTaggedCodes 
 
         status(result) mustBe BAD_REQUEST
         verify(mockLocationOfGoods).apply(any())(any(), any())
+        verifyNoAudit()
       }
     }
 
@@ -188,6 +190,7 @@ class LocationOfGoodsControllerSpec extends ControllerSpec with MockTaggedCodes 
         thePageNavigatedTo mustBe OfficeOfExitController.displayPage
 
         verifyTheCacheIsUnchanged()
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/MucrControllerSpec.scala
+++ b/test/controllers/declaration/MucrControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.TestHelper._
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.SectionSummaryController
@@ -34,12 +34,15 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.mucr_code
 
-class MucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class MucrControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   private val mucrPage = mock[mucr_code]
 
   val controller =
-    new MucrController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mucrPage)(ec)
+    new MucrController(mockAuthAction, mockJourneyAction, mockExportsCacheService, navigator, stubMessagesControllerComponents(), mucrPage)(
+      ec,
+      auditService
+    )
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -105,6 +108,7 @@ class MucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
 
       "no data has been entered on the page" in {
@@ -113,6 +117,7 @@ class MucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
 
       "data entered is too long" in {
@@ -121,6 +126,7 @@ class MucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
         val result = controller.submitForm()(postRequest(incorrectForm))
         status(result) must be(BAD_REQUEST)
         verifyPageInvoked
+        verifyNoAudit()
       }
     }
   }
@@ -135,6 +141,7 @@ class MucrControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
     val result = controller.submitForm()(postRequest(correctForm))
 
     status(result) mustBe SEE_OTHER
+    verifyAudit()
     thePageNavigatedTo mustBe call
   }
 }

--- a/test/controllers/declaration/NactCodeAddControllerSpec.scala
+++ b/test/controllers/declaration/NactCodeAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, TestHelper}
+import base.{AuditedControllerSpec, ControllerSpec, TestHelper}
 import controllers.declaration.routes.StatisticalValueController
 import controllers.routes.RootController
 import forms.declaration.{NactCode, NactCodeFirst}
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.{nact_code_add, nact_code_add_first}
 
-class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
+class NactCodeAddControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockAddPage = mock[nact_code_add]
   val mockAddFirstPage = mock[nact_code_add_first]
@@ -45,7 +45,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
       stubMessagesControllerComponents(),
       mockAddFirstPage,
       mockAddPage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -138,6 +138,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageFirstInvoked()
+          verifyNoAudit()
         }
 
         "user adds duplicate code" in {
@@ -150,6 +151,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user adds too many codes" in {
@@ -162,6 +164,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
       }
 
@@ -178,6 +181,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
           thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
 
           theCacheModelUpdated.itemBy(item.id).flatMap(_.nactCodes) mustBe Some(Seq(NactCode("VATR")))
+          verifyAudit()
         }
 
         "user submits valid additional code" in {
@@ -192,6 +196,7 @@ class NactCodeAddControllerSpec extends ControllerSpec with OptionValues {
           thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
 
           theCacheModelUpdated.itemBy(item.id).flatMap(_.nactCodes) mustBe Some(Seq(nactCode, NactCode("VATR")))
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/NactCodeRemoveControllerSpec.scala
+++ b/test/controllers/declaration/NactCodeRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.routes.RootController
 import forms.common.YesNoAnswer
 import forms.declaration.NactCode
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.nact_code_remove
 
-class NactCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
+class NactCodeRemoveControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockRemovePage = mock[nact_code_remove]
 
@@ -43,7 +43,7 @@ class NactCodeRemoveControllerSpec extends ControllerSpec with OptionValues {
       navigator,
       stubMessagesControllerComponents(),
       mockRemovePage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
+++ b/test/controllers/declaration/NatureOfTransactionControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.PreviousDocumentsSummaryController
 import forms.declaration.{Document, NatureOfTransaction}
 import models.DeclarationType
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.nature_of_transaction
 
-class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues {
+class NatureOfTransactionControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockNatureOfTransactionPage = mock[nature_of_transaction]
 
@@ -42,7 +42,7 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
     stubMessagesControllerComponents(),
     mockNatureOfTransactionPage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -101,6 +101,7 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
 
         status(result) mustBe BAD_REQUEST
         verify(mockNatureOfTransactionPage, times(1)).apply(any())(any(), any())
+        verifyNoAudit()
       }
     }
 
@@ -115,6 +116,7 @@ class NatureOfTransactionControllerSpec extends ControllerSpec with OptionValues
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
 
         verify(mockNatureOfTransactionPage, times(0)).apply(any())(any(), any())
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/OfficeOfExitControllerSpec.scala
+++ b/test/controllers/declaration/OfficeOfExitControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import forms.declaration.officeOfExit.OfficeOfExit
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
@@ -29,7 +29,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.office_of_exit
 
-class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
+class OfficeOfExitControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockOfficeOfExitPage = mock[office_of_exit]
 
@@ -40,7 +40,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
     stubMessagesControllerComponents(),
     mockOfficeOfExitPage,
     mockExportsCacheService
-  )(ec)
+  )(ec, auditService)
 
   def checkViewInteractions(noOfInvocations: Int = 1): Unit =
     verify(mockOfficeOfExitPage, times(noOfInvocations)).apply(any())(any(), any())
@@ -106,6 +106,7 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
 
         status(result) mustBe BAD_REQUEST
         checkViewInteractions()
+        verifyNoAudit()
       }
     }
   }
@@ -126,8 +127,8 @@ class OfficeOfExitControllerSpec extends ControllerSpec with OptionValues {
         thePageNavigatedTo mustBe routes.SectionSummaryController.displayPage(3)
         checkViewInteractions(0)
         theCacheModelUpdated.locations.officeOfExit must be(Some(OfficeOfExit(officeOfExitInput)))
+        verifyAudit()
       }
-
     }
   }
 }

--- a/test/controllers/declaration/PackageInformationAddControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationAddControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, Injector}
+import base.{AuditedControllerSpec, ControllerSpec, Injector}
 import controllers.helpers.SequenceIdHelper.valueOfEso
 import forms.declaration.PackageInformation
 import org.mockito.ArgumentCaptor
@@ -31,7 +31,7 @@ import services.PackageTypesService
 import views.declaration.PackageInformationViewSpec.packageInformation
 import views.html.declaration.packageInformation.package_information_add
 
-class PackageInformationAddControllerSpec extends ControllerSpec with OptionValues with Injector with GivenWhenThen {
+class PackageInformationAddControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues with Injector with GivenWhenThen {
 
   val mockAddPage = mock[package_information_add]
   val mockPackageTypesService = instanceOf[PackageTypesService]
@@ -44,7 +44,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
       navigator,
       stubMessagesControllerComponents(),
       mockAddPage
-    )(ec, mockPackageTypesService)
+    )(ec, mockPackageTypesService, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -100,6 +100,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user adds duplicate data" in {
@@ -115,6 +116,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
 
         "user adds too many codes" in {
@@ -127,6 +129,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
 
           status(result) mustBe BAD_REQUEST
           verifyAddPageInvoked()
+          verifyNoAudit()
         }
       }
 
@@ -149,6 +152,7 @@ class PackageInformationAddControllerSpec extends ControllerSpec with OptionValu
 
           And("max seq id is updated in dec meta")
           valueOfEso[PackageInformation](declaration).value mustBe 1
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/PackageInformationChangeControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationChangeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, Injector}
+import base.{AuditedControllerSpec, ControllerSpec, Injector}
 import controllers.helpers.SequenceIdHelper.valueOfEso
 import forms.declaration.PackageInformation
 import mock.ErrorHandlerMocks
@@ -31,7 +31,8 @@ import play.twirl.api.HtmlFormat
 import services.PackageTypesService
 import views.html.declaration.packageInformation.package_information_change
 
-class PackageInformationChangeControllerSpec extends ControllerSpec with OptionValues with ErrorHandlerMocks with Injector {
+class PackageInformationChangeControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with OptionValues with ErrorHandlerMocks with Injector {
 
   val mockChangePage = mock[package_information_change]
   val mockPackageTypesService = instanceOf[PackageTypesService]
@@ -45,7 +46,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
       mockErrorHandler,
       stubMessagesControllerComponents(),
       mockChangePage
-    )(ec, mockPackageTypesService)
+    )(ec, mockPackageTypesService, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -105,6 +106,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+          verifyNoAudit()
         }
 
         "user makes changes resulting in duplicate data" in {
@@ -121,6 +123,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
 
           status(result) mustBe BAD_REQUEST
           verifyChangePageInvoked()
+          verifyNoAudit()
         }
 
         "user tries to display page with non-existent package info" in {
@@ -131,6 +134,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
           status(result) mustBe BAD_REQUEST
           verifyNoInteractions(mockChangePage)
           verify(mockErrorHandler).redirectToErrorPage(any())
+          verifyNoAudit()
         }
 
         "user tries to remove non-existent package info" in {
@@ -140,6 +144,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
 
           status(result) mustBe BAD_REQUEST
           verify(mockErrorHandler).redirectToErrorPage(any())
+          verifyNoAudit()
         }
       }
 
@@ -160,6 +165,7 @@ class PackageInformationChangeControllerSpec extends ControllerSpec with OptionV
           savedPackage.shippingMarks mustBe Some("1234")
 
           valueOfEso[PackageInformation](declaration).value mustBe 1
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/PackageInformationRemoveControllerSpec.scala
+++ b/test/controllers/declaration/PackageInformationRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.helpers.SequenceIdHelper.valueOfEso
 import forms.common.YesNoAnswer
 import forms.declaration.PackageInformation
@@ -31,7 +31,8 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.packageInformation.package_information_remove
 
-class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
+class PackageInformationRemoveControllerSpec
+    extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with GivenWhenThen with OptionValues {
 
   val mockRemovePage = mock[package_information_remove]
 
@@ -44,7 +45,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
       navigator,
       stubMessagesControllerComponents(),
       mockRemovePage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -110,6 +111,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
 
           status(result) mustBe BAD_REQUEST
           verifyRemovePageInvoked()
+          verifyNoAudit()
         }
 
         "user tries to display page with non-existent package info" in {
@@ -120,6 +122,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
           status(result) mustBe BAD_REQUEST
           verifyNoInteractions(mockRemovePage)
           verify(mockErrorHandler).redirectToErrorPage(any())
+          verifyNoAudit()
         }
 
         "user tries to remove non-existent package info" in {
@@ -130,6 +133,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
           status(result) mustBe BAD_REQUEST
           verifyNoInteractions(mockRemovePage)
           verify(mockErrorHandler).redirectToErrorPage(any())
+          verifyNoAudit()
         }
       }
 
@@ -156,6 +160,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
 
           And("max seq Id remains the same in dec meta")
           valueOfEso[PackageInformation](declaration).value mustBe 1
+          verifyAudit()
         }
 
         "user submits 'No' answer" in {
@@ -168,6 +173,7 @@ class PackageInformationRemoveControllerSpec extends ControllerSpec with ErrorHa
           thePageNavigatedTo mustBe routes.PackageInformationSummaryController.displayPage(item.id)
 
           verifyTheCacheIsUnchanged()
+          verifyNoAudit()
         }
       }
     }

--- a/test/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
+++ b/test/controllers/declaration/PersonPresentingGoodsDetailsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.ExporterEoriNumberController
 import controllers.routes.RootController
 import forms.common.Eori
@@ -34,7 +34,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.person_presenting_goods_details
 
-class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with ScalaFutures {
+class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with AuditedControllerSpec with ScalaFutures {
 
   private val testEori = "GB1234567890000"
 
@@ -47,7 +47,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
     navigator,
     stubMessagesControllerComponents(),
     page
-  )(ec)
+  )(ec, auditService)
 
   override def beforeEach(): Unit = {
     super.beforeEach()
@@ -56,7 +56,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
   }
 
   override def afterEach(): Unit = {
-    reset(page)
+    reset(page, auditService)
     super.afterEach()
   }
 
@@ -135,6 +135,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
           val result = controller.submitForm()(postRequest(correctForm))
 
           status(result) mustBe SEE_OTHER
+          verifyAudit()
         }
 
         "redirect to Exporter Details page" in {
@@ -153,6 +154,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
           controller.submitForm()(postRequest(correctForm)).futureValue
 
           theCacheModelUpdated.parties.personPresentingGoodsDetails mustBe Some(PersonPresentingGoodsDetails(Eori(testEori)))
+          verifyAudit()
         }
 
         "call Navigator" in {
@@ -185,6 +187,7 @@ class PersonPresentingGoodsDetailsControllerSpec extends ControllerSpec with Sca
         val result = controller.submitForm()(postRequest(correctForm))
 
         status(result) mustBe SEE_OTHER
+        verifyNoAudit()
       }
 
       "redirect to start page" in {

--- a/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerWithoutFormSpec
+import base.{AuditedControllerSpec, ControllerWithoutFormSpec}
 import controllers.declaration.routes.PreviousDocumentsSummaryController
 import forms.declaration.{Document, PreviousDocumentsData}
 import models.DeclarationType
@@ -30,7 +30,7 @@ import play.twirl.api.{Html, HtmlFormat}
 import services.{DocumentType, DocumentTypeService}
 import views.html.declaration.previousDocuments.previous_documents
 
-class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
+class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec with AuditedControllerSpec {
 
   val mockPreviousDocumentsPage = mock[previous_documents]
   val mockDocumentTypeService = mock[DocumentTypeService]
@@ -43,7 +43,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
     mockPreviousDocumentsPage,
     mockExportsCacheService,
     mockDocumentTypeService
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -92,6 +92,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
         status(result) mustBe BAD_REQUEST
         verifyPage()
+        verifyNoAudit()
       }
 
       "user doesn't provide the Document reference" in {
@@ -102,6 +103,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
         status(result) mustBe BAD_REQUEST
         verifyPage()
+        verifyNoAudit()
       }
 
       "user doesn't provide Document type and Document reference" in {
@@ -112,6 +114,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
         status(result) mustBe BAD_REQUEST
         verifyPage()
+        verifyNoAudit()
       }
 
       "user put duplicated item" in {
@@ -123,6 +126,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
         status(result) mustBe BAD_REQUEST
         verifyPage()
+        verifyNoAudit()
       }
 
       "user reach maximum amount of items" in {
@@ -135,6 +139,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
 
         status(result) mustBe BAD_REQUEST
         verifyPage()
+        verifyNoAudit()
       }
     }
 
@@ -149,6 +154,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
 
       "user fills in all fields" in {
@@ -160,6 +166,7 @@ class PreviousDocumentsControllerSpec extends ControllerWithoutFormSpec {
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
+++ b/test/controllers/declaration/PreviousDocumentsRemoveControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerWithoutFormSpec
+import base.{AuditedControllerSpec, ControllerWithoutFormSpec}
 import controllers.declaration.routes.PreviousDocumentsSummaryController
 import forms.common.YesNoAnswer
 import forms.declaration.Document
@@ -28,7 +28,7 @@ import play.twirl.api.HtmlFormat
 import utils.ListItem
 import views.html.declaration.previousDocuments.previous_documents_remove
 
-class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
+class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec with AuditedControllerSpec {
 
   private val page = mock[previous_documents_remove]
 
@@ -39,7 +39,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
     navigator,
     stubMessagesControllerComponents(),
     page
-  )
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -78,6 +78,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
         val result = controller.submit(documentId)(postRequest(incorrectForm))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 
@@ -101,6 +102,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
+        verifyAudit()
       }
 
       "user answer No" in {
@@ -112,6 +114,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
+        verifyNoAudit()
       }
 
       "submit method is invoked for incorrect document" in {
@@ -123,6 +126,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
+        verifyNoAudit()
       }
     }
 
@@ -136,6 +140,7 @@ class PreviousDocumentsRemoveControllerSpec extends ControllerWithoutFormSpec {
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe PreviousDocumentsSummaryController.displayPage
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/ProcedureCodeControllerSpec.scala
+++ b/test/controllers/declaration/ProcedureCodeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.AdditionalProcedureCodesController
 import forms.declaration._
 import forms.declaration.procedurecodes.ProcedureCode
@@ -36,7 +36,7 @@ import play.twirl.api.HtmlFormat
 import views.declaration.PackageInformationViewSpec
 import views.html.declaration.procedureCodes.procedure_codes
 
-class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks with OptionValues with ScalaFutures {
+class ProcedureCodeControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with OptionValues with ScalaFutures {
 
   private val procedureCodesPage = mock[procedure_codes]
 
@@ -47,7 +47,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
     mockExportsCacheService,
     stubMessagesControllerComponents(),
     procedureCodesPage
-  )(ec)
+  )(ec, auditService)
 
   val itemId = "itemId12345"
 
@@ -65,7 +65,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
   }
 
   override protected def afterEach(): Unit = {
-    reset(procedureCodesPage)
+    reset(procedureCodesPage, auditService)
     super.afterEach()
   }
 
@@ -125,6 +125,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
           status(result) mustBe BAD_REQUEST
           verify(procedureCodesPage).apply(any(), any())(any(), any())
+          verifyNoAudit()
         }
       }
 
@@ -138,6 +139,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
           status(result) mustBe BAD_REQUEST
           verify(procedureCodesPage).apply(any(), any())(any(), any())
+          verifyNoAudit()
         }
       }
 
@@ -151,6 +153,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
           status(result) mustBe SEE_OTHER
           thePageNavigatedTo mustBe AdditionalProcedureCodesController.displayPage(itemId)
           verify(procedureCodesPage, never()).apply(any(), any())(any(), any())
+          verifyAudit()
         }
       }
 
@@ -169,6 +172,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
             updatedItem.get.procedureCodes mustBe defined
             updatedItem.get.procedureCodes.get.procedureCode mustBe defined
             updatedItem.get.procedureCodes.get.procedureCode.get mustBe "1234"
+            verifyAudit()
           }
 
           "NOT remove Additional Procedure Codes from the cache" in {
@@ -182,6 +186,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
             updatedItem mustBe defined
             updatedItem.get.procedureCodes mustBe defined
             updatedItem.get.procedureCodes.get.additionalProcedureCodes mustBe Seq("123", "456")
+            verifyAudit()
           }
         }
 
@@ -199,6 +204,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
             updatedItem.get.procedureCodes mustBe defined
             updatedItem.get.procedureCodes.get.procedureCode mustBe defined
             updatedItem.get.procedureCodes.get.procedureCode.get mustBe "5678"
+            verifyAudit()
           }
 
           "remove all Additional Procedure Codes from the cache" in {
@@ -212,6 +218,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
             updatedItem mustBe defined
             updatedItem.get.procedureCodes mustBe defined
             updatedItem.get.procedureCodes.get.additionalProcedureCodes mustBe empty
+            verifyAudit()
           }
 
           "NOT remove Additional Procedure Codes from the cache" when {
@@ -226,6 +233,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
               updatedItem mustBe defined
               updatedItem.get.procedureCodes mustBe defined
               updatedItem.get.procedureCodes.get.additionalProcedureCodes mustBe Seq("123", "456")
+              verifyAudit()
             }
           }
         }
@@ -246,6 +254,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
           val updatedItem = theCacheModelUpdated.itemBy(itemId)
           updatedItem.flatMap(_.fiscalInformation).value mustBe fiscalInformation
           updatedItem.flatMap(_.additionalFiscalReferencesData).value mustBe fiscalReferencesData
+          verifyAudit()
         }
       }
 
@@ -264,6 +273,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
           val updatedItem = theCacheModelUpdated.itemBy(itemId)
           updatedItem.flatMap(_.fiscalInformation) mustBe None
           updatedItem.flatMap(_.additionalFiscalReferencesData) mustBe None
+          verifyAudit()
         }
       }
     }
@@ -281,6 +291,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
           val updatedItem = theCacheModelUpdated.itemBy(itemId)
           updatedItem.flatMap(_.packageInformation) mustBe Some(Seq(PackageInformationViewSpec.packageInformation))
+          verifyAudit()
         }
       }
 
@@ -295,6 +306,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
           val updatedItem = theCacheModelUpdated.itemBy(itemId)
           updatedItem.flatMap(_.packageInformation) mustBe None
+          verifyAudit()
         }
       }
     }
@@ -317,6 +329,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
             val updatedLocations = theCacheModelUpdated.locations
             updatedLocations.warehouseIdentification mustBe None
+            verifyAudit()
           }
         }
 
@@ -336,6 +349,7 @@ class ProcedureCodeControllerSpec extends ControllerSpec with ErrorHandlerMocks 
 
             val updatedLocations = theCacheModelUpdated.locations
             updatedLocations.warehouseIdentification.value mustBe warehouseIdentification
+            verifyAudit()
           }
         }
       }

--- a/test/controllers/declaration/RepresentativeAgentControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeAgentControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{RepresentativeEntityController, RepresentativeStatusController}
 import forms.common.Eori
 import forms.declaration.RepresentativeAgent
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.representative_details_agent
 
-class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues {
+class RepresentativeAgentControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[representative_details_agent]
 
@@ -42,7 +42,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
     mockExportsCacheService,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   def theResponseForm: Form[RepresentativeAgent] = {
     val formCaptor = ArgumentCaptor.forClass(classOf[Form[RepresentativeAgent]])
@@ -57,7 +57,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
   }
 
   override protected def afterEach(): Unit = {
-    reset(mockPage)
+    reset(mockPage, auditService)
     super.afterEach()
   }
 
@@ -106,6 +106,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
 
           status(result) mustBe BAD_REQUEST
           verifyPage(1)
+          verifyNoAudit()
         }
       }
     }
@@ -124,6 +125,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
           thePageNavigatedTo mustBe RepresentativeStatusController.displayPage
 
           verifyPage(0)
+          verifyAudit()
         }
 
         "clear the representative eori if already present " in {
@@ -136,6 +138,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
 
           val representativeDetails = theCacheModelUpdated.parties.representativeDetails
           representativeDetails.flatMap(_.details).isDefined mustBe false
+          verifyAudit()
         }
       }
 
@@ -152,6 +155,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
           thePageNavigatedTo mustBe RepresentativeEntityController.displayPage
 
           verifyPage(0)
+          verifyAudit()
         }
 
         "not clear the representative eori if already present" in {
@@ -164,6 +168,7 @@ class RepresentativeAgentControllerSpec extends ControllerSpec with OptionValues
 
           val representativeDetails = theCacheModelUpdated.parties.representativeDetails
           representativeDetails.flatMap(_.details).isDefined mustBe true
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/RepresentativeEntityControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeEntityControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.RepresentativeStatusController
 import forms.common.Eori
 import forms.declaration.{EntityDetails, RepresentativeEntity}
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.representative_details_entity
 
-class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValues {
+class RepresentativeEntityControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[representative_details_entity]
 
@@ -42,7 +42,7 @@ class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValue
     mockExportsCacheService,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   val eori = "GB12345678912345"
 
@@ -111,6 +111,7 @@ class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValue
 
           status(result) mustBe BAD_REQUEST
           verifyPage(1)
+          verifyNoAudit()
         }
       }
     }
@@ -127,6 +128,7 @@ class RepresentativeEntityControllerSpec extends ControllerSpec with OptionValue
         thePageNavigatedTo mustBe RepresentativeStatusController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
   }

--- a/test/controllers/declaration/RepresentativeStatusControllerSpec.scala
+++ b/test/controllers/declaration/RepresentativeStatusControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{CarrierEoriNumberController, ConsigneeDetailsController}
 import forms.common.YesNoAnswer.YesNoAnswers
 import forms.declaration.{IsExs, RepresentativeStatus}
@@ -32,7 +32,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.representative_details_status
 
-class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValues {
+class RepresentativeStatusControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[representative_details_status]
 
@@ -43,7 +43,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
     mockExportsCacheService,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   val statusCode = "2"
 
@@ -111,6 +111,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
 
           status(result) mustBe BAD_REQUEST
           verifyPage(1)
+          verifyNoAudit()
         }
       }
     }
@@ -127,6 +128,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
         thePageNavigatedTo mustBe ConsigneeDetailsController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
 
@@ -142,6 +144,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
         thePageNavigatedTo mustBe CarrierEoriNumberController.displayPage
 
         verifyPage(0)
+        verifyAudit()
       }
     }
 
@@ -159,6 +162,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
           thePageNavigatedTo mustBe CarrierEoriNumberController.displayPage
 
           verifyPage(0)
+          verifyAudit()
         }
       }
 
@@ -175,6 +179,7 @@ class RepresentativeStatusControllerSpec extends ControllerSpec with OptionValue
           thePageNavigatedTo mustBe ConsigneeDetailsController.displayPage
 
           verifyPage(0)
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/StatisticalValueControllerSpec.scala
+++ b/test/controllers/declaration/StatisticalValueControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.PackageInformationSummaryController
 import controllers.helpers.MultipleItemsHelper
 import controllers.routes.RootController
@@ -35,7 +35,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.statistical_value
 
-class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMocks with OptionValues {
+class StatisticalValueControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with OptionValues {
 
   val mockItemTypePage = mock[statistical_value]
 
@@ -46,7 +46,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
     navigator,
     stubMessagesControllerComponents(),
     mockItemTypePage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -127,6 +127,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
 
           status(result) mustBe BAD_REQUEST
           verify(mockItemTypePage, times(1)).apply(any(), any())(any(), any())
+          verifyNoAudit()
         }
       }
     }
@@ -141,6 +142,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
 
           status(result) mustBe SEE_OTHER
           redirectLocation(result) mustBe Some(RootController.displayPage.url)
+          verifyNoAudit()
         }
       }
 
@@ -157,6 +159,7 @@ class StatisticalValueControllerSpec extends ControllerSpec with ErrorHandlerMoc
           verify(mockItemTypePage, times(0)).apply(any(), any())(any(), any())
 
           validateCache(StatisticalValue("7"))
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/SummaryControllerSpec.scala
+++ b/test/controllers/declaration/SummaryControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerWithoutFormSpec
+import base.{AuditedControllerSpec, ControllerWithoutFormSpec}
 import config.AppConfig
 import controllers.declaration.SummaryControllerSpec.{expectedHref, fakeSummaryPage}
 import controllers.declaration.routes.SummaryController
@@ -41,7 +41,7 @@ import views.html.error_template
 
 import scala.concurrent.{ExecutionContext, Future}
 
-class SummaryControllerSpec extends ControllerWithoutFormSpec with ErrorHandlerMocks with OptionValues {
+class SummaryControllerSpec extends ControllerWithoutFormSpec with AuditedControllerSpec with ErrorHandlerMocks with OptionValues {
 
   private val amendmentSummaryPage = mock[amendment_summary]
   private val normalSummaryPage = mock[normal_summary_page]
@@ -64,7 +64,7 @@ class SummaryControllerSpec extends ControllerWithoutFormSpec with ErrorHandlerM
     normalSummaryPage,
     mockSummaryPageNoData,
     mockLrnValidator
-  )(ec, appConfig)
+  )(ec, appConfig, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()

--- a/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
+++ b/test/controllers/declaration/SupervisingCustomsOfficeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.ExportsTestData.allValuesRequiringToSkipInlandOrBorder
 import controllers.declaration.routes.{
   DepartureTransportController,
@@ -42,7 +42,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.supervising_customs_office
 
-class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeAndAfterEach with OptionValues {
+class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with AuditedControllerSpec with BeforeAndAfterEach with OptionValues {
 
   private val inlandOrBorderHelper = instanceOf[InlandOrBorderHelper]
   private val supervisingCustomsOfficeHelper = instanceOf[SupervisingCustomsOfficeHelper]
@@ -57,7 +57,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
     supervisingCustomsOfficePage = supervisingCustomsOfficeTemplate,
     inlandOrBorderHelper = inlandOrBorderHelper,
     supervisingCustomsOfficeHelper = supervisingCustomsOfficeHelper
-  )
+  )(ec, auditService)
 
   private val exampleCustomsOfficeIdentifier = "A1B2C3D4"
   private val exampleWarehouseIdentificationNumber = "SecretStash"
@@ -126,6 +126,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe InlandOrBorderController.displayPage
+        verifyAudit()
       }
 
       "update cache after successful bind" in {
@@ -135,6 +136,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         val supervisingCustomsOffice = theCacheModelUpdated.locations.supervisingCustomsOffice.value
         supervisingCustomsOffice.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        verifyAudit()
       }
 
       "return Bad Request if payload is not compatible with model" in {
@@ -144,6 +146,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         val result = controller.submit()(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 
@@ -156,6 +159,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe InlandOrBorderController.displayPage
+        verifyAudit()
       }
 
       "redirect to /inland-transport-details after a successful bind" in {
@@ -165,6 +169,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe InlandTransportDetailsController.displayPage
+        verifyAudit()
       }
 
       "update cache after successful bind" in {
@@ -174,6 +179,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         val supervisingCustomsOffice = theCacheModelUpdated.locations.supervisingCustomsOffice.value
         supervisingCustomsOffice.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        verifyAudit()
       }
 
       "return Bad Request if payload is not compatible with model" in {
@@ -183,6 +189,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         val result = controller.submit()(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 
@@ -198,6 +205,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
               await(result) mustBe aRedirectToTheNextPage
               thePageNavigatedTo mustBe InlandTransportDetailsController.displayPage
+              verifyAudit()
             }
           }
         }
@@ -213,6 +221,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe InlandOrBorderController.displayPage
+        verifyAudit()
       }
 
       "update cache after successful bind" in {
@@ -222,6 +231,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         val supervisingCustomsOffice = theCacheModelUpdated.locations.supervisingCustomsOffice.value
         supervisingCustomsOffice.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        verifyAudit()
       }
 
       "return Bad Request if payload is not compatible with model" in {
@@ -231,6 +241,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         val result = controller.submit()(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 
@@ -243,6 +254,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         result mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe DepartureTransportController.displayPage
+        verifyAudit()
       }
 
       "redirect to /express-consignment after a successful bind" when {
@@ -255,6 +267,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
             result mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe ExpressConsignmentController.displayPage
+            verifyAudit()
           }
         }
       }
@@ -266,6 +279,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
 
         val supervisingCustomsOffice = theCacheModelUpdated.locations.supervisingCustomsOffice.value
         supervisingCustomsOffice.supervisingCustomsOffice.value mustBe exampleCustomsOfficeIdentifier
+        verifyAudit()
       }
 
       "return Bad Request if payload is not compatible with model" in {
@@ -275,6 +289,7 @@ class SupervisingCustomsOfficeControllerSpec extends ControllerSpec with BeforeA
         val result = controller.submit()(postRequest(body))
 
         status(result) mustBe BAD_REQUEST
+        verifyNoAudit()
       }
     }
 

--- a/test/controllers/declaration/SupplementaryUnitsControllerSpec.scala
+++ b/test/controllers/declaration/SupplementaryUnitsControllerSpec.scala
@@ -17,8 +17,7 @@
 package controllers.declaration
 
 import scala.concurrent.Future
-
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.AdditionalInformationRequiredController
 import controllers.routes.RootController
 import forms.declaration.commodityMeasure.SupplementaryUnits
@@ -37,7 +36,7 @@ import services.TariffApiService.{CommodityCodeNotFound, SupplementaryUnitsNotRe
 import services.{CommodityInfo, TariffApiService}
 import views.html.declaration.commodityMeasure.{supplementary_units, supplementary_units_yes_no}
 
-class SupplementaryUnitsControllerSpec extends ControllerSpec {
+class SupplementaryUnitsControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val supplementaryUnitsPage = mock[supplementary_units]
   private val supplementaryUnitsYesNoPage = mock[supplementary_units_yes_no]
@@ -53,7 +52,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
     stubMessagesControllerComponents(),
     supplementaryUnitsPage,
     supplementaryUnitsYesNoPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -65,7 +64,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
   override protected def afterEach(): Unit = {
     super.afterEach()
-    reset(supplementaryUnitsPage, supplementaryUnitsYesNoPage, tariffApiService)
+    reset(supplementaryUnitsPage, supplementaryUnitsYesNoPage, tariffApiService, auditService)
   }
 
   def responseMandatoryForm: Form[SupplementaryUnits] = {
@@ -200,6 +199,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe AdditionalInformationRequiredController.displayPage("itemId")
+            verifyAudit()
           }
         }
 
@@ -213,6 +213,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
             status(result) must be(BAD_REQUEST)
             verify(supplementaryUnitsYesNoPage).apply(any(), any())(any(), any())
+            verifyNoAudit()
           }
         }
       }
@@ -231,6 +232,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe AdditionalInformationRequiredController.displayPage("itemId")
+            verifyAudit()
           }
         }
 
@@ -246,6 +248,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
             status(result) must be(BAD_REQUEST)
             verify(supplementaryUnitsPage).apply(any(), any(), any())(any(), any())
+            verifyNoAudit()
           }
         }
       }
@@ -259,6 +262,7 @@ class SupplementaryUnitsControllerSpec extends ControllerSpec {
 
         status(response) must be(SEE_OTHER)
         redirectLocation(response) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/TotalPackageQuantityControllerSpec.scala
+++ b/test/controllers/declaration/TotalPackageQuantityControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.NatureOfTransactionController
 import controllers.helpers.TransportSectionHelper.{Guernsey, Jersey}
 import controllers.routes.RootController
@@ -33,7 +33,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.total_package_quantity
 
-class TotalPackageQuantityControllerSpec extends ControllerSpec {
+class TotalPackageQuantityControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val totalPackageQuantity = mock[total_package_quantity]
 
@@ -44,7 +44,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
     navigator,
     mockExportsCacheService,
     totalPackageQuantity
-  )
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -96,6 +96,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
           val body = Json.obj("totalPackage" -> "one")
           val result = controller.saveTotalPackageQuantity().apply(postRequest(body, request.cacheModel))
           status(result) mustBe BAD_REQUEST
+          verifyNoAudit()
         }
       }
 
@@ -112,6 +113,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
             thePageNavigatedTo mustBe NatureOfTransactionController.displayPage
 
             theCacheModelUpdated
+            verifyAudit()
           }
         }
 
@@ -123,6 +125,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe NatureOfTransactionController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -135,6 +138,7 @@ class TotalPackageQuantityControllerSpec extends ControllerSpec {
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) must contain(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/TraderReferenceControllerSpec.scala
+++ b/test/controllers/declaration/TraderReferenceControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.actions.AmendmentDraftFilterSpec
 import controllers.declaration.routes.ConfirmDucrController
 import forms.Ducr
@@ -35,7 +35,7 @@ import views.html.declaration.trader_reference
 
 import java.time.{LocalDate, ZonedDateTime}
 
-class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFilterSpec {
+class TraderReferenceControllerSpec extends ControllerSpec with AuditedControllerSpec with AmendmentDraftFilterSpec {
 
   private val traderReferencePage = mock[trader_reference]
 
@@ -46,7 +46,7 @@ class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFi
     stubMessagesControllerComponents(),
     mockExportsCacheService,
     traderReferencePage
-  )
+  )(ec, auditService)
 
   def nextPageOnTypes: Seq[NextPageOnType] =
     allDeclarationTypesExcluding(SUPPLEMENTARY).map(NextPageOnType(_, ConfirmDucrController.displayPage))
@@ -108,6 +108,7 @@ class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFi
 
         status(result) mustBe BAD_REQUEST
         verifyTheCacheIsUnchanged()
+        verifyNoAudit()
       }
 
       "form was submitted with no data" in {
@@ -118,6 +119,7 @@ class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFi
 
         status(result) mustBe BAD_REQUEST
         verifyTheCacheIsUnchanged()
+        verifyNoAudit()
       }
     }
 
@@ -133,6 +135,7 @@ class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFi
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.ConfirmDucrController.displayPage
         theCacheModelUpdated().head mustBe aDeclarationAfter(declaration, withConsignmentReferences(dummyConRefs))
+        verifyAudit()
       }
 
       "display page method is invoked on supplementary journey" in {
@@ -142,6 +145,7 @@ class TraderReferenceControllerSpec extends ControllerSpec with AmendmentDraftFi
 
         status(result) mustBe 303
         redirectLocation(result) mustBe Some(controllers.routes.RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }

--- a/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
+++ b/test/controllers/declaration/TransportLeavingTheBorderControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.ExportsTestData.{modifierForPC1040, valuesRequiringToSkipInlandOrBorder}
 import controllers.declaration.routes.{
   InlandOrBorderController,
@@ -44,7 +44,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.transport_leaving_the_border
 
-class TransportLeavingTheBorderControllerSpec extends ControllerSpec with OptionValues {
+class TransportLeavingTheBorderControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   private val transportLeavingTheBorder = mock[transport_leaving_the_border]
 
@@ -60,7 +60,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
     transportLeavingTheBorder,
     inlandOrBorderHelper = inlandOrBorderHelper,
     supervisingCustomsOfficeHelper
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -119,6 +119,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
           val result = controller.submitForm()(postRequest(Json.obj()))
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -133,6 +134,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
             await(controller.submitForm()(postRequest(body)))
 
             theCacheModelUpdated.transportLeavingBorderCode mustBe Some(RoRo)
+            verifyAudit()
           }
         }
 
@@ -145,6 +147,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
               val result = controller.submitForm()(postRequest(body))
               status(result) must be(BAD_REQUEST)
+              verifyNoAudit()
             }
           }
         }
@@ -167,6 +170,8 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
             transport.meansOfTransportCrossingTheBorderType mustBe None
             transport.meansOfTransportCrossingTheBorderIDNumber mustBe None
             transport.transportCrossingTheBorderNationality mustBe None
+
+            verifyAudit()
           }
         }
       }
@@ -186,6 +191,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
             await(controller.submitForm()(postRequest(body)))
 
             theCacheModelUpdated.transportLeavingBorderCode.value mustBe modeOfTransportCode
+            verifyAudit()
           }
         }
 
@@ -200,6 +206,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
                 await(result) mustBe aRedirectToTheNextPage
                 thePageNavigatedTo mustBe WarehouseIdentificationController.displayPage
+                verifyAudit()
               }
             }
           }
@@ -211,6 +218,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe SupervisingCustomsOfficeController.displayPage
+            verifyAudit()
           }
         }
 
@@ -229,6 +237,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
                   else InlandOrBorderController.displayPage
 
                 thePageNavigatedTo mustBe expectedPage
+                verifyAudit()
               }
             }
           }
@@ -244,6 +253,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
                 await(result) mustBe aRedirectToTheNextPage
                 thePageNavigatedTo mustBe InlandTransportDetailsController.displayPage
+                verifyAudit()
               }
             }
 
@@ -269,6 +279,8 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
                     await(result) mustBe aRedirectToTheNextPage
                     thePageNavigatedTo mustBe expectedPage
+
+                    verifyAudit()
                   }
                 }
               }
@@ -284,6 +296,7 @@ class TransportLeavingTheBorderControllerSpec extends ControllerSpec with Option
 
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe WarehouseIdentificationController.displayPage
+            verifyAudit()
           }
         }
       }

--- a/test/controllers/declaration/TransportPaymentControllerSpec.scala
+++ b/test/controllers/declaration/TransportPaymentControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.TransportContainerController
 import controllers.routes.RootController
 import forms.declaration.TransportPayment
@@ -31,7 +31,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.transport_payment
 
-class TransportPaymentControllerSpec extends ControllerSpec {
+class TransportPaymentControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   val transportPaymentPage = mock[transport_payment]
 
@@ -42,7 +42,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
     mockExportsCacheService,
     stubMessagesControllerComponents(),
     transportPaymentPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -53,7 +53,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
 
   override protected def afterEach(): Unit = {
     super.afterEach()
-    reset(transportPaymentPage)
+    reset(transportPaymentPage, auditService)
   }
 
   def theResponseForm: Form[TransportPayment] = {
@@ -101,6 +101,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
           val result = controller.submitForm()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -114,6 +115,7 @@ class TransportPaymentControllerSpec extends ControllerSpec {
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe TransportContainerController.displayContainerSummary
           verify(transportPaymentPage, times(0)).apply(any())(any(), any())
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
+++ b/test/controllers/declaration/UNDangerousGoodsCodeControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import controllers.declaration.routes.{
   CommodityMeasureController,
   CusCodeController,
@@ -43,7 +43,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.un_dangerous_goods_code
 
-class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValues {
+class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with AuditedControllerSpec with OptionValues {
 
   val mockPage = mock[un_dangerous_goods_code]
 
@@ -54,7 +54,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
     navigator,
     stubMessagesControllerComponents(),
     mockPage
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -126,6 +126,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
 
         status(result) mustBe BAD_REQUEST
         verify(mockPage, times(1)).apply(any(), any())(any(), any())
+        verifyNoAudit()
       }
     }
 
@@ -141,6 +142,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
 
           val result = controller.submitForm(item.id)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
+          verifyAudit()
           thePageNavigatedTo mustBe expectedCall(item.id)
         }
 
@@ -162,6 +164,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
 
           val result = controller.submitForm(item.id)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
+          verifyAudit()
           thePageNavigatedTo mustBe expectedCall(item.id)
         }
 
@@ -184,6 +187,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
           val result = controller.submitForm(itemId)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(itemId)
+          verifyAudit()
         }
 
         "NatureOfTransaction is 'Sale'" in {
@@ -191,6 +195,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
           val result = controller.submitForm(itemId)(postRequest(correctForm))
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(itemId)
+          verifyAudit()
         }
       }
 
@@ -203,6 +208,7 @@ class UNDangerousGoodsCodeControllerSpec extends ControllerSpec with OptionValue
             val result = controller.submitForm(item.id)(postRequest(correctForm))
             await(result) mustBe aRedirectToTheNextPage
             thePageNavigatedTo mustBe ZeroRatedForVatController.displayPage(item.id)
+            verifyAudit()
           }
         }
       }

--- a/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
+++ b/test/controllers/declaration/WarehouseIdentificationControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.ControllerSpec
+import base.{AuditedControllerSpec, ControllerSpec}
 import base.ExportsTestData.modifierForPC1040
 import controllers.declaration.routes._
 import controllers.helpers.SupervisingCustomsOfficeHelper
@@ -35,7 +35,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.{warehouse_identification, warehouse_identification_yesno}
 
-class WarehouseIdentificationControllerSpec extends ControllerSpec {
+class WarehouseIdentificationControllerSpec extends ControllerSpec with AuditedControllerSpec {
 
   private val pageYesNo = mock[warehouse_identification_yesno]
   private val pageIdentification = mock[warehouse_identification]
@@ -51,7 +51,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
     pageYesNo,
     pageIdentification,
     supervisingCustomsOfficeHelper
-  )(ec)
+  )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -114,6 +114,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           val result = controller.saveIdentificationNumber()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -126,6 +127,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe SupervisingCustomsOfficeController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -141,6 +143,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           status(result) mustBe SEE_OTHER
 
           thePageNavigatedTo mustBe InlandTransportDetailsController.displayPage
+          verifyAudit()
         }
       }
     }
@@ -156,6 +159,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
             status(result) mustBe SEE_OTHER
             thePageNavigatedTo mustBe InlandOrBorderController.displayPage
+            verifyAudit()
           }
         }
       }
@@ -188,6 +192,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
           val result = controller.saveIdentificationNumber()(postRequest(incorrectForm))
 
           status(result) must be(BAD_REQUEST)
+          verifyNoAudit()
         }
       }
 
@@ -201,6 +206,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe SupervisingCustomsOfficeController.displayPage
+          verifyAudit()
         }
       }
 
@@ -214,6 +220,7 @@ class WarehouseIdentificationControllerSpec extends ControllerSpec {
 
           await(result) mustBe aRedirectToTheNextPage
           thePageNavigatedTo mustBe SupervisingCustomsOfficeController.displayPage
+          verifyAudit()
         }
       }
     }

--- a/test/controllers/declaration/ZeroRatedForVatControllerSpec.scala
+++ b/test/controllers/declaration/ZeroRatedForVatControllerSpec.scala
@@ -16,7 +16,7 @@
 
 package controllers.declaration
 
-import base.{ControllerSpec, Injector}
+import base.{AuditedControllerSpec, ControllerSpec, Injector}
 import connectors.CodeLinkConnector
 import controllers.routes.RootController
 import forms.declaration.NactCode
@@ -35,7 +35,7 @@ import play.api.test.Helpers._
 import play.twirl.api.HtmlFormat
 import views.html.declaration.zero_rated_for_vat
 
-class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMocks with Injector {
+class ZeroRatedForVatControllerSpec extends ControllerSpec with AuditedControllerSpec with ErrorHandlerMocks with Injector {
 
   val zeroRatedForVatPage = mock[zero_rated_for_vat]
   val codeLinkConnector = mock[CodeLinkConnector]
@@ -54,7 +54,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
       stubMessagesControllerComponents(),
       codeLinkConnector,
       zeroRatedForVatPage
-    )(ec)
+    )(ec, auditService)
 
   override protected def beforeEach(): Unit = {
     super.beforeEach()
@@ -108,6 +108,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
         val result = controller.submitForm(item.id)(postRequestAsFormUrlEncoded(wrongAction: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
 
       "incorrect data" in {
@@ -116,6 +117,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
         val result = controller.submitForm(item.id)(postRequestAsFormUrlEncoded(wrongAction: _*))
 
         status(result) must be(BAD_REQUEST)
+        verifyNoAudit()
       }
     }
 
@@ -128,6 +130,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
+        verifyAudit()
       }
 
       "VatZeroRatedReduced" in {
@@ -137,6 +140,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
+        verifyAudit()
       }
 
       "VatZeroRatedExempt" in {
@@ -146,6 +150,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
+        verifyAudit()
       }
 
       "VatZeroRatedPaid" in {
@@ -155,6 +160,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
 
         await(result) mustBe aRedirectToTheNextPage
         thePageNavigatedTo mustBe routes.NactCodeSummaryController.displayPage(item.id)
+        verifyAudit()
       }
     }
   }
@@ -199,6 +205,7 @@ class ZeroRatedForVatControllerSpec extends ControllerSpec with ErrorHandlerMock
 
         status(result) mustBe SEE_OTHER
         redirectLocation(result) mustBe Some(RootController.displayPage.url)
+        verifyNoAudit()
       }
     }
   }


### PR DESCRIPTION
Adding an explicit audit event that logs the current state of a draft declaration each time the user updates a value.

Also adding some extra logging on our auth action to understand why a user has been rejected (for TDR debugging)