### PR TITLE
DCWL-4801: Error message accessibility requirements fix

### DIFF
--- a/app/views/section2/authorisationHolder/authorisation_holder_edit_content.scala.html
+++ b/app/views/section2/authorisationHolder/authorisation_holder_edit_content.scala.html
@@ -63,7 +63,7 @@
         name = EoriSourceId,
         items = Seq(
             RadioItem(
-                id = Some(UserEori.toString),
+                id = Some(EoriSourceId),
                 value = Some(UserEori.toString),
                 content = Text(messages("declaration.authorisationHolder.eori.user.text", userEori)),
                 checked = form(EoriSourceId).value.contains(UserEori.toString)
@@ -76,7 +76,6 @@
                 conditionalHtml = Some(otherEoriInput),
             )
         ),
-        attributes = Map("id" -> EoriSourceId),
         errorMessage = form(EoriSourceId).error.map(prefixedErrorMessage(_))
     ))
 }

--- a/app/views/section5/zero_rated_for_vat.scala.html
+++ b/app/views/section5/zero_rated_for_vat.scala.html
@@ -115,7 +115,10 @@
 
     @formHelper(action = ZeroRatedForVatController.submitForm(itemId), Symbol("autoComplete") -> "off") {
 
-        @errorSummary(form.errors)
+        @errorSummary(form.errors.map { error =>
+            if (error.key == NactCode.nactCodeKey) error.copy(key = VatReportAfterDeclaration.toString)
+            else error
+        })
 
         @sectionHeader(messages("declaration.section.5"))
 

--- a/test/views/section2/AuthorisationHolderAddViewSpec.scala
+++ b/test/views/section2/AuthorisationHolderAddViewSpec.scala
@@ -67,11 +67,11 @@ class AuthorisationHolderAddViewSpec extends UnitViewSpec with CommonMessages wi
 
       "display unselected radio buttons with labels" in {
         view
-          .getElementById("UserEori")
+          .getElementById("eoriSource")
           .getElementsByAttribute("checked")
           .size mustBe 0
 
-        view.getElementsByAttributeValue("for", "UserEori").text mustBe messages("declaration.authorisationHolder.eori.user.text", eori)
+        view.getElementsByAttributeValue("for", "eoriSource").text mustBe messages("declaration.authorisationHolder.eori.user.text", eori)
 
         view
           .getElementById("OtherEori")
@@ -216,12 +216,12 @@ class AuthorisationHolderAddViewSpec extends UnitViewSpec with CommonMessages wi
         view.getElementById("eori").attr("value") mustBe empty
       }
 
-      "display UserEori checked" in {
+      "display eoriSource checked" in {
         val authorisationHolder = AuthorisationHolder(Some("test"), Some(Eori("test1")), Some(UserEori))
         val view = createView(createForm.fill(authorisationHolder))
 
         view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe true
-        view.getElementById("UserEori").getElementsByAttribute("checked").size mustBe 1
+        view.getElementById("eoriSource").getElementsByAttribute("checked").size mustBe 1
       }
 
       "display OtherEori checked and data is present in EORI input only" in {

--- a/test/views/section2/AuthorisationHolderChangeViewSpec.scala
+++ b/test/views/section2/AuthorisationHolderChangeViewSpec.scala
@@ -74,7 +74,7 @@ class AuthorisationHolderChangeViewSpec extends UnitViewSpec with CommonMessages
         val view = createView(createForm.fill(authorisationHolder))
 
         view.getElementById("conditional-OtherEori").attr("class").contains("hidden") mustBe true
-        view.getElementById("UserEori").getElementsByAttribute("checked").size mustBe 1
+        view.getElementById("eoriSource").getElementsByAttribute("checked").size mustBe 1
       }
 
       "display data OtherEori checked and data is present in EORI input" in {


### PR DESCRIPTION
Pointed href to first button in 'Add Authorisations' screen and 'Zero rated VAT' screen for error messages to comply with accessibility requirements