### PR TITLE
CEDS-5528 Bugfix on rejected amendments when using new error report page

### DIFF
--- a/app/controllers/ErrorsReportedController.scala
+++ b/app/controllers/ErrorsReportedController.scala
@@ -82,7 +82,7 @@ class ErrorsReportedController @Inject() (
 
               declarationsAndNotificationsInvolved.flatMap {
                 case (Some(declaration), maybeDraftInProgress, Some(notification)) =>
-                  val errors = errorsReportedHelper.generateErrorRows(Some(notification), declaration, maybeDraftInProgress, false)
+                  val errors = errorsReportedHelper.generateErrorRows(Some(notification), declaration, maybeDraftInProgress, true)
 
                   Future.successful(
                     Ok(


### PR DESCRIPTION
Prior to fix, when user clicked "Change" link to address the error, the system was erroneously creating a DRAFT dec instead of an AMENDMENT_DRAFT