### PR TITLE
DCWL-3295 - Remove 'More Details' link

### DIFF
--- a/app/views/section6/container_add.scala.html
+++ b/app/views/section6/container_add.scala.html
@@ -59,8 +59,6 @@
             inputClasses = Some("govuk-input--width-20")
         )
 
-        @tariffExpander(ContainerAdd, request.declarationType)(messages, appConfig)
-
         @saveButtons()
     }
 }


### PR DESCRIPTION
Remove 'More Details' link from 'What is the Container ID?' page. 